### PR TITLE
fix(tap-agent): never log config

### DIFF
--- a/tap-agent/src/main.rs
+++ b/tap-agent/src/main.rs
@@ -12,7 +12,6 @@ use indexer_tap_agent::{agent, metrics, CONFIG};
 async fn main() -> Result<()> {
     // Parse basic configurations, also initializes logging.
     lazy_static::initialize(&CONFIG);
-    debug!("Config: {:?}", *CONFIG);
 
     let (manager, handler) = agent::start_agent().await;
     info!("TAP Agent started.");


### PR DESCRIPTION
We are currently printing the contents of the config in the logs at the debug level. While that was useful at early testing stage,  we should now drop it before it gets used on mainnet.