### PR TITLE
fix: capitalize scalar receipt header

### DIFF
--- a/common/src/indexer_service/http/scalar_receipt_header.rs
+++ b/common/src/indexer_service/http/scalar_receipt_header.rs
@@ -25,7 +25,7 @@ impl Deref for ScalarReceipt {
 }
 
 lazy_static! {
-    static ref SCALAR_RECEIPT: HeaderName = HeaderName::from_static("scalar-receipt");
+    static ref SCALAR_RECEIPT: HeaderName = HeaderName::from_static("Scalar-Receipt");
 }
 
 impl Header for ScalarReceipt {


### PR DESCRIPTION

I was having trouble receiving scalar receipts, so took a look at how the gateway construct the receipt, found that it creates receipt's header with capital letters `HeaderName::from_str("Scalar-Receipt").unwrap(),` from [line](https://github.com/edgeandnode/graph-gateway/blob/f32e5f33447d27f6425fa2754f64bc1b5acfe1ef/graph-gateway/src/indexer_client.rs#L66)
indexer framework process header with just lower-case `scalar-receipt`. I *think* the convention uses capital letters so proposing a change here. if not, I can propose a change on the gateway's side.



