### PR TITLE
Add limit of receipts per rav request

### DIFF
--- a/tap-agent/src/agent/sender_allocation.rs
+++ b/tap-agent/src/agent/sender_allocation.rs
@@ -334,8 +334,7 @@ impl SenderAllocationState {
             .tap_manager
             .create_rav_request(
                 self.config.tap.rav_request_timestamp_buffer_ms * 1_000_000,
-                // TODO: limit the number of receipts to aggregate per request.
-                None,
+                Some(self.config.tap.rav_request_receipt_limit),
             )
             .await
             .map_err(|e| match e {
@@ -628,6 +627,7 @@ mod tests {
                 rav_request_trigger_value: 100,
                 rav_request_timestamp_buffer_ms: 1,
                 rav_request_timeout_secs: 5,
+                rav_request_receipt_limit: 1000,
                 ..Default::default()
             },
             ..Default::default()

--- a/tap-agent/src/config.rs
+++ b/tap-agent/src/config.rs
@@ -239,7 +239,7 @@ pub struct Tap {
         env = "RAV_REQUEST_TIMESTAMP_BUFFER",
         help = "Buffer (in ms) to add between the current time and the timestamp of the \
         last unaggregated fee when triggering a RAV request.",
-        default_value_t = 1_000 // 1 second
+        default_value_t = 60_000 // 60 seconds
     )]
     pub rav_request_timestamp_buffer_ms: u64,
     #[clap(
@@ -259,6 +259,15 @@ pub struct Tap {
         help = "YAML file with a map of sender addresses to aggregator endpoints."
     )]
     pub sender_aggregator_endpoints_file: PathBuf,
+
+    #[clap(
+        long,
+        value_name = "rav-request-receipt-limit",
+        env = "RAV_REQUEST_RECEIPT_LIMIT",
+        help = "Amount that will define the limit of receipts to aggregate per request",
+        default_value_t = 10000
+    )]
+    pub rav_request_receipt_limit: u64,
 }
 
 /// Sets up tracing, allows log level to be set from the environment variables

--- a/tap-agent/src/config.rs
+++ b/tap-agent/src/config.rs
@@ -264,7 +264,7 @@ pub struct Tap {
         long,
         value_name = "rav-request-receipt-limit",
         env = "RAV_REQUEST_RECEIPT_LIMIT",
-        help = "Amount that will define the limit of receipts to aggregate per request",
+        help = "Maximum number of receipts per aggregation request",
         default_value_t = 10000
     )]
     pub rav_request_receipt_limit: u64,


### PR DESCRIPTION
Added to config a limit  that will define the amount of receipts to aggregate per request
fixes #96 