### PR TITLE
feat: store failed receipts and RAVs

### DIFF
--- a/.sqlx/query-a24f3bde2965abe825d896dd7fd65783fea041032e08b6c7ecd65a4b6599a81c.json
+++ b/.sqlx/query-a24f3bde2965abe825d896dd7fd65783fea041032e08b6c7ecd65a4b6599a81c.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO scalar_tap_rav_requests_failed (\n                    allocation_id,\n                    sender_address,\n                    expected_rav,\n                    rav_response,\n                    reason\n                )\n                VALUES ($1, $2, $3, $4, $5)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bpchar",
+        "Bpchar",
+        "Json",
+        "Json",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a24f3bde2965abe825d896dd7fd65783fea041032e08b6c7ecd65a4b6599a81c"
+}

--- a/.sqlx/query-cbf8955f0b6bd355b56b448497abcf6325e1ee9a10e5be9d8cbc919fbb8c87f7.json
+++ b/.sqlx/query-cbf8955f0b6bd355b56b448497abcf6325e1ee9a10e5be9d8cbc919fbb8c87f7.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    INSERT INTO scalar_tap_receipts_invalid (\n                        allocation_id,\n                        sender_address,\n                        timestamp_ns,\n                        value,\n                        received_receipt\n                    )\n                    VALUES ($1, $2, $3, $4, $5)\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bpchar",
+        "Bpchar",
+        "Numeric",
+        "Numeric",
+        "Json"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cbf8955f0b6bd355b56b448497abcf6325e1ee9a10e5be9d8cbc919fbb8c87f7"
+}

--- a/migrations/20230912220523_tap_receipts.down.sql
+++ b/migrations/20230912220523_tap_receipts.down.sql
@@ -3,3 +3,4 @@ DROP TRIGGER IF EXISTS receipt_update ON scalar_tap_receipts CASCADE;
 DROP FUNCTION IF EXISTS scalar_tap_receipt_notify() CASCADE;
 
 DROP TABLE IF EXISTS scalar_tap_receipts CASCADE;
+DROP TABLE IF EXISTS scalar_tap_receipts_invalid CASCADE;

--- a/migrations/20230912220523_tap_receipts.up.sql
+++ b/migrations/20230912220523_tap_receipts.up.sql
@@ -23,3 +23,14 @@ CREATE TRIGGER receipt_update AFTER INSERT OR UPDATE
 
 CREATE INDEX IF NOT EXISTS scalar_tap_receipts_allocation_id_idx ON scalar_tap_receipts (allocation_id);
 CREATE INDEX IF NOT EXISTS scalar_tap_receipts_timestamp_ns_idx ON scalar_tap_receipts (timestamp_ns);
+
+-- This table is used to store invalid receipts (receipts that fail at least one of the checks in the tap-agent).
+-- Used for logging and debugging purposes.
+CREATE TABLE IF NOT EXISTS scalar_tap_receipts_invalid (
+    id BIGSERIAL PRIMARY KEY,
+    allocation_id CHAR(40) NOT NULL,
+    sender_address CHAR(40) NOT NULL,
+    timestamp_ns NUMERIC(20) NOT NULL,
+    value NUMERIC(39) NOT NULL,
+    received_receipt JSON NOT NULL
+);

--- a/migrations/20230915230734_tap_ravs.down.sql
+++ b/migrations/20230915230734_tap_ravs.down.sql
@@ -1,1 +1,2 @@
 DROP TABLE IF EXISTS scalar_tap_ravs CASCADE;
+DROP TABLE IF EXISTS scalar_tap_rav_requests_failed CASCADE;

--- a/migrations/20230915230734_tap_ravs.up.sql
+++ b/migrations/20230915230734_tap_ravs.up.sql
@@ -5,3 +5,14 @@ CREATE TABLE IF NOT EXISTS scalar_tap_ravs (
     final BOOLEAN DEFAULT FALSE NOT NULL,
     PRIMARY KEY (allocation_id, sender_address)
 );
+
+-- This table is used to store failed RAV requests.
+-- Used for logging and debugging purposes.
+CREATE TABLE IF NOT EXISTS scalar_tap_rav_requests_failed (
+    id BIGSERIAL PRIMARY KEY,
+    allocation_id CHAR(40) NOT NULL,
+    sender_address CHAR(40) NOT NULL,
+    expected_rav JSON NOT NULL,
+    rav_response JSON NOT NULL,
+    reason TEXT NOT NULL
+);


### PR DESCRIPTION
Fixes #98 

Note that for now there is no easy way to unit test this because of how `tap_core` is designed.