### PR TITLE
Fix `query_url` in config

### DIFF
--- a/common/src/subgraph_client/client.rs
+++ b/common/src/subgraph_client/client.rs
@@ -91,7 +91,8 @@ impl DeploymentDetails {
         Ok(Self {
             deployment: Some(deployment),
             status_url: Some(Url::parse(graph_node_status_url)?),
-            query_url: Url::parse(&format!("{graph_node_base_url}/subgraphs/id/{deployment}"))?,
+            query_url: Url::parse(graph_node_base_url)?
+                .join(&format!("subgraphs/id/{deployment}"))?,
         })
     }
 
@@ -425,6 +426,7 @@ mod test {
             )
             .await;
 
+        println!("mock_server_local.uri(): {}", mock_server_local.uri());
         // Create the subgraph client
         let client = SubgraphClient::new(
             reqwest::Client::new(),

--- a/common/src/subgraph_client/client.rs
+++ b/common/src/subgraph_client/client.rs
@@ -426,7 +426,6 @@ mod test {
             )
             .await;
 
-        println!("mock_server_local.uri(): {}", mock_server_local.uri());
         // Create the subgraph client
         let client = SubgraphClient::new(
             reqwest::Client::new(),


### PR DESCRIPTION
After recent refactoring, `[subgraphs.*.query_url]` is broken in config resulting in double slash in query url in the client

What happens is `query_url` deserializes into Url, then gets converted to String with a trailing slash (even if originally it didn't have it), then appended with `/subgraphs/id/Qmxxx`, resulting in double-slash that graph-node can't handle
 
i.e. `http://query-node:8000` -> `http://query-node:8000/` -> `http://query-node:8000//subgraphs/id/Qmxxx`

<img width="1037" alt="image" src="https://github.com/graphprotocol/indexer-rs/assets/29608734/49bd26e9-0b8f-46d4-bad8-3c5221dfd35c">


This PR fixes it