### PR TITLE
fix: Rename trigger rav to Rav trigger

### DIFF
--- a/docs/dashboard.json
+++ b/docs/dashboard.json
@@ -231,7 +231,7 @@
             "uid": "b70befc5-0872-448c-b502-9875d467edaf"
           },
           "editorMode": "code",
-          "expr": "tap_max_fee_per_sender_grt_total * 10^-18/tap_rav_request_trigger_value",
+          "expr": "tap_rav_request_trigger_value * 10^-18",
           "hide": false,
           "legendFormat": "Rav Trigger {{sender}}",
           "range": true,

--- a/docs/dashboard.json
+++ b/docs/dashboard.json
@@ -231,9 +231,9 @@
             "uid": "b70befc5-0872-448c-b502-9875d467edaf"
           },
           "editorMode": "code",
-          "expr": "tap_max_fee_per_sender_grt_total * 10^-18/1000",
+          "expr": "tap_max_fee_per_sender_grt_total * 10^-18/tap_rav_request_trigger_value",
           "hide": false,
-          "legendFormat": "Trigger Rav {{sender}}",
+          "legendFormat": "Rav Trigger {{sender}}",
           "range": true,
           "refId": "C"
         }

--- a/tap-agent/src/agent/sender_account.rs
+++ b/tap-agent/src/agent/sender_account.rs
@@ -66,6 +66,12 @@ lazy_static! {
         &["sender"]
     )
     .unwrap();
+    static ref RAV_REQUEST_TRIGGER_VALUE: GaugeVec = register_gauge_vec!(
+        "tap_rav_request_trigger_value",
+        "RAV request trigger value divisor",
+        &["sender"]
+    )
+    .unwrap();
 }
 
 type RavMap = HashMap<Address, u128>;
@@ -466,6 +472,10 @@ impl Actor for SenderAccount {
         MAX_FEE_PER_SENDER
             .with_label_values(&[&sender_id.to_string()])
             .set(config.tap.max_unnaggregated_fees_per_sender as f64);
+
+        RAV_REQUEST_TRIGGER_VALUE
+            .with_label_values(&[&sender_id.to_string()])
+            .set(config.tap.rav_request_trigger_value as f64);
 
         let state = State {
             sender_fee_tracker: SenderFeeTracker::default(),


### PR DESCRIPTION
Change hardcoded trigger value of 1000 to a metric tap_rav_request_trigger_value
fixes #313 