### PR TITLE
fix: use better error handling for subgraph query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,7 +3205,7 @@ dependencies = [
  "tap_core",
  "test-log",
  "thegraph",
- "thegraph-graphql-http",
+ "thegraph-graphql-http 0.2.0 (git+https://github.com/semiotic-ai/toolshed?rev=89a8411)",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -3247,7 +3247,7 @@ dependencies = [
  "tap_core",
  "tempfile",
  "thegraph",
- "thegraph-graphql-http",
+ "thegraph-graphql-http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "tracing",
@@ -5859,7 +5859,7 @@ dependencies = [
  "tap_core",
  "test-log",
  "thegraph",
- "thegraph-graphql-http",
+ "thegraph-graphql-http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "tower",
@@ -6617,6 +6617,18 @@ name = "thegraph-graphql-http"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "013ce559c2fc1427dc22aacd2b6eb66f63be5680c04fa5e1b9ac9a79fb275937"
+dependencies = [
+ "async-trait",
+ "reqwest 0.12.3",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "thegraph-graphql-http"
+version = "0.2.0"
+source = "git+https://github.com/semiotic-ai/toolshed?rev=89a8411#89a8411352fab77e150d7fb08a038bd5dbbc8ae4"
 dependencies = [
  "async-trait",
  "reqwest 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,7 +3205,7 @@ dependencies = [
  "tap_core",
  "test-log",
  "thegraph",
- "thegraph-graphql-http 0.2.0 (git+https://github.com/semiotic-ai/toolshed?rev=89a8411)",
+ "thegraph-graphql-http",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -3247,7 +3247,7 @@ dependencies = [
  "tap_core",
  "tempfile",
  "thegraph",
- "thegraph-graphql-http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thegraph-graphql-http",
  "thiserror",
  "tokio",
  "tracing",
@@ -5859,7 +5859,7 @@ dependencies = [
  "tap_core",
  "test-log",
  "thegraph",
- "thegraph-graphql-http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thegraph-graphql-http",
  "thiserror",
  "tokio",
  "tower",
@@ -6614,21 +6614,9 @@ dependencies = [
 
 [[package]]
 name = "thegraph-graphql-http"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013ce559c2fc1427dc22aacd2b6eb66f63be5680c04fa5e1b9ac9a79fb275937"
-dependencies = [
- "async-trait",
- "reqwest 0.12.3",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "thegraph-graphql-http"
-version = "0.2.0"
-source = "git+https://github.com/semiotic-ai/toolshed?rev=89a8411#89a8411352fab77e150d7fb08a038bd5dbbc8ae4"
+checksum = "c5b7231f969a5168347a7efac9f92cc83a4ada280238139ade4d82d45360b99c"
 dependencies = [
  "async-trait",
  "reqwest 0.12.3",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,7 +31,7 @@ sqlx = { version = "0.7.1", features = [
 ] }
 tokio = { version = "1.32.0", features = ["full", "macros", "rt"] }
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
-thegraph-graphql-http = { version = "0.2.0", features = [
+thegraph-graphql-http = { version = "0.2.0", git = "https://github.com/semiotic-ai/toolshed", rev = "89a8411", features = [
     "http-client-reqwest",
 ] }
 tap_core = "0.8.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,7 +31,7 @@ sqlx = { version = "0.7.1", features = [
 ] }
 tokio = { version = "1.32.0", features = ["full", "macros", "rt"] }
 thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.5.0" }
-thegraph-graphql-http = { version = "0.2.0", git = "https://github.com/semiotic-ai/toolshed", rev = "89a8411", features = [
+thegraph-graphql-http = { version = "0.2.1", features = [
     "http-client-reqwest",
 ] }
 tap_core = "0.8.0"


### PR DESCRIPTION
The newer version for toolshed correctly displays the original message that failed to be deserialized