### PR TITLE
fix: drop the manager handler correctly

### DIFF
--- a/tap-agent/src/agent.rs
+++ b/tap-agent/src/agent.rs
@@ -13,7 +13,7 @@ use crate::{
     tap::sender_allocation_relationships_manager::SenderAllocationRelationshipsManager,
 };
 
-pub async fn start_agent(config: &'static config::Cli) {
+pub async fn start_agent(config: &'static config::Cli) -> SenderAllocationRelationshipsManager {
     let pgpool = database::connect(&config.postgres).await;
 
     let http_client = reqwest::Client::new();
@@ -79,7 +79,7 @@ pub async fn start_agent(config: &'static config::Cli) {
         verifying_contract: config.receipts.receipts_verifier_address,
     };
 
-    let _sender_allocation_relationships_manager = SenderAllocationRelationshipsManager::new(
+    SenderAllocationRelationshipsManager::new(
         config,
         pgpool,
         indexer_allocations,
@@ -88,5 +88,5 @@ pub async fn start_agent(config: &'static config::Cli) {
         tap_eip712_domain_separator,
         sender_aggregator_endpoints,
     )
-    .await;
+    .await
 }

--- a/tap-agent/src/main.rs
+++ b/tap-agent/src/main.rs
@@ -24,19 +24,22 @@ async fn main() -> Result<()> {
     lazy_static::initialize(&CONFIG);
     debug!("Config: {:?}", *CONFIG);
 
-    agent::start_agent(&CONFIG).await;
-    info!("TAP Agent started.");
+    {
+        let _manager = agent::start_agent(&CONFIG).await;
+        info!("TAP Agent started.");
 
-    // Have tokio wait for SIGTERM or SIGINT.
-    let mut signal_sigint = signal(SignalKind::interrupt())?;
-    let mut signal_sigterm = signal(SignalKind::terminate())?;
-    tokio::select! {
-        _ = signal_sigint.recv() => debug!("Received SIGINT."),
-        _ = signal_sigterm.recv() => debug!("Received SIGTERM."),
+        // Have tokio wait for SIGTERM or SIGINT.
+        let mut signal_sigint = signal(SignalKind::interrupt())?;
+        let mut signal_sigterm = signal(SignalKind::terminate())?;
+        tokio::select! {
+            _ = signal_sigint.recv() => debug!("Received SIGINT."),
+            _ = signal_sigterm.recv() => debug!("Received SIGTERM."),
+        }
+
+        // If we're here, we've received a signal to exit.
+        info!("Shutting down...");
     }
-
-    // If we're here, we've received a signal to exit.
-    info!("Shutting down...");
+    // Manager should be successfully dropped here.
 
     // Stop the server and wait for it to finish gracefully.
     debug!("Goodbye!");


### PR DESCRIPTION
The current implementation implements the `Drop` trait for the manager by aborting the handler. 

The manager was being dropped at the end of `create_agent()` and wouldn't execute the thread correctly. This PR transfer the ownership to the main function which is dropped correctly when the execution is terminated.