### PR TITLE
Gusinacio/bump axum reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,49 +388,16 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "6.0.11"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298a5d587d6e6fdb271bf56af2dc325a80eb291fd0fc979146584b9a05494a8c"
+checksum = "261fa27d5bff5afdf7beff291b3bc73f99d1529804c70e51b0fbc51e70b1c6a9"
 dependencies = [
- "async-graphql-derive 6.0.11",
- "async-graphql-parser 6.0.11",
- "async-graphql-value 6.0.11",
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
  "async-stream",
  "async-trait",
- "base64 0.13.1",
- "bytes",
- "fast_chemail",
- "fnv",
- "futures-util",
- "handlebars",
- "http 0.2.9",
- "indexmap 2.0.2",
- "mime",
- "multer 2.1.0",
- "num-traits",
- "once_cell",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "static_assertions",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "async-graphql"
-version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16926f97f683ff3b47b035cc79622f3d6a374730b07a5d9051e81e88b5f1904"
-dependencies = [
- "async-graphql-derive 7.0.1",
- "async-graphql-parser 7.0.1",
- "async-graphql-value 7.0.1",
- "async-stream",
- "async-trait",
- "base64 0.13.1",
+ "base64 0.21.4",
  "bytes",
  "fast_chemail",
  "fnv",
@@ -439,7 +406,7 @@ dependencies = [
  "http 1.0.0",
  "indexmap 2.0.2",
  "mime",
- "multer 3.0.0",
+ "multer",
  "num-traits",
  "once_cell",
  "pin-project-lite",
@@ -454,13 +421,13 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-axum"
-version = "6.0.11"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a1c20a2059bffbc95130715b23435a05168c518fba9709c81fa2a38eed990c"
+checksum = "93605d26b9da33b4cf6541906a9eb9e74396f1accbbc0f066e06f3b0869b84fc"
 dependencies = [
- "async-graphql 6.0.11",
+ "async-graphql",
  "async-trait",
- "axum",
+ "axum 0.7.5",
  "bytes",
  "futures-util",
  "serde_json",
@@ -472,57 +439,28 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "6.0.11"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f329c7eb9b646a72f70c9c4b516c70867d356ec46cb00dcac8ad343fd006b0"
+checksum = "3188809947798ea6db736715a60cf645ba3b87ea031c710130e1476b48e45967"
 dependencies = [
  "Inflector",
- "async-graphql-parser 6.0.11",
+ "async-graphql-parser",
  "darling",
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "strum 0.25.0",
- "syn 2.0.38",
- "thiserror",
-]
-
-[[package]]
-name = "async-graphql-derive"
-version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a7349168b79030e3172a620f4f0e0062268a954604e41475eff082380fe505"
-dependencies = [
- "Inflector",
- "async-graphql-parser 7.0.1",
- "darling",
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "strum 0.25.0",
+ "strum 0.26.2",
  "syn 2.0.38",
  "thiserror",
 ]
 
 [[package]]
 name = "async-graphql-parser"
-version = "6.0.11"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6139181845757fd6a73fbb8839f3d036d7150b798db0e9bb3c6e83cdd65bd53b"
+checksum = "d4e65a0b83027f35b2a5d9728a098bc66ac394caa8191d2c65ed9eb2985cf3d8"
 dependencies = [
- "async-graphql-value 6.0.11",
- "pest",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-parser"
-version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdc0adf9f53c2b65bb0ff5170cba1912299f248d0e48266f444b6f005deb1d"
-dependencies = [
- "async-graphql-value 7.0.1",
+ "async-graphql-value",
  "pest",
  "serde",
  "serde_json",
@@ -530,21 +468,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "6.0.11"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323a5143f5bdd2030f45e3f2e0c821c9b1d36e79cf382129c64299c50a7f3750"
-dependencies = [
- "bytes",
- "indexmap 2.0.2",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-value"
-version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf4d4e86208f4f9b81a503943c07e6e7f29ad3505e6c9ce6431fe64dc241681"
+checksum = "68e40849c29a39012d38bff87bfed431f1ed6c53fbec493294c1045d61a7ae75"
 dependencies = [
  "bytes",
  "indexmap 2.0.2",
@@ -654,25 +580,25 @@ dependencies = [
  "metrics-exporter-prometheus 0.11.0",
  "once_cell",
  "opentelemetry-prometheus 0.11.0",
- "opentelemetry_api 0.18.0",
+ "opentelemetry_api",
  "opentelemetry_sdk 0.18.0",
  "prometheus",
 ]
 
 [[package]]
 name = "autometrics"
-version = "0.6.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cef5eb1e18adfb843202bf71587174e480ed67c0ca3e976bf40e82d9adce86"
+checksum = "10eaae539e7319a3813dc8cd53776a7128bdd6d82067275c12586f5a0fce9137"
 dependencies = [
- "autometrics-macros 0.6.0",
+ "autometrics-macros 1.0.1",
  "cfg_aliases",
- "http 0.2.9",
+ "http 1.0.0",
  "linkme",
  "metrics-exporter-prometheus 0.12.1",
  "once_cell",
- "opentelemetry-prometheus 0.13.0",
- "opentelemetry_sdk 0.20.0",
+ "opentelemetry-prometheus 0.14.1",
+ "opentelemetry_sdk 0.21.2",
  "prometheus",
  "prometheus-client",
  "spez",
@@ -693,14 +619,15 @@ dependencies = [
 
 [[package]]
 name = "autometrics-macros"
-version = "0.6.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543250f01aa62c3b2666e327b335be532845a35e440eb984f5e6bad69106833d"
+checksum = "fdf7c9ebfee6425011c65788c746adf80fac99ba38957ba1cdb824b593cfc993"
 dependencies = [
  "percent-encoding",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "regex",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -710,15 +637,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
- "base64 0.21.4",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "headers",
  "http 0.2.9",
- "http-body",
- "hyper",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "base64 0.21.4",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -731,12 +690,13 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -749,11 +709,55 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 0.2.9",
- "http-body",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+dependencies = [
+ "axum 0.7.5",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -788,6 +792,12 @@ name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64ct"
@@ -1805,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
 dependencies = [
  "base64 0.21.4",
  "bytes",
@@ -1954,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7cd562832e2ff584fa844cd2f6e5d4f35bbe11b28c7c9b8df957b2e1d0c701"
+checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1970,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35dc9a249c066d17e8947ff52a4116406163cf92c7f0763cb8c001760b26403f"
+checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1982,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43304317c7f776876e47f2f637859f6d0701c1ec7930a150f169d5fbe7d76f5a"
+checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -2001,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f96502317bf34f6d71a3e3d270defaa9485d754d789e15a8e04a84161c95eb"
+checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -2015,7 +2025,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "reqwest",
+ "reqwest 0.11.22",
  "serde",
  "serde_json",
  "syn 2.0.38",
@@ -2025,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452ff6b0a64507ce8d67ffd48b1da3b42f03680dcf5382244e9c93822cbbf5de"
+checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -2041,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab3cef6cc1c9fd7f787043c81ad3052eff2b96a3878ef1526aa446311bdbfc9"
+checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2061,7 +2071,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum 0.26.2",
  "syn 2.0.38",
  "tempfile",
  "thiserror",
@@ -2071,13 +2081,13 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d45b981f5fa769e1d0343ebc2a44cfa88c9bc312eb681b676318b40cef6fb1"
+checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
 dependencies = [
  "chrono",
  "ethers-core",
- "reqwest",
+ "reqwest 0.11.22",
  "semver 1.0.20",
  "serde",
  "serde_json",
@@ -2087,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145211f34342487ef83a597c1e69f0d3e01512217a7c72cc8a25931854c7dca0"
+checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2102,7 +2112,7 @@ dependencies = [
  "futures-locks",
  "futures-util",
  "instant",
- "reqwest",
+ "reqwest 0.11.22",
  "serde",
  "serde_json",
  "thiserror",
@@ -2114,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6b15393996e3b8a78ef1332d6483c11d839042c17be58decc92fa8b1c3508a"
+checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2134,12 +2144,12 @@ dependencies = [
  "jsonwebtoken",
  "once_cell",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.22",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tracing",
  "tracing-futures",
  "url",
@@ -2151,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b125a103b56aef008af5d5fb48191984aa326b50bfd2557d231dc499833de3"
+checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2170,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21df08582e0a43005018a858cc9b465c5fff9cf4056651be64f844e57d1f55f"
+checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -2673,19 +2683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphql-http"
-version = "0.2.1"
-source = "git+https://github.com/edgeandnode/toolshed?tag=graphql-http-v0.2.1#b2ba62e7eedf24b98f999797c4955527de6c3e64"
-dependencies = [
- "anyhow",
- "async-trait",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "graphql-parser"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,6 +2716,25 @@ dependencies = [
  "futures-util",
  "http 0.2.9",
  "indexmap 1.9.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
+ "indexmap 2.0.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -2787,14 +2803,14 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
 dependencies = [
  "base64 0.21.4",
  "bytes",
  "headers-core",
- "http 0.2.9",
+ "http 1.0.0",
  "httpdate",
  "mime",
  "sha1",
@@ -2802,22 +2818,11 @@ dependencies = [
 
 [[package]]
 name = "headers-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 0.2.9",
-]
-
-[[package]]
-name = "headers-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33cf300c485e3cbcba0235013fcc768723451c9b84d1b31aa7fec0491ac9a11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "http 1.0.0",
 ]
 
 [[package]]
@@ -2920,6 +2925,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-range-header"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,9 +3002,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.21",
  "http 0.2.9",
- "http-body",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -2989,6 +3017,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2996,7 +3045,7 @@ checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
  "http 0.2.9",
- "hyper",
+ "hyper 0.14.27",
  "log",
  "rustls",
  "rustls-native-certs",
@@ -3006,15 +3055,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2 0.5.4",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3109,8 +3181,9 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
- "autometrics 0.6.0",
- "axum",
+ "autometrics 1.0.1",
+ "axum 0.7.5",
+ "axum-extra",
  "bigdecimal 0.4.2",
  "build-info",
  "env_logger",
@@ -3118,16 +3191,13 @@ dependencies = [
  "ethers-core",
  "eventuals",
  "faux",
- "graphql-http",
- "headers",
- "headers-derive",
  "keccak-hash",
  "lazy_static",
  "lru",
  "once_cell",
  "prometheus",
  "regex",
- "reqwest",
+ "reqwest 0.12.3",
  "secp256k1",
  "serde",
  "serde_json",
@@ -3135,11 +3205,12 @@ dependencies = [
  "tap_core",
  "test-log",
  "thegraph",
+ "thegraph-graphql-http",
  "thiserror",
  "tokio",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.5.2",
  "tower_governor",
  "tracing",
  "wiremock",
@@ -3163,12 +3234,11 @@ dependencies = [
  "ethers-signers",
  "eventuals",
  "futures",
- "graphql-http",
  "indexer-common",
  "jsonrpsee 0.20.2",
  "lazy_static",
  "ractor",
- "reqwest",
+ "reqwest 0.12.3",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3177,6 +3247,7 @@ dependencies = [
  "tap_core",
  "tempfile",
  "thegraph",
+ "thegraph-graphql-http",
  "thiserror",
  "tokio",
  "tracing",
@@ -3339,7 +3410,7 @@ dependencies = [
  "beef",
  "futures-util",
  "globset",
- "hyper",
+ "hyper 0.14.27",
  "jsonrpsee-types 0.18.2",
  "parking_lot",
  "rand 0.8.5",
@@ -3362,7 +3433,7 @@ dependencies = [
  "async-trait",
  "beef",
  "futures-util",
- "hyper",
+ "hyper 0.14.27",
  "jsonrpsee-types 0.20.2",
  "serde",
  "serde_json",
@@ -3378,7 +3449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02308562f2e8162a32f8d6c3dc19c29c858d5d478047c886a5c3c25b5f7fa868"
 dependencies = [
  "async-trait",
- "hyper",
+ "hyper 0.14.27",
  "hyper-rustls",
  "jsonrpsee-core 0.20.2",
  "jsonrpsee-types 0.20.2",
@@ -3424,7 +3495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f06661d1a6b6e5b85469dc9c29acfbb9b3bb613797a6fd10a3ebb8a70754057"
 dependencies = [
  "futures-util",
- "hyper",
+ "hyper 0.14.27",
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
  "serde",
@@ -3854,24 +3925,6 @@ dependencies = [
 
 [[package]]
 name = "multer"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 0.2.9",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin 0.9.8",
- "version_check",
-]
-
-[[package]]
-name = "multer"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15d522be0a9c3e46fd2632e272d178f56387bdb5c9fbb3a36c649062e9b5219"
@@ -4142,8 +4195,24 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
 dependencies = [
- "opentelemetry_api 0.18.0",
+ "opentelemetry_api",
  "opentelemetry_sdk 0.18.0",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.0.2",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
@@ -4152,20 +4221,20 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c3d833835a53cf91331d2cfb27e9121f5a95261f31f08a1f79ab31688b8da8"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.18.0",
  "prometheus",
  "protobuf",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d81bc254e2d572120363a2b16cdb0d715d301b5789be0cfc26ad87e4e10e53"
+checksum = "6f8f082da115b0dcb250829e3ed0b8792b8f963a1ad42466e48422fbe6a079bd"
 dependencies = [
  "once_cell",
- "opentelemetry_api 0.20.0",
- "opentelemetry_sdk 0.20.0",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
  "prometheus",
  "protobuf",
 ]
@@ -4187,22 +4256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,7 +4269,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "once_cell",
- "opentelemetry_api 0.18.0",
+ "opentelemetry_api",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
@@ -4224,18 +4277,18 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.20.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api 0.20.0",
+ "opentelemetry 0.21.0",
  "ordered-float",
- "regex",
  "thiserror",
 ]
 
@@ -4247,9 +4300,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "3.9.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -4731,9 +4784,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.21.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
+checksum = "c1ca959da22a332509f2a73ae9e5f23f9dcfc31fd3a54d71f159495bd5909baa"
 dependencies = [
  "dtoa",
  "itoa",
@@ -5083,12 +5136,53 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.21",
  "http 0.2.9",
- "http-body",
- "hyper",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile 1.0.3",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -5097,22 +5191,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
- "winreg",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -5367,7 +5459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
  "schannel",
  "security-framework",
 ]
@@ -5380,6 +5472,22 @@ checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.4",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -5669,9 +5777,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
 dependencies = [
  "base64 0.21.4",
  "chrono",
@@ -5679,6 +5787,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.0.2",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -5686,9 +5795,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5716,10 +5825,10 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
- "async-graphql 6.0.11",
+ "async-graphql",
  "async-graphql-axum",
  "autometrics 0.3.3",
- "axum",
+ "axum 0.7.5",
  "build-info",
  "build-info-build",
  "cargo-husky",
@@ -5733,16 +5842,15 @@ dependencies = [
  "faux",
  "figment",
  "graphql",
- "graphql-http",
  "hex",
  "hex-literal",
- "hyper",
+ "hyper 0.14.27",
  "indexer-common",
  "lazy_static",
  "log",
  "once_cell",
  "prometheus",
- "reqwest",
+ "reqwest 0.12.3",
  "serde",
  "serde_json",
  "serde_spanned",
@@ -5751,10 +5859,11 @@ dependencies = [
  "tap_core",
  "test-log",
  "thegraph",
+ "thegraph-graphql-http",
  "thiserror",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.4.4",
  "tracing",
  "tracing-subscriber",
  "wiremock",
@@ -5884,9 +5993,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smol_str"
@@ -6257,11 +6366,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.25.3",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -6279,9 +6388,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6306,7 +6415,7 @@ dependencies = [
  "fs2",
  "hex",
  "once_cell",
- "reqwest",
+ "reqwest 0.11.22",
  "semver 1.0.20",
  "serde",
  "serde_json",
@@ -6357,6 +6466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6392,7 +6507,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
- "axum",
+ "axum 0.6.20",
  "clap",
  "ethereum-types",
  "ethers-core",
@@ -6487,13 +6602,25 @@ source = "git+https://github.com/edgeandnode/toolshed?tag=thegraph-v0.5.0#7ab59b
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "async-graphql 7.0.1",
+ "async-graphql",
  "bs58",
  "ethers-core",
  "lazy_static",
  "serde",
  "serde_with",
  "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "thegraph-graphql-http"
+version = "0.2.0"
+source = "git+https://github.com/edgeandnode/toolshed?tag=thegraph-graphql-http-v0.2.0#697ed76da278de9c6a441ad73cebc5df7b93f44e"
+dependencies = [
+ "async-trait",
+ "reqwest 0.12.3",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -6653,8 +6780,20 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.20.1",
  "webpki-roots",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -6754,8 +6893,25 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.9",
- "http-body",
+ "http-body 0.4.5",
  "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.4.1",
+ "bytes",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -6776,21 +6932,17 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tower_governor"
-version = "0.1.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db81d9313372d714152194f3f2b66badda23a783fb6a97462e35f632814f4cff"
+checksum = "3790eac6ad3fb8d9d96c2b040ae06e2517aa24b067545d1078b96ae72f7bb9a7"
 dependencies = [
- "axum",
+ "axum 0.7.5",
  "forwarded-header-value",
- "futures",
- "futures-core",
  "governor",
- "http 0.2.9",
+ "http 1.0.0",
  "pin-project",
  "thiserror",
- "tokio",
  "tower",
- "tower-layer",
  "tracing",
 ]
 
@@ -6899,6 +7051,25 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustls",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.0.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
  "sha1",
  "thiserror",
  "url",
@@ -7367,6 +7538,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7379,7 +7560,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "http-types",
- "hyper",
+ "hyper 0.14.27",
  "log",
  "once_cell",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6615,7 +6615,8 @@ dependencies = [
 [[package]]
 name = "thegraph-graphql-http"
 version = "0.2.0"
-source = "git+https://github.com/edgeandnode/toolshed?tag=thegraph-graphql-http-v0.2.0#697ed76da278de9c6a441ad73cebc5df7b93f44e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "013ce559c2fc1427dc22aacd2b6eb66f63be5680c04fa5e1b9ac9a79fb275937"
 dependencies = [
  "async-trait",
  "reqwest 0.12.3",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,7 +31,7 @@ sqlx = { version = "0.7.1", features = [
 ] }
 tokio = { version = "1.32.0", features = ["full", "macros", "rt"] }
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
-thegraph-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-graphql-http-v0.2.0", features = [
+thegraph-graphql-http = { version = "0.2.0", features = [
     "http-client-reqwest",
 ] }
 tap_core = "0.8.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,34 +18,33 @@ lru = "0.11.1"
 once_cell = "1.17"
 prometheus = "0.13.3"
 regex = "1.7.1"
-reqwest = "0.11.20"
+reqwest = "0.12"
 secp256k1 = { version = "0.28.0", features = ["recovery"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = { version = "1.0.107", features = ["arbitrary_precision"] }
 sqlx = { version = "0.7.1", features = [
-  "postgres",
-  "runtime-tokio",
-  "bigdecimal",
-  "rust_decimal",
-  "time",
+    "postgres",
+    "runtime-tokio",
+    "bigdecimal",
+    "rust_decimal",
+    "time",
 ] }
 tokio = { version = "1.32.0", features = ["full", "macros", "rt"] }
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-http-v0.2.1", features = [
-  "http-reqwest",
+thegraph-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-graphql-http-v0.2.0", features = [
+    "http-client-reqwest",
 ] }
 tap_core = "0.8.0"
-axum = { version = "0.6.20", default_features = true, features = ["headers"] }
+axum = { version = "0.7.5", default_features = true }
+axum-extra = { version = "0.9.3", features = ["typed-header"] }
 thiserror = "1.0.49"
 async-trait = "0.1.74"
-headers-derive = "0.1.1"
-headers = "0.3.9"
 build-info = "0.0.34"
-autometrics = { version = "0.6.0", features = ["prometheus-exporter"] }
+autometrics = { version = "1.0.1", features = ["prometheus-exporter"] }
 tracing = "0.1.40"
 tower = "0.4.13"
-tower_governor = "0.1.0"
-tower-http = { version = "0.4.4", features = ["trace"] }
+tower_governor = "0.3.2"
+tower-http = { version = "0.5.2", features = ["trace"] }
 tokio-util = "0.7.10"
 bigdecimal = "0.4.2"
 

--- a/common/src/indexer_service/http/indexer_service.rs
+++ b/common/src/indexer_service/http/indexer_service.rs
@@ -377,7 +377,6 @@ impl IndexerService {
                     .join(format!("{}/id/:id", options.url_namespace))
                     .to_str()
                     .expect("Failed to set up `/{url_namespace}/id/:id` route"),
-                // post(|| async { "Test" }),
                 post(request_handler::<I>),
             )
             .with_state(state.clone());

--- a/common/src/indexer_service/http/indexer_service.rs
+++ b/common/src/indexer_service/http/indexer_service.rs
@@ -416,7 +416,9 @@ impl IndexerService {
             address = %options.config.server.host_and_port,
             "Serving requests",
         );
-        let listener = TcpListener::bind(&options.config.server.host_and_port).await?;
+        let listener = TcpListener::bind(&options.config.server.host_and_port)
+            .await
+            .expect("Failed to bind to indexer-service port");
 
         Ok(serve(
             listener,
@@ -436,7 +438,9 @@ impl IndexerService {
             );
 
             serve(
-                TcpListener::bind(host_and_port).await.unwrap(),
+                TcpListener::bind(host_and_port)
+                    .await
+                    .expect("Failed to bind to metrics port"),
                 router.into_make_service(),
             )
             .await

--- a/common/src/indexer_service/http/indexer_service.rs
+++ b/common/src/indexer_service/http/indexer_service.rs
@@ -11,13 +11,12 @@ use anyhow;
 use autometrics::prometheus_exporter;
 use axum::extract::MatchedPath;
 use axum::http::Request;
+use axum::serve;
 use axum::{
     async_trait,
-    body::Body,
-    error_handling::HandleErrorLayer,
     response::{IntoResponse, Response},
     routing::{get, post},
-    BoxError, Extension, Json, Router, Server,
+    Extension, Json, Router,
 };
 use build_info::BuildInfo;
 use eventuals::Eventual;
@@ -28,9 +27,9 @@ use tap_core::{manager::Manager, receipt::checks::Checks};
 use thegraph::types::Address;
 use thegraph::types::{Attestation, DeploymentId};
 use thiserror::Error;
+use tokio::net::TcpListener;
 use tokio::signal;
-use tower::ServiceBuilder;
-use tower_governor::{errors::display_error, governor::GovernorConfigBuilder, GovernorLayer};
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 use tower_http::trace::TraceLayer;
 use tracing::{info, info_span};
 
@@ -167,7 +166,7 @@ where
     pub release: IndexerServiceRelease,
     pub url_namespace: &'static str,
     pub metrics_prefix: &'static str,
-    pub extra_routes: Router<Arc<IndexerServiceState<I>>, Body>,
+    pub extra_routes: Router<Arc<IndexerServiceState<I>>>,
 }
 
 pub struct IndexerServiceState<I>
@@ -329,13 +328,7 @@ impl IndexerService {
             .route("/", get("Service is up and running"))
             .route("/version", get(Json(options.release)))
             .route("/info", get(operator_address))
-            .layer(
-                ServiceBuilder::new()
-                    .layer(HandleErrorLayer::new(|e: BoxError| async move {
-                        display_error(e)
-                    }))
-                    .layer(misc_rate_limiter),
-            );
+            .layer(misc_rate_limiter);
 
         // Rate limits by allowing bursts of 50 requests and requiring 20ms of
         // time between consecutive requests after that, effectively rate
@@ -360,13 +353,7 @@ impl IndexerService {
                     .route_layer(Extension(
                         options.config.network_subgraph.serve_auth_token.clone(),
                     ))
-                    .route_layer(
-                        ServiceBuilder::new()
-                            .layer(HandleErrorLayer::new(|e: BoxError| async move {
-                                display_error(e)
-                            }))
-                            .layer(static_subgraph_rate_limiter.clone()),
-                    ),
+                    .route_layer(static_subgraph_rate_limiter.clone()),
             );
         }
 
@@ -379,13 +366,7 @@ impl IndexerService {
                 .route_layer(Extension(
                     options.config.escrow_subgraph.serve_auth_token.clone(),
                 ))
-                .route_layer(
-                    ServiceBuilder::new()
-                        .layer(HandleErrorLayer::new(|e: BoxError| async move {
-                            display_error(e)
-                        }))
-                        .layer(static_subgraph_rate_limiter),
-                );
+                .route_layer(static_subgraph_rate_limiter);
         }
 
         misc_routes = misc_routes.with_state(state.clone());
@@ -396,6 +377,7 @@ impl IndexerService {
                     .join(format!("{}/id/:id", options.url_namespace))
                     .to_str()
                     .expect("Failed to set up `/{url_namespace}/id/:id` route"),
+                // post(|| async { "Test" }),
                 post(request_handler::<I>),
             )
             .with_state(state.clone());
@@ -435,11 +417,14 @@ impl IndexerService {
             address = %options.config.server.host_and_port,
             "Serving requests",
         );
+        let listener = TcpListener::bind(&options.config.server.host_and_port).await?;
 
-        Ok(Server::bind(&options.config.server.host_and_port)
-            .serve(router.into_make_service_with_connect_info::<SocketAddr>())
-            .with_graceful_shutdown(shutdown_signal())
-            .await?)
+        Ok(serve(
+            listener,
+            router.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(shutdown_signal())
+        .await?)
     }
 
     fn serve_metrics(host_and_port: SocketAddr) {
@@ -451,10 +436,12 @@ impl IndexerService {
                 get(|| async { prometheus_exporter::encode_http_response() }),
             );
 
-            Server::bind(&host_and_port)
-                .serve(router.into_make_service())
-                .await
-                .expect("Failed to serve metrics")
+            serve(
+                TcpListener::bind(host_and_port).await.unwrap(),
+                router.into_make_service(),
+            )
+            .await
+            .expect("Failed to serve metrics")
         });
     }
 }

--- a/common/src/indexer_service/http/request_handler.rs
+++ b/common/src/indexer_service/http/request_handler.rs
@@ -8,8 +8,8 @@ use axum::{
     extract::{Path, State},
     http::HeaderMap,
     response::IntoResponse,
-    TypedHeader,
 };
+use axum_extra::TypedHeader;
 use reqwest::StatusCode;
 use thegraph::types::DeploymentId;
 use tracing::trace;

--- a/common/src/indexer_service/http/scalar_receipt_header.rs
+++ b/common/src/indexer_service/http/scalar_receipt_header.rs
@@ -3,7 +3,7 @@
 
 use std::ops::Deref;
 
-use headers::{Header, HeaderName, HeaderValue};
+use axum_extra::headers::{self, Header, HeaderName, HeaderValue};
 use lazy_static::lazy_static;
 use tap_core::receipt::SignedReceipt;
 
@@ -61,7 +61,8 @@ impl Header for ScalarReceipt {
 mod test {
     use std::str::FromStr;
 
-    use axum::{headers::Header, http::HeaderValue};
+    use axum::http::HeaderValue;
+    use axum_extra::headers::Header;
     use thegraph::types::Address;
 
     use crate::test_vectors::create_signed_receipt;

--- a/common/src/subgraph_client/client.rs
+++ b/common/src/subgraph_client/client.rs
@@ -4,15 +4,15 @@
 use anyhow::anyhow;
 use axum::body::Bytes;
 use eventuals::Eventual;
-use graphql_http::{
-    graphql::{Document, IntoDocument},
-    http::request::{IntoRequestParameters, RequestParameters},
-    http_client::{ReqwestExt, ResponseResult},
-};
 use reqwest::{header, Url};
 use serde::de::Deserialize;
 use serde_json::{Map, Value};
 use thegraph::types::DeploymentId;
+use thegraph_graphql_http::{
+    graphql::{Document, IntoDocument},
+    http::request::{IntoRequestParameters, RequestParameters},
+    http_client::{ReqwestExt, ResponseResult},
+};
 use tracing::warn;
 
 use super::monitor::{monitor_deployment_status, DeploymentStatus};

--- a/common/src/subgraph_client/monitor.rs
+++ b/common/src/subgraph_client/monitor.rs
@@ -4,14 +4,14 @@
 use std::time::Duration;
 
 use eventuals::{timer, Eventual, EventualExt};
-use graphql_http::{
-    http::request::IntoRequestParameters,
-    http_client::{ReqwestExt, ResponseResult},
-};
 use reqwest::Url;
 use serde::Deserialize;
 use serde_json::json;
 use thegraph::types::DeploymentId;
+use thegraph_graphql_http::{
+    http::request::IntoRequestParameters,
+    http_client::{ReqwestExt, ResponseResult},
+};
 use tokio::time::sleep;
 use tracing::warn;
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -15,13 +15,13 @@ eventuals = "0.6.7"
 dotenvy = "0.15"
 log = "0.4.17"
 anyhow = "1.0.57"
-reqwest = "0.11.10"
+reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["rt", "macros", "sync", "full"] }
 tracing = "0.1.34"
 thiserror = "1.0.49"
 serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1"
-axum = "0.6.20"
+axum = "0.7.5"
 hyper = "0.14.27"
 tower = { version = "0.4", features = ["util", "timeout", "limit"] }
 tower-http = { version = "0.4.0", features = [
@@ -30,8 +30,8 @@ tower-http = { version = "0.4.0", features = [
     "cors",
 ] }
 once_cell = "1.17"
-async-graphql = "6.0.11"
-async-graphql-axum = "6.0.11"
+async-graphql = "7.0.3"
+async-graphql-axum = "7.0.3"
 sha3 = "0.10.6"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
@@ -58,8 +58,8 @@ alloy-sol-types = "0.6"
 lazy_static = "1.4.0"
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0" }
-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-http-v0.2.1", features = [
-    "http-reqwest",
+thegraph-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-graphql-http-v0.2.0", features = [
+    "http-client-reqwest",
 ] }
 build-info = "0.0.34"
 figment = { version = "0.10", features = ["toml", "env"] }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -58,7 +58,7 @@ alloy-sol-types = "0.6"
 lazy_static = "1.4.0"
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0" }
-thegraph-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-graphql-http-v0.2.0", features = [
+thegraph-graphql-http = { version = "0.2.0", features = [
     "http-client-reqwest",
 ] }
 build-info = "0.0.34"

--- a/service/src/routes/status.rs
+++ b/service/src/routes/status.rs
@@ -7,11 +7,11 @@ use std::sync::Arc;
 use async_graphql_axum::GraphQLRequest;
 use axum::{extract::State, response::IntoResponse, Json};
 use graphql::graphql_parser::query as q;
-use graphql_http::{
+use serde_json::{json, Map, Value};
+use thegraph_graphql_http::{
     http::request::{IntoRequestParameters, RequestParameters},
     http_client::{ReqwestExt, ResponseError},
 };
-use serde_json::{json, Map, Value};
 
 use crate::{SubgraphServiceError, SubgraphServiceState};
 

--- a/tap-agent/Cargo.toml
+++ b/tap-agent/Cargo.toml
@@ -22,7 +22,7 @@ eventuals = "0.6.7"
 indexer-common = { version = "0.1.0", path = "../common" }
 jsonrpsee = { version = "0.20.2", features = ["http-client", "macros"] }
 lazy_static = "1.4.0"
-reqwest = "0.11.20"
+reqwest = "0.12"
 serde = "1.0.188"
 serde_json = "1.0.104"
 serde_yaml = "0.9.25"
@@ -38,7 +38,9 @@ tap_core = "0.8.0"
 thiserror = "1.0.44"
 tokio = { version = "1.33.0" }
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-http-v0.2.1" }
+thegraph-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-graphql-http-v0.2.0", features = [
+    "http-client-reqwest",
+] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
@@ -48,7 +50,7 @@ tracing-subscriber = { version = "0.3", features = [
     "json",
 ] }
 enum-as-inner = "0.6.0"
-ethers = "2.0.13"
+ethers = "2.0.14"
 typetag = "0.2.14"
 ractor = "0.9.7"
 

--- a/tap-agent/Cargo.toml
+++ b/tap-agent/Cargo.toml
@@ -38,7 +38,7 @@ tap_core = "0.8.0"
 thiserror = "1.0.44"
 tokio = { version = "1.33.0" }
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
-thegraph-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-graphql-http-v0.2.0", features = [
+thegraph-graphql-http = { version = "0.2.0", features = [
     "http-client-reqwest",
 ] }
 tracing = "0.1.37"


### PR DESCRIPTION
This PR aims to update `graphql-http` into the released version of `thegraph-graphql-http`.

By doing it, I had to update `reqwest` to version 0.12 which triggered a whole chain effect of updating multiple dependencies including: `axum`, add `axum-extra`, `tower`, `tower-http`, `tower-governor`, `autometrics`, `async-graphql` and `async-graphql-axum`.

The rest of the changes are just fixes for the breaking changes of each dependency.

The reason for the update of `thegraph-graphql-http` is that we are getting some serialization errors and we plan to fix them soon on a future pr.