### PR TITLE
chore: add ansi feature flag for subscriber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol
 tracing-subscriber = { version = "0.3", features = [
     "json",
     "env-filter",
+    "ansi",
 ], default-features = false }
 thegraph-core = { git = "https://github.com/edgeandnode/toolshed", rev = "85ee00b", features = [
     "subgraph-client",


### PR DESCRIPTION
If you try to compile directly `service` after compiling other components, you need to do `cargo clean && cargo build`. By adding this flag, you don't have to clean and rebuild