### PR TITLE
refactor(database): streamline model merging

### DIFF
--- a/service/src/database.rs
+++ b/service/src/database.rs
@@ -122,11 +122,7 @@ pub async fn cost_models(
         models = models
             .into_iter()
             .map(|model| merge_global(model, &global_model))
-            .collect();
-
-        // Inject a cost model for all deployments that don't have one
-        models = models
-            .into_iter()
+            // Inject a cost model for all deployments that don't have one
             .chain(
                 deployments_without_models
                     .into_iter()


### PR DESCRIPTION
Another small thing I caught while familiarizing myself with the code, this removes the need to create an intermediate vector when merging models in `database`.