### PR TITLE
fix: config comment of using both queryurl and deployment_id

### DIFF
--- a/config/maximal-config-example.toml
+++ b/config/maximal-config-example.toml
@@ -59,6 +59,7 @@ syncing_interval_secs = 60
 recently_closed_allocation_buffer_secs = 3600
 
 [subgraphs.escrow]
+# NOTE: It is heavily recomended to use both `query_url` and `deployment_id`,
 # Query URL for the Escrow subgraph.
 query_url = "http://example.com/network-subgraph"
 # Optional, Auth token will used a "bearer auth"
@@ -66,7 +67,6 @@ query_url = "http://example.com/network-subgraph"
 
 # Optional, deployment to look for in the local `graph-node`, if locally indexed.
 # Locally indexing the subgraph is recommended.
-# NOTE: Use `query_url` or `deployment_id` only
 deployment_id = "Qmaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 # Refreshing interval for the Escrow contracts information from the Escrow subgraph.
 syncing_interval_secs = 60


### PR DESCRIPTION
fixes #257 