### PR TITLE
fix: share HTTP client between `DeploymentClient`s

### DIFF
--- a/common/src/allocations/monitor.rs
+++ b/common/src/allocations/monitor.rs
@@ -203,6 +203,7 @@ mod test {
         // Set up a mock network subgraph
         let mock_server = MockServer::start().await;
         let network_subgraph = SubgraphClient::new(
+            reqwest::Client::new(),
             None,
             DeploymentDetails::for_query_url(&format!(
                 "{}/subgraphs/id/{}",
@@ -210,8 +211,7 @@ mod test {
                 *test_vectors::NETWORK_SUBGRAPH_DEPLOYMENT
             ))
             .unwrap(),
-        )
-        .unwrap();
+        );
 
         // Mock result for current epoch requests
         mock_server

--- a/common/src/attestations/dispute_manager.rs
+++ b/common/src/attestations/dispute_manager.rs
@@ -99,6 +99,7 @@ mod test {
         // Set up a mock network subgraph
         let mock_server = MockServer::start().await;
         let network_subgraph = SubgraphClient::new(
+            reqwest::Client::new(),
             None,
             DeploymentDetails::for_query_url(&format!(
                 "{}/subgraphs/id/{}",
@@ -106,8 +107,7 @@ mod test {
                 *test_vectors::NETWORK_SUBGRAPH_DEPLOYMENT
             ))
             .unwrap(),
-        )
-        .unwrap();
+        );
 
         // Mock result for current epoch requests
         mock_server

--- a/common/src/escrow_accounts.rs
+++ b/common/src/escrow_accounts.rs
@@ -127,18 +127,16 @@ mod tests {
     async fn test_current_accounts() {
         // Set up a mock escrow subgraph
         let mock_server = MockServer::start().await;
-        let escrow_subgraph = Box::leak(Box::new(
-            SubgraphClient::new(
-                None,
-                DeploymentDetails::for_query_url(&format!(
-                    "{}/subgraphs/id/{}",
-                    &mock_server.uri(),
-                    *test_vectors::ESCROW_SUBGRAPH_DEPLOYMENT
-                ))
-                .unwrap(),
-            )
+        let escrow_subgraph = Box::leak(Box::new(SubgraphClient::new(
+            reqwest::Client::new(),
+            None,
+            DeploymentDetails::for_query_url(&format!(
+                "{}/subgraphs/id/{}",
+                &mock_server.uri(),
+                *test_vectors::ESCROW_SUBGRAPH_DEPLOYMENT
+            ))
             .unwrap(),
-        ));
+        )));
 
         let mock = Mock::given(method("POST"))
             .and(path(format!(


### PR DESCRIPTION
Ideally, a single `reqwest::Client` is reused so that they use the same connection pool. This also provides a clearer point to set timeout policies, etc. and removes an unused error case.