### PR TITLE
chore(common): disable integration test depending on the hosted service

### DIFF
--- a/common/src/subgraph_client/client.rs
+++ b/common/src/subgraph_client/client.rs
@@ -355,6 +355,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[ignore = "depends on the defunct hosted-service"]
     async fn test_network_query() {
         let _mock_server = mock_graph_node_server().await;
 


### PR DESCRIPTION
This integration test depends on the now "defunct" hosted service, so the test always fails.

I am disabling it until we find a solution to this dependency on the hosted service.