### PR TITLE
operator info endpoint to return an object

### DIFF
--- a/common/src/indexer_service/http/indexer_service.rs
+++ b/common/src/indexer_service/http/indexer_service.rs
@@ -313,12 +313,14 @@ impl IndexerService {
             )),
         };
 
-        let operator_address = public_key(&options.config.indexer.operator_mnemonic)?;
+        let operator_address = Json(
+            serde_json::json!({ "operator": public_key(&options.config.indexer.operator_mnemonic)?}),
+        );
 
         let mut misc_routes = Router::new()
             .route("/", get("Service is up and running"))
             .route("/version", get(Json(options.release)))
-            .route("/info", get(Json(operator_address)))
+            .route("/info", get(operator_address))
             .layer(
                 ServiceBuilder::new()
                     .layer(HandleErrorLayer::new(|e: BoxError| async move {

--- a/common/src/indexer_service/http/indexer_service.rs
+++ b/common/src/indexer_service/http/indexer_service.rs
@@ -314,7 +314,7 @@ impl IndexerService {
         };
 
         let operator_address = Json(
-            serde_json::json!({ "operator": public_key(&options.config.indexer.operator_mnemonic)?}),
+            serde_json::json!({ "publicKey": public_key(&options.config.indexer.operator_mnemonic)?}),
         );
 
         let mut misc_routes = Router::new()


### PR DESCRIPTION
update from `Json(address)` to more like the existing format of `Json(operator: address)`
Addressing https://github.com/graphprotocol/indexer-rs/pull/120#issuecomment-1937089863