### PR TITLE
chore: add Edge & Node to copyright headers

### DIFF
--- a/.github/workflows/license_headers_check.yml
+++ b/.github/workflows/license_headers_check.yml
@@ -21,7 +21,7 @@ jobs:
         run: >
           addlicense \
             -check \
-            -c "GraphOps and Semiotic Labs." \
+            -c "Edge & Node, GraphOps, and Semiotic Labs." \
             -l "apache" \
             -s=only \
             -ignore '.github/workflows/*.yml' \

--- a/common/src/allocations/mod.rs
+++ b/common/src/allocations/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use alloy_primitives::Address;

--- a/common/src/allocations/monitor.rs
+++ b/common/src/allocations/monitor.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::HashMap, time::Duration};

--- a/common/src/attestations/dispute_manager.rs
+++ b/common/src/attestations/dispute_manager.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/common/src/attestations/mod.rs
+++ b/common/src/attestations/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod dispute_manager;

--- a/common/src/attestations/signer.rs
+++ b/common/src/attestations/signer.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use alloy_primitives::{Address, U256};

--- a/common/src/attestations/signers.rs
+++ b/common/src/attestations/signers.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use alloy_primitives::Address;

--- a/common/src/escrow_accounts.rs
+++ b/common/src/escrow_accounts.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::HashMap, time::Duration};

--- a/common/src/graphql.rs
+++ b/common/src/graphql.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod allocations;

--- a/common/src/signature_verification.rs
+++ b/common/src/signature_verification.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use alloy_primitives::Address;

--- a/common/src/subgraph_client/client.rs
+++ b/common/src/subgraph_client/client.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;

--- a/common/src/subgraph_client/mod.rs
+++ b/common/src/subgraph_client/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 mod client;

--- a/common/src/subgraph_client/monitor.rs
+++ b/common/src/subgraph_client/monitor.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/common/src/tap_manager.rs
+++ b/common/src/tap_manager.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use alloy_primitives::Address;

--- a/common/src/test_vectors.rs
+++ b/common/src/test_vectors.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::HashMap, str::FromStr};

--- a/service/src/common/address.rs
+++ b/service/src/common/address.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use ethers::signers::{

--- a/service/src/common/database.rs
+++ b/service/src/common/database.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use sqlx::{postgres::PgPoolOptions, PgPool};

--- a/service/src/common/indexer_error.rs
+++ b/service/src/common/indexer_error.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/service/src/common/indexer_management/mod.rs
+++ b/service/src/common/indexer_management/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::HashSet, str::FromStr};

--- a/service/src/common/mod.rs
+++ b/service/src/common/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod address;

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{command, Args, Parser, ValueEnum};

--- a/service/src/graph_node.rs
+++ b/service/src/graph_node.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use alloy_sol_types::eip712_domain;

--- a/service/src/metrics/mod.rs
+++ b/service/src/metrics/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use autometrics::{encode_global_metrics, global_metrics_exporter};

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;

--- a/service/src/server/mod.rs
+++ b/service/src/server/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) use axum::{

--- a/service/src/server/routes/basic.rs
+++ b/service/src/server/routes/basic.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::{extract::Extension, routing::get, Router};

--- a/service/src/server/routes/cost.rs
+++ b/service/src/server/routes/cost.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;

--- a/service/src/server/routes/deployment.rs
+++ b/service/src/server/routes/deployment.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::{http::StatusCode, response::IntoResponse, Extension, Json};

--- a/service/src/server/routes/mod.rs
+++ b/service/src/server/routes/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::indexer_error::{IndexerError, IndexerErrorCause};

--- a/service/src/server/routes/network.rs
+++ b/service/src/server/routes/network.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::{

--- a/service/src/server/routes/status.rs
+++ b/service/src/server/routes/status.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;

--- a/service/src/server/routes/subgraphs.rs
+++ b/service/src/server/routes/subgraphs.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::{

--- a/service/src/test_vectors.rs
+++ b/service/src/test_vectors.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;

--- a/service/src/util.rs
+++ b/service/src/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-, GraphOps and Semiotic Labs.
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 use ethers::signers::WalletError;


### PR DESCRIPTION
`// Copyright 2023-, GraphOps, and Semiotic Labs.`
-> 
`// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.`