### PR TITLE
fix(tap-agent): metrics port config

### DIFF
--- a/tap-agent/src/config.rs
+++ b/tap-agent/src/config.rs
@@ -226,14 +226,6 @@ pub struct EscrowSubgraph {
 pub struct Tap {
     #[clap(
         long,
-        value_name = "tap-metrics-port",
-        env = "TAP_METRICS_PORT",
-        default_value_t = 7303,
-        help = "Port to serve tap agent Prometheus metrics at"
-    )]
-    pub metrics_port: u16,
-    #[clap(
-        long,
         value_name = "rav-request-trigger-value",
         env = "RAV_REQUEST_TRIGGER_VALUE",
         help = "Value of unaggregated fees that triggers a RAV request (in GRT).",

--- a/tap-agent/src/main.rs
+++ b/tap-agent/src/main.rs
@@ -17,7 +17,9 @@ async fn main() -> Result<()> {
     let (manager, handler) = agent::start_agent().await;
     info!("TAP Agent started.");
 
-    tokio::spawn(metrics::run_server(CONFIG.indexer_infrastructure.metrics_port));
+    tokio::spawn(metrics::run_server(
+        CONFIG.indexer_infrastructure.metrics_port,
+    ));
     info!("Metrics port opened");
 
     // Have tokio wait for SIGTERM or SIGINT.

--- a/tap-agent/src/main.rs
+++ b/tap-agent/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     let (manager, handler) = agent::start_agent().await;
     info!("TAP Agent started.");
 
-    tokio::spawn(metrics::run_server(CONFIG.tap.metrics_port));
+    tokio::spawn(metrics::run_server(CONFIG.indexer_infrastructure.metrics_port));
     info!("Metrics port opened");
 
     // Have tokio wait for SIGTERM or SIGINT.


### PR DESCRIPTION
A metrics config port was unnecessarily added in #156 , and created a conflict in clap that breaks argument parsing completely.