### PR TITLE
chore(ci): group all build-info upgrade PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -91,6 +91,19 @@
         'async-graphql-',
       ],
     },
+    {
+      groupName: 'build-info crates',
+      groupSlug: 'build-info',
+      matchManagers: [
+        'cargo',
+      ],
+      matchPackageNames: [
+        'build-info',
+      ],
+      matchPackagePrefixes: [
+        'build-info-',
+      ],
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
Update renovate config to group all `build-info` crate updates 