### PR TITLE
build(deps): fix toolshed deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "alloy-primitives"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ca2c09d5911548a5cb620382ea0e1af99d3c898ce0efecbbd274a4676cf53e"
+checksum = "f4b6fb2b432ff223d513db7f908937f63c252bee0af9b82bfd25b0a5dd1eb0d8"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -89,6 +89,8 @@ dependencies = [
  "derive_more",
  "hex-literal",
  "itoa",
+ "k256",
+ "keccak-asm",
  "proptest",
  "rand 0.8.5",
  "ruint",
@@ -109,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e40cea54ac58080a1b88ea6556866eac1902b321186c77d53ad2b5ebbbf0e038"
+checksum = "8b0b5ab0cb07c21adf9d72e988b34e8200ce648c2bba8d009183bb1c50fb1216"
 dependencies = [
  "const-hex",
  "dunce",
@@ -127,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81aa34725607be118c395d62c1d8d97c8a343dd1ada5370ed508ed5232eab6a"
+checksum = "6c08f62ded7ce03513bfb60ef5cad4fff5d4f67eac6feb4df80426b7b9ffb06e"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -390,9 +392,9 @@ version = "6.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "298a5d587d6e6fdb271bf56af2dc325a80eb291fd0fc979146584b9a05494a8c"
 dependencies = [
- "async-graphql-derive",
- "async-graphql-parser",
- "async-graphql-value",
+ "async-graphql-derive 6.0.11",
+ "async-graphql-parser 6.0.11",
+ "async-graphql-value 6.0.11",
  "async-stream",
  "async-trait",
  "base64 0.13.1",
@@ -401,10 +403,10 @@ dependencies = [
  "fnv",
  "futures-util",
  "handlebars",
- "http",
+ "http 0.2.9",
  "indexmap 2.0.2",
  "mime",
- "multer",
+ "multer 2.1.0",
  "num-traits",
  "once_cell",
  "pin-project-lite",
@@ -418,12 +420,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-graphql"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16926f97f683ff3b47b035cc79622f3d6a374730b07a5d9051e81e88b5f1904"
+dependencies = [
+ "async-graphql-derive 7.0.1",
+ "async-graphql-parser 7.0.1",
+ "async-graphql-value 7.0.1",
+ "async-stream",
+ "async-trait",
+ "base64 0.13.1",
+ "bytes",
+ "fast_chemail",
+ "fnv",
+ "futures-util",
+ "handlebars",
+ "http 1.0.0",
+ "indexmap 2.0.2",
+ "mime",
+ "multer 3.0.0",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "static_assertions_next",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "async-graphql-axum"
 version = "6.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a1c20a2059bffbc95130715b23435a05168c518fba9709c81fa2a38eed990c"
 dependencies = [
- "async-graphql",
+ "async-graphql 6.0.11",
  "async-trait",
  "axum",
  "bytes",
@@ -442,7 +477,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f329c7eb9b646a72f70c9c4b516c70867d356ec46cb00dcac8ad343fd006b0"
 dependencies = [
  "Inflector",
- "async-graphql-parser",
+ "async-graphql-parser 6.0.11",
+ "darling",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "strum 0.25.0",
+ "syn 2.0.38",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a7349168b79030e3172a620f4f0e0062268a954604e41475eff082380fe505"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser 7.0.1",
  "darling",
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -458,7 +510,19 @@ version = "6.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6139181845757fd6a73fbb8839f3d036d7150b798db0e9bb3c6e83cdd65bd53b"
 dependencies = [
- "async-graphql-value",
+ "async-graphql-value 6.0.11",
+ "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-parser"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdc0adf9f53c2b65bb0ff5170cba1912299f248d0e48266f444b6f005deb1d"
+dependencies = [
+ "async-graphql-value 7.0.1",
  "pest",
  "serde",
  "serde_json",
@@ -469,6 +533,18 @@ name = "async-graphql-value"
 version = "6.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323a5143f5bdd2030f45e3f2e0c821c9b1d36e79cf382129c64299c50a7f3750"
+dependencies = [
+ "bytes",
+ "indexmap 2.0.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf4d4e86208f4f9b81a503943c07e6e7f29ad3505e6c9ce6431fe64dc241681"
 dependencies = [
  "bytes",
  "indexmap 2.0.2",
@@ -591,7 +667,7 @@ checksum = "95cef5eb1e18adfb843202bf71587174e480ed67c0ca3e976bf40e82d9adce86"
 dependencies = [
  "autometrics-macros 0.6.0",
  "cfg_aliases",
- "http",
+ "http 0.2.9",
  "linkme",
  "metrics-exporter-prometheus 0.12.1",
  "once_cell",
@@ -640,7 +716,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http",
+ "http 0.2.9",
  "http-body",
  "hyper",
  "itoa",
@@ -672,7 +748,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.9",
  "http-body",
  "mime",
  "rustversion",
@@ -1255,13 +1331,14 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37be52ef5e3b394db27a2341010685ad5103c72ac15ce2e9420a7e8f93f342c"
+checksum = "a5104de16b218eddf8e34ffe2f86f74bfa4e61e95a1b89732fccf6325efd0557"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "hex",
+ "proptest",
  "serde",
 ]
 
@@ -2032,7 +2109,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http",
+ "http 0.2.9",
  "instant",
  "jsonwebtoken",
  "once_cell",
@@ -2620,7 +2697,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 1.9.3",
  "slab",
  "tokio",
@@ -2697,7 +2774,7 @@ dependencies = [
  "base64 0.21.4",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.9",
  "httpdate",
  "mime",
  "sha1",
@@ -2709,7 +2786,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.9",
 ]
 
 [[package]]
@@ -2801,13 +2878,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
  "pin-project-lite",
 ]
 
@@ -2827,7 +2915,7 @@ dependencies = [
  "async-channel",
  "base64 0.13.1",
  "futures-lite",
- "http",
+ "http 0.2.9",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -2867,7 +2955,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body",
  "httparse",
  "httpdate",
@@ -2887,7 +2975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.9",
  "hyper",
  "log",
  "rustls",
@@ -3382,6 +3470,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb8515fff80ed850aea4a1595f2e519c003e2a00a82fe168ebf5269196caf444"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
 name = "keccak-hash"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3730,7 +3828,25 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.9",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
+
+[[package]]
+name = "multer"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15d522be0a9c3e46fd2632e272d178f56387bdb5c9fbb3a36c649062e9b5219"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.0.0",
  "httparse",
  "log",
  "memchr",
@@ -4920,7 +5036,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -5552,7 +5668,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
- "async-graphql",
+ "async-graphql 6.0.11",
  "async-graphql-axum",
  "autometrics 0.3.3",
  "axum",
@@ -5639,6 +5755,16 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac61da6b35ad76b195eb4771210f947734321a8d81d7738e1580d953bc7a15e"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -5752,7 +5878,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "futures",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -6033,6 +6159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_assertions_next"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6156,9 +6288,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c7ad08db24862d5b787a94714ff6b047935c3e3f60af944ac969404debd7ff"
+checksum = "63bef2e2c735acbc06874eca3a8506f02a3c4700e6e748afc92cc2e4220e8a03"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -6202,8 +6334,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tap_aggregator"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3344e835a276a75d94a5e63db7786e4deb5e0d82748182a826e7ff62c0a0c8f2"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?branch=aasseman/tap_core_0_7_0_fix_toolshed_dep#f6fc773947dca0cd515a592cb89f1bc0db652e89"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -6223,6 +6354,7 @@ dependencies = [
  "serde_json",
  "strum 0.24.1",
  "tap_core",
+ "thegraph",
  "tokio",
  "tracing-subscriber",
 ]
@@ -6230,10 +6362,8 @@ dependencies = [
 [[package]]
 name = "tap_core"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684316a94bf1ab08d6c32c578b5efec441278594d066f27d619edb478d926c6"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?branch=aasseman/tap_core_0_7_0_fix_toolshed_dep#f6fc773947dca0cd515a592cb89f1bc0db652e89"
 dependencies = [
- "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
  "async-trait",
@@ -6248,6 +6378,7 @@ dependencies = [
  "serde",
  "strum 0.24.1",
  "strum_macros 0.24.3",
+ "thegraph",
  "thiserror",
  "tokio",
 ]
@@ -6298,14 +6429,15 @@ dependencies = [
 
 [[package]]
 name = "thegraph"
-version = "0.1.1"
-source = "git+https://github.com/edgeandnode/toolshed?branch=main#af60592fcd8ecf67cb043cc9f2ce7ceb1829370b"
+version = "0.5.0"
+source = "git+https://github.com/edgeandnode/toolshed?tag=thegraph-v0.5.0#7ab59b4fe0b19cd520edf025b72ad323be8e0506"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "async-graphql",
+ "async-graphql 7.0.1",
  "bs58",
  "ethers-core",
+ "lazy_static",
  "serde",
  "serde_with",
  "sha3",
@@ -6567,7 +6699,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.9",
  "http-body",
  "http-range-header",
  "pin-project-lite",
@@ -6599,7 +6731,7 @@ dependencies = [
  "futures",
  "futures-core",
  "governor",
- "http",
+ "http 0.2.9",
  "pin-project",
  "thiserror",
  "tokio",
@@ -6708,7 +6840,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "graphql"
 version = "0.3.0"
-source = "git+https://github.com/edgeandnode/toolshed?branch=main#af60592fcd8ecf67cb043cc9f2ce7ceb1829370b"
+source = "git+https://github.com/edgeandnode/toolshed?tag=graphql-v0.3.0#19ec30dc044137b805528181873f4413b45ab8d4"
 dependencies = [
  "firestorm",
  "graphql-parser",
@@ -2654,8 +2654,8 @@ dependencies = [
 
 [[package]]
 name = "graphql-http"
-version = "0.1.1"
-source = "git+https://github.com/edgeandnode/toolshed?branch=main#af60592fcd8ecf67cb043cc9f2ce7ceb1829370b"
+version = "0.2.1"
+source = "git+https://github.com/edgeandnode/toolshed?tag=graphql-http-v0.2.1#b2ba62e7eedf24b98f999797c4955527de6c3e64"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6334,7 +6334,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tap_aggregator"
 version = "0.2.0"
-source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?branch=aasseman/tap_core_0_7_0_fix_toolshed_dep#f6fc773947dca0cd515a592cb89f1bc0db652e89"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?branch=aasseman/tap_core_0_7_0_fix_toolshed_dep#ae4fc69a5de5a33528b31284a32f71ae1093186c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -6362,7 +6362,7 @@ dependencies = [
 [[package]]
 name = "tap_core"
 version = "0.7.0"
-source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?branch=aasseman/tap_core_0_7_0_fix_toolshed_dep#f6fc773947dca0cd515a592cb89f1bc0db652e89"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?branch=aasseman/tap_core_0_7_0_fix_toolshed_dep#ae4fc69a5de5a33528b31284a32f71ae1093186c"
 dependencies = [
  "alloy-sol-types",
  "anyhow",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,7 +31,7 @@ sqlx = { version = "0.7.1", features = [
 ] }
 tokio = { version = "1.32.0", features = ["full", "macros", "rt"] }
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
-graphql-http = { git = "https://github.com/edgeandnode/toolshed", branch = "main", features = [
+graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-http-v0.2.1", features = [
   "http-reqwest",
 ] }
 tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", branch = "aasseman/tap_core_0_7_0_fix_toolshed_dep" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-alloy-primitives = { version = "0.5.2", features = ["serde"] }
-alloy-sol-types = "0.5.2"
+alloy-primitives = { version = "0.6", features = ["serde"] }
+alloy-sol-types = "0.6"
 anyhow = "1.0.75"
 arc-swap = "1.6.0"
 ethers = "2.0.10"
@@ -30,11 +30,11 @@ sqlx = { version = "0.7.1", features = [
   "time",
 ] }
 tokio = { version = "1.32.0", features = ["full", "macros", "rt"] }
-thegraph = { git = "https://github.com/edgeandnode/toolshed", branch = "main" }
+thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
 graphql-http = { git = "https://github.com/edgeandnode/toolshed", branch = "main", features = [
   "http-reqwest",
 ] }
-tap_core = "0.7.0"
+tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", branch = "aasseman/tap_core_0_7_0_fix_toolshed_dep" }
 axum = { version = "0.6.20", default_features = true, features = ["headers"] }
 thiserror = "1.0.49"
 async-trait = "0.1.74"

--- a/common/src/allocations/mod.rs
+++ b/common/src/allocations/mod.rs
@@ -1,9 +1,9 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy_primitives::Address;
 use ethers_core::types::U256;
 use serde::{Deserialize, Deserializer};
+use thegraph::types::Address;
 use thegraph::types::DeploymentId;
 
 pub mod monitor;

--- a/common/src/allocations/monitor.rs
+++ b/common/src/allocations/monitor.rs
@@ -3,10 +3,10 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use alloy_primitives::Address;
 use anyhow::anyhow;
 use eventuals::{timer, Eventual, EventualExt};
 use serde::Deserialize;
+use thegraph::types::Address;
 use tokio::time::sleep;
 use tracing::warn;
 

--- a/common/src/attestations/dispute_manager.rs
+++ b/common/src/attestations/dispute_manager.rs
@@ -3,9 +3,9 @@
 
 use std::time::Duration;
 
-use alloy_primitives::Address;
 use eventuals::{timer, Eventual, EventualExt};
 use serde::Deserialize;
+use thegraph::types::Address;
 use tokio::time::sleep;
 use tracing::warn;
 

--- a/common/src/attestations/signer.rs
+++ b/common/src/attestations/signer.rs
@@ -1,12 +1,12 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy_primitives::{Address, U256};
 use alloy_sol_types::Eip712Domain;
 use ethers::signers::coins_bip39::English;
 use ethers::signers::{MnemonicBuilder, Signer, Wallet};
 use ethers_core::k256::ecdsa::SigningKey;
 use thegraph::types::{attestation, Attestation, DeploymentId};
+use thegraph::types::{Address, U256};
 
 use crate::prelude::Allocation;
 
@@ -124,7 +124,6 @@ fn wallet_for_allocation(
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::Address;
     use ethers_core::types::U256;
     use std::str::FromStr;
     use test_log::test;

--- a/common/src/attestations/signers.rs
+++ b/common/src/attestations/signers.rs
@@ -1,11 +1,11 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy_primitives::Address;
 use ethers_core::types::U256;
 use eventuals::{join, Eventual, EventualExt};
 use std::collections::HashMap;
 use std::sync::Arc;
+use thegraph::types::Address;
 use tokio::sync::Mutex;
 use tracing::warn;
 
@@ -61,8 +61,6 @@ pub fn attestation_signers(
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::Address;
-
     use crate::test_vectors::{
         DISPUTE_MANAGER_ADDRESS, INDEXER_ALLOCATIONS, INDEXER_OPERATOR_MNEMONIC,
     };

--- a/common/src/escrow_accounts.rs
+++ b/common/src/escrow_accounts.rs
@@ -6,11 +6,11 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::Address;
 use anyhow::Result;
 use ethers_core::types::U256;
 use eventuals::{timer, Eventual, EventualExt};
 use serde::Deserialize;
+use thegraph::types::Address;
 use thiserror::Error;
 use tokio::time::sleep;
 use tracing::{error, warn};

--- a/common/src/indexer_service/http/config.rs
+++ b/common/src/indexer_service/http/config.rs
@@ -3,8 +3,8 @@
 
 use std::net::SocketAddr;
 
-use alloy_primitives::Address;
 use serde::{Deserialize, Serialize};
+use thegraph::types::Address;
 use thegraph::types::DeploymentId;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/common/src/indexer_service/http/indexer_service.rs
+++ b/common/src/indexer_service/http/indexer_service.rs
@@ -6,7 +6,6 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::Address;
 use alloy_sol_types::eip712_domain;
 use anyhow;
 use autometrics::prometheus_exporter;
@@ -23,6 +22,7 @@ use eventuals::Eventual;
 use reqwest::StatusCode;
 use serde::{de::DeserializeOwned, Serialize};
 use sqlx::postgres::PgPoolOptions;
+use thegraph::types::Address;
 use thegraph::types::{Attestation, DeploymentId};
 use thiserror::Error;
 use tokio::signal;

--- a/common/src/indexer_service/http/scalar_receipt_header.rs
+++ b/common/src/indexer_service/http/scalar_receipt_header.rs
@@ -61,8 +61,8 @@ impl Header for ScalarReceipt {
 mod test {
     use std::str::FromStr;
 
-    use alloy_primitives::Address;
     use axum::{headers::Header, http::HeaderValue};
+    use thegraph::types::Address;
 
     use crate::test_vectors::create_signed_receipt;
 

--- a/common/src/signature_verification.rs
+++ b/common/src/signature_verification.rs
@@ -1,12 +1,12 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy_primitives::Address;
 use arc_swap::ArcSwap;
 use keccak_hash::keccak;
 use lazy_static::lazy_static;
 use secp256k1::{ecdsa::RecoverableSignature, Message, PublicKey, Secp256k1, VerifyOnly};
 use std::sync::Arc;
+use thegraph::types::Address;
 
 lazy_static! {
     static ref SECP256K1: Secp256k1<VerifyOnly> = Secp256k1::verification_only();

--- a/common/src/tap_manager.rs
+++ b/common/src/tap_manager.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use alloy_primitives::hex::ToHex;
-use alloy_primitives::Address;
 use alloy_sol_types::Eip712Domain;
 use anyhow::anyhow;
 use ethers_core::types::U256;
@@ -12,6 +11,7 @@ use sqlx::{types::BigDecimal, PgPool};
 use std::collections::HashSet;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 use tap_core::tap_manager::SignedReceipt;
+use thegraph::types::Address;
 use tokio::sync::RwLock;
 use tracing::error;
 
@@ -246,7 +246,6 @@ mod test {
     use std::str::FromStr;
 
     use crate::prelude::{AllocationStatus, SubgraphDeployment};
-    use alloy_primitives::Address;
     use keccak_hash::H256;
     use sqlx::postgres::PgListener;
 

--- a/common/src/test_vectors.rs
+++ b/common/src/test_vectors.rs
@@ -3,7 +3,6 @@
 
 use std::{collections::HashMap, str::FromStr};
 
-use alloy_primitives::Address;
 use alloy_sol_types::{eip712_domain, Eip712Domain};
 use ethers::signers::{coins_bip39::English, LocalWallet, MnemonicBuilder, Signer};
 use ethers_core::types::U256;
@@ -11,6 +10,7 @@ use lazy_static::lazy_static;
 use tap_core::{
     eip_712_signed_message::EIP712SignedMessage, tap_manager::SignedReceipt, tap_receipt::Receipt,
 };
+use thegraph::types::Address;
 use thegraph::types::DeploymentId;
 
 use crate::prelude::{Allocation, AllocationStatus, SubgraphDeployment};
@@ -166,11 +166,9 @@ lazy_static! {
                 created_at_epoch: 953,
                 closed_at_epoch: None,
                 subgraph_deployment: SubgraphDeployment {
-                    id: DeploymentId(
+                    id: DeploymentId::from_str(
                         "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a"
-                            .parse()
-                            .unwrap(),
-                    ),
+                    ).unwrap(),
                     denied_at: Some(0),
                 },
                 status: AllocationStatus::Null,
@@ -192,11 +190,9 @@ lazy_static! {
                 created_at_epoch: 953,
                 closed_at_epoch: None,
                 subgraph_deployment: SubgraphDeployment {
-                    id: DeploymentId(
+                    id: DeploymentId::from_str(
                         "0xcda7fa0405d6fd10721ed13d18823d24b535060d8ff661f862b26c23334f13bf"
-                            .parse()
-                            .unwrap(),
-                    ),
+                    ).unwrap(),
                     denied_at: Some(0),
                 },
                 status: AllocationStatus::Null,
@@ -218,11 +214,9 @@ lazy_static! {
                 created_at_epoch: 940,
                 closed_at_epoch: Some(953),
                 subgraph_deployment: SubgraphDeployment {
-                    id: DeploymentId(
+                    id: DeploymentId::from_str(
                         "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a"
-                            .parse()
-                            .unwrap(),
-                    ),
+                    ).unwrap(),
                     denied_at: Some(0),
                 },
                 status: AllocationStatus::Null,
@@ -244,11 +238,9 @@ lazy_static! {
                 created_at_epoch: 940,
                 closed_at_epoch: Some(953),
                 subgraph_deployment: SubgraphDeployment {
-                    id: DeploymentId(
+                    id: DeploymentId::from_str(
                         "0xc064c354bc21dd958b1d41b67b8ef161b75d2246b425f68ed4c74964ae705cbd"
-                            .parse()
-                            .unwrap(),
-                    ),
+                    ).unwrap(),
                     denied_at: Some(0),
                 },
                 status: AllocationStatus::Null,

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -45,7 +45,7 @@ autometrics = { version = "0.3.3", features = ["prometheus-exporter"] }
 clap = { version = "4.3.1", features = ["derive", "env"] }
 prometheus = "0.13.3"
 hex = "0.4.3"
-tap_core = "0.7.0"
+tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", branch = "aasseman/tap_core_0_7_0_fix_toolshed_dep" }
 ethereum-types = "0.14.1"
 sqlx = { version = "0.7.1", features = [
     "postgres",
@@ -54,10 +54,10 @@ sqlx = { version = "0.7.1", features = [
     "rust_decimal",
     "time",
 ] }
-alloy-primitives = { version = "0.5.2", features = ["serde"] }
-alloy-sol-types = "0.5.2"
+alloy-primitives = { version = "0.6", features = ["serde"] }
+alloy-sol-types = "0.6"
 lazy_static = "1.4.0"
-thegraph = { git = "https://github.com/edgeandnode/toolshed", branch = "main" }
+thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
 graphql = { git = "https://github.com/edgeandnode/toolshed", branch = "main" }
 graphql-http = { git = "https://github.com/edgeandnode/toolshed", branch = "main", features = [
     "http-reqwest",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -58,8 +58,8 @@ alloy-primitives = { version = "0.6", features = ["serde"] }
 alloy-sol-types = "0.6"
 lazy_static = "1.4.0"
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
-graphql = { git = "https://github.com/edgeandnode/toolshed", branch = "main" }
-graphql-http = { git = "https://github.com/edgeandnode/toolshed", branch = "main", features = [
+graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0" }
+graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-http-v0.2.1", features = [
     "http-reqwest",
 ] }
 build-info = "0.0.34"

--- a/service/src/database.rs
+++ b/service/src/database.rs
@@ -445,11 +445,10 @@ mod test {
         setup_cost_models_table(&pool).await;
         add_cost_models(&pool, to_db_models(test_data())).await;
 
-        let deployment_id_from_bytes = DeploymentId(
-            "0xbd499f7673ca32ef4a642207a8bebdd0fb03888cf2678b298438e3a1ae5206ea"
-                .parse()
-                .unwrap(),
-        );
+        let deployment_id_from_bytes = DeploymentId::from_str(
+            "0xbd499f7673ca32ef4a642207a8bebdd0fb03888cf2678b298438e3a1ae5206ea",
+        )
+        .unwrap();
         let deployment_id_from_hash =
             DeploymentId::from_str("Qmb5Ysp5oCUXhLA8NmxmYKDAX2nCMnh7Vvb5uffb9n5vss").unwrap();
 

--- a/tap-agent/Cargo.toml
+++ b/tap-agent/Cargo.toml
@@ -37,7 +37,7 @@ tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol
 thiserror = "1.0.44"
 tokio = { version = "1.33.0" }
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
-graphql-http = { git = "https://github.com/edgeandnode/toolshed", branch = "main" }
+graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-http-v0.2.1" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",

--- a/tap-agent/Cargo.toml
+++ b/tap-agent/Cargo.toml
@@ -9,8 +9,8 @@ name = "indexer-tap-agent"
 path = "src/main.rs"
 
 [dependencies]
-alloy-primitives = "0.5.2"
-alloy-sol-types = "0.5.2"
+alloy-primitives = "0.6"
+alloy-sol-types = "0.6"
 anyhow = "1.0.72"
 async-trait = "0.1.72"
 bigdecimal = { version = "0.4.2", features = ["serde"] }
@@ -32,11 +32,11 @@ sqlx = { version = "0.7.2", features = [
     "bigdecimal",
     "rust_decimal",
 ] }
-tap_aggregator = "0.2.0"
-tap_core = "0.7.0"
+tap_aggregator = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", branch = "aasseman/tap_core_0_7_0_fix_toolshed_dep" }
+tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", branch = "aasseman/tap_core_0_7_0_fix_toolshed_dep" }
 thiserror = "1.0.44"
 tokio = { version = "1.33.0" }
-thegraph = { git = "https://github.com/edgeandnode/toolshed", branch = "main" }
+thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
 graphql-http = { git = "https://github.com/edgeandnode/toolshed", branch = "main" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3", features = [

--- a/tap-agent/src/aggregator_endpoints.rs
+++ b/tap-agent/src/aggregator_endpoints.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 
-use alloy_primitives::Address;
+use thegraph::types::Address;
 
 /// Load a hashmap of sender addresses and their corresponding aggregator endpoints
 /// from a yaml file. We're using serde_yaml.

--- a/tap-agent/src/config.rs
+++ b/tap-agent/src/config.rs
@@ -3,11 +3,11 @@
 
 use std::{path::PathBuf, str::FromStr};
 
-use alloy_primitives::Address;
 use bigdecimal::{BigDecimal, ToPrimitive};
 use clap::{command, Args, Parser, ValueEnum};
 use dotenvy::dotenv;
 use serde::{Deserialize, Serialize};
+use thegraph::types::Address;
 use thegraph::types::DeploymentId;
 use tracing::subscriber::{set_global_default, SetGlobalDefaultError};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};

--- a/tap-agent/src/tap/escrow_adapter.rs
+++ b/tap-agent/src/tap/escrow_adapter.rs
@@ -3,11 +3,11 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use alloy_primitives::Address;
 use async_trait::async_trait;
 use eventuals::Eventual;
 use indexer_common::escrow_accounts::EscrowAccounts;
 use tap_core::adapters::escrow_adapter::EscrowAdapter as EscrowAdapterTrait;
+use thegraph::types::Address;
 use thiserror::Error;
 use tokio::sync::RwLock;
 

--- a/tap-agent/src/tap/mod.rs
+++ b/tap-agent/src/tap/mod.rs
@@ -1,10 +1,11 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy_primitives::{hex::ToHex, Address};
+use alloy_primitives::hex::ToHex;
 use anyhow::anyhow;
 use eventuals::Eventual;
 use indexer_common::escrow_accounts::EscrowAccounts;
+use thegraph::types::Address;
 
 mod escrow_adapter;
 mod rav_storage_adapter;

--- a/tap-agent/src/tap/rav_storage_adapter.rs
+++ b/tap-agent/src/tap/rav_storage_adapter.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use alloy_primitives::hex::ToHex;
-use alloy_primitives::Address;
 use anyhow::Result;
 use async_trait::async_trait;
 use sqlx::PgPool;
 use tap_core::adapters::rav_storage_adapter::RAVStorageAdapter as RAVStorageAdapterTrait;
 use tap_core::tap_manager::SignedRAV;
+use thegraph::types::Address;
 use thiserror::Error;
 
 #[derive(Debug)]

--- a/tap-agent/src/tap/receipt_checks_adapter.rs
+++ b/tap-agent/src/tap/receipt_checks_adapter.rs
@@ -3,7 +3,6 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use alloy_primitives::Address;
 use async_trait::async_trait;
 use ethereum_types::U256;
 use eventuals::{timer, Eventual, EventualExt};
@@ -12,6 +11,7 @@ use indexer_common::subgraph_client::{Query, SubgraphClient};
 use sqlx::PgPool;
 use tap_core::adapters::receipt_checks_adapter::ReceiptChecksAdapter as ReceiptChecksAdapterTrait;
 use tap_core::{eip_712_signed_message::EIP712SignedMessage, tap_receipt::Receipt};
+use thegraph::types::Address;
 use thiserror::Error;
 use tokio::{sync::RwLock, time::sleep};
 use tracing::error;

--- a/tap-agent/src/tap/receipt_storage_adapter.rs
+++ b/tap-agent/src/tap/receipt_storage_adapter.rs
@@ -6,7 +6,7 @@ use std::{
     ops::{Bound, RangeBounds},
 };
 
-use alloy_primitives::{hex::ToHex, Address};
+use alloy_primitives::hex::ToHex;
 use async_trait::async_trait;
 use eventuals::Eventual;
 use indexer_common::escrow_accounts::EscrowAccounts;
@@ -16,6 +16,7 @@ use tap_core::{
     tap_manager::SignedReceipt,
     tap_receipt::{ReceiptCheck, ReceivedReceipt},
 };
+use thegraph::types::Address;
 use thiserror::Error;
 use tracing::error;
 

--- a/tap-agent/src/tap/sender_allocation_relationship.rs
+++ b/tap-agent/src/tap/sender_allocation_relationship.rs
@@ -3,9 +3,10 @@
 
 use std::{str::FromStr, sync::Arc, time::Duration};
 
-use alloy_primitives::{hex::ToHex, Address};
+use alloy_primitives::hex::ToHex;
 use alloy_sol_types::Eip712Domain;
 use anyhow::{anyhow, ensure, Result};
+use thegraph::types::Address;
 
 use eventuals::Eventual;
 use indexer_common::{escrow_accounts::EscrowAccounts, prelude::SubgraphClient};

--- a/tap-agent/src/tap/sender_allocation_relationships_manager.rs
+++ b/tap-agent/src/tap/sender_allocation_relationships_manager.rs
@@ -4,7 +4,6 @@
 use std::collections::HashSet;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 
-use alloy_primitives::Address;
 use alloy_sol_types::Eip712Domain;
 use anyhow::anyhow;
 use anyhow::Result;
@@ -13,6 +12,7 @@ use indexer_common::escrow_accounts::EscrowAccounts;
 use indexer_common::prelude::{Allocation, SubgraphClient};
 use serde::Deserialize;
 use sqlx::{postgres::PgListener, PgPool};
+use thegraph::types::Address;
 use tokio::sync::RwLock;
 use tracing::{error, warn};
 
@@ -416,11 +416,9 @@ mod tests {
                 created_at_epoch: 953,
                 closed_at_epoch: None,
                 subgraph_deployment: SubgraphDeployment {
-                    id: DeploymentId(
+                    id: DeploymentId::from_str(
                         "0xcda7fa0405d6fd10721ed13d18823d24b535060d8ff661f862b26c23334f13bf"
-                            .parse()
-                            .unwrap(),
-                    ),
+                    ).unwrap(),
                     denied_at: Some(0),
                 },
                 status: AllocationStatus::Null,

--- a/tap-agent/src/tap/test_utils.rs
+++ b/tap-agent/src/tap/test_utils.rs
@@ -4,7 +4,6 @@
 use std::str::FromStr;
 
 use alloy_primitives::hex::ToHex;
-use alloy_primitives::Address;
 use alloy_sol_types::{eip712_domain, Eip712Domain};
 use anyhow::Result;
 use ethers_signers::{coins_bip39::English, LocalWallet, MnemonicBuilder, Signer};
@@ -15,6 +14,7 @@ use tap_core::receipt_aggregate_voucher::ReceiptAggregateVoucher;
 use tap_core::tap_manager::{SignedRAV, SignedReceipt};
 use tap_core::tap_receipt::{get_full_list_of_checks, ReceivedReceipt};
 use tap_core::{eip_712_signed_message::EIP712SignedMessage, tap_receipt::Receipt};
+use thegraph::types::Address;
 
 lazy_static! {
     pub static ref ALLOCATION_ID: Address =


### PR DESCRIPTION
Fixed the versions of `toolshed` crates to proper tags.
Also, replaced direct usage of `alloy_primitives::Address` to the toolshed re-export `thegraph::types::Address` to enforce `alloy` version compatibility between `indexer-rs` and other projects that depend on `toolshed`.

Note that the `tap_core` dependency is based on a custom branch based off of `tap_core` v0.7.0 on which the same treatment was applied. This is temporary as for now `tap_core`'s main branch contains a lot of breaking changes. 