### PR TITLE
feat(config): env support for nested fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,6 +3177,7 @@ dependencies = [
  "serde_repr",
  "serde_test",
  "serde_with",
+ "tempfile",
  "thegraph",
  "toml",
  "tracing",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -19,5 +19,6 @@ serde_ignored = "0.1.10"
 [dev-dependencies]
 sealed_test = "1.1.0"
 serde_test = "1.0.176"
+tempfile = "3.10.1"
 toml = "0.8.12"
 tracing-test = "0.2.5"

--- a/config/maximal-config-example.toml
+++ b/config/maximal-config-example.toml
@@ -9,13 +9,16 @@
 # Some of the config below are global graph network values, which you can find here:
 # https://github.com/graphprotocol/indexer/tree/main/docs/networks
 #
-# Pro tip: if you need to load some values from the environment into this config, you
-# can overwrite with environment variables. For example, the following can be replaced
-# by [PREFIX]_DATABASE_POSTGRESURL, where PREFIX can be `INDEXER_SERVICE` or `TAP_AGENT`:
+# If you want to supply some or all of the configuration below using environment variables,
+# use the prefix "INDEXER_SERVICE" or "TAP_AGENT" for indexer-service or tap-agent, respectively,
+# followed by the name of the field, using double underscores "__" for nesting. Example:
 #
-# [database]
-# postgres_url = "postgresql://indexer:${POSTGRES_PASSWORD}@postgres:5432/indexer_components_0"
-
+#       INDEXER_SERVICE_SUBGRAPHS__NETWORK__QUERY_URL = [...]
+#
+#   For
+#
+#       [subgraphs.network]
+#       query_url = [...]
 
 [indexer]
 indexer_address = "0x1111111111111111111111111111111111111111"


### PR DESCRIPTION
Having the possibility of supplying all of the configuration using environment variables is already a requested feature.
This makes sure that we can do so, even for nested configuration fields.

With this, nesting it handled with double underscore in env var name, example:
```
INDEXER_SERVICE_SUBGRAPHS__NETWORK__QUERY_URL = http[...]
```