### PR TITLE
Revert "fix: capitalize scalar receipt header"

### DIFF
--- a/common/src/indexer_service/http/scalar_receipt_header.rs
+++ b/common/src/indexer_service/http/scalar_receipt_header.rs
@@ -25,7 +25,7 @@ impl Deref for ScalarReceipt {
 }
 
 lazy_static! {
-    static ref SCALAR_RECEIPT: HeaderName = HeaderName::from_static("Scalar-Receipt");
+    static ref SCALAR_RECEIPT: HeaderName = HeaderName::from_static("scalar-receipt");
 }
 
 impl Header for ScalarReceipt {


### PR DESCRIPTION
Reverts graphprotocol/indexer-rs#126

As per `HeaderName::from_static` documentation https://docs.rs/http/latest/http/header/struct.HeaderName.html#method.from_static. This panics if it's not lowercase and gets into a poisoned state because of lazy_static! use