### PR TITLE
chore: set indexer-service version to 1.0.0-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.1.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "service"
-version = "0.1.0"
+version = "1.0.0-alpha.0"
 edition = "2021"
-description = "Could not find crate on crates.io and could not import with git and path at the same time, so copied a version directly at https://github.com/graphprotocol/indexer/blob/972658b3ce8c512ad7b4dc575d29cd9d5377e3fe/packages/indexer-native/native"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This is needed because the gateway knows we're running TAP if the indexer-service version is >= 1.0.0