### PR TITLE
Refactor rav requester

### DIFF
--- a/.sqlx/query-7ff23083cf2afaf2c6b9693736053136baee1406f48f61db2b7bc504825a6fc3.json
+++ b/.sqlx/query-7ff23083cf2afaf2c6b9693736053136baee1406f48f61db2b7bc504825a6fc3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                    UPDATE scalar_tap_ravs\n                    SET final = true\n                    WHERE allocation_id = $1 AND sender_address = $2\n                    RETURNING *\n                ",
+  "query": "\n                        UPDATE scalar_tap_ravs\n                        SET final = true\n                        WHERE allocation_id = $1 AND sender_address = $2\n                        RETURNING *\n                    ",
   "describe": {
     "columns": [
       {
@@ -37,5 +37,5 @@
       false
     ]
   },
-  "hash": "7a48651e528b87c6a618534806e70c2c494f3ba0774097652df984248869c20d"
+  "hash": "7ff23083cf2afaf2c6b9693736053136baee1406f48f61db2b7bc504825a6fc3"
 }

--- a/tap-agent/src/tap/sender_allocation_relationship.rs
+++ b/tap-agent/src/tap/sender_allocation_relationship.rs
@@ -901,7 +901,19 @@ mod tests {
         }
 
         // Wait for the RAV requester to finish.
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        for _ in 0..100 {
+            if sender_allocation_relatioship
+                .inner
+                .unaggregated_fees
+                .lock()
+                .await
+                .value
+                < trigger_value
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
 
         // Get the latest RAV from the database.
         let latest_rav = sqlx::query!(
@@ -975,7 +987,19 @@ mod tests {
         }
 
         // Wait for the RAV requester to finish.
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        for _ in 0..100 {
+            if sender_allocation_relatioship
+                .inner
+                .unaggregated_fees
+                .lock()
+                .await
+                .value
+                < trigger_value
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
 
         // Get the latest RAV from the database.
         let latest_rav = sqlx::query!(


### PR DESCRIPTION
It's smaller than it looks, most of the diff is about splitting `rav_quester_try()` into multiple functions to help with readability.