### PR TITLE
feat(tap-agent): Deny senders over max_unnaggregated_fees_per_sender

### DIFF
--- a/.sqlx/query-6389d2951877d3211943268c36145f3665501acea0adadea3f09695d0503ee7b.json
+++ b/.sqlx/query-6389d2951877d3211943268c36145f3665501acea0adadea3f09695d0503ee7b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT EXISTS (\n                    SELECT 1\n                    FROM scalar_tap_denylist\n                    WHERE sender_address = $1\n                ) as denied\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "denied",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "6389d2951877d3211943268c36145f3665501acea0adadea3f09695d0503ee7b"
+}

--- a/.sqlx/query-6d1c71ee8f32e696e6a091b37ec415ca3e12356f3418a376980e5458fee7e200.json
+++ b/.sqlx/query-6d1c71ee8f32e696e6a091b37ec415ca3e12356f3418a376980e5458fee7e200.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    DELETE FROM scalar_tap_denylist \n                    WHERE sender_address = $1\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bpchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6d1c71ee8f32e696e6a091b37ec415ca3e12356f3418a376980e5458fee7e200"
+}

--- a/.sqlx/query-7487b58e603ccc4ac2e55e676295517040b78eb9bba04c9db33229fe52f85259.json
+++ b/.sqlx/query-7487b58e603ccc4ac2e55e676295517040b78eb9bba04c9db33229fe52f85259.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    INSERT INTO scalar_tap_denylist (sender_address)\n                    VALUES ($1) ON CONFLICT DO NOTHING\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bpchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7487b58e603ccc4ac2e55e676295517040b78eb9bba04c9db33229fe52f85259"
+}

--- a/.sqlx/query-a15f95e1e74e806a6bbc355139b6af57911eb79e5233e80bb08f6e5ef6d14fc9.json
+++ b/.sqlx/query-a15f95e1e74e806a6bbc355139b6af57911eb79e5233e80bb08f6e5ef6d14fc9.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT EXISTS (\n                        SELECT 1\n                        FROM scalar_tap_denylist\n                        WHERE sender_address = $1\n                    ) as deny\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "deny",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "a15f95e1e74e806a6bbc355139b6af57911eb79e5233e80bb08f6e5ef6d14fc9"
+}

--- a/tap-agent/src/config.rs
+++ b/tap-agent/src/config.rs
@@ -276,6 +276,18 @@ pub struct Tap {
         default_value_t = 10000
     )]
     pub rav_request_receipt_limit: u64,
+
+    #[clap(
+        long,
+        value_name = "max-unnaggregated-fees-per-sender",
+        env = "MAX_UNNAGGREGATED_FEES_PER_SENDER",
+        help = "Maximum amount of unaggregated fees in GRT per sender. This is the amount of fees \
+        you are willing to risk at any given time. For ex. if the sender stops supplying RAVs for \
+        long enough and the fees exceed this amount, the indexer-service will stop accepting \
+        queries from the sender until the fees are aggregated.",
+        default_value_t = 20
+    )]
+    pub max_unnaggregated_fees_per_sender: u64,
 }
 
 /// Sets up tracing, allows log level to be set from the environment variables


### PR DESCRIPTION
Fixes #103. (the remaining half)

Adds a new setting `max_unnaggregated_fees_per_sender` (in GRT).
When a sender's unaggregated fees go over that value, it gets added to the `scalar_tap_denylist`, which tells the indexer-service to refuse service from that sender.
When the unaggregated fees come back under the value, it gets removed from the `scalar_tap_denylist`, which tells the indexer-service to accept service from that sender again.
