### PR TITLE
fix: indexing statuses filter key

### DIFF
--- a/common/src/subgraph_client/monitor.rs
+++ b/common/src/subgraph_client/monitor.rs
@@ -51,7 +51,7 @@ pub fn monitor_deployment_status(
                 let body = json!({
                     "query": r#"
                     query indexingStatuses($ids: [ID!]!) {
-                        indexingStatuses(deployments: $ids) {
+                        indexingStatuses(subgraphs: $ids) {
                             synced
                             health
                         }


### PR DESCRIPTION
Fix filter key for `monitor_deployment_status` 
For https://github.com/graphprotocol/indexer-rs/issues/89