### PR TITLE
fix: proper build graph-node query url

### DIFF
--- a/common/src/indexer_service/http/indexer_service.rs
+++ b/common/src/indexer_service/http/indexer_service.rs
@@ -207,12 +207,23 @@ impl IndexerService {
 
         let network_subgraph: &'static SubgraphClient = Box::leak(Box::new(SubgraphClient::new(
             http_client.clone(),
-            Some(DeploymentDetails {
-                deployment: options.config.subgraphs.network.config.deployment_id,
-                status_url: Some(options.config.graph_node.status_url.clone()),
-                query_url: options.config.graph_node.query_url.clone(),
-                query_auth_token: options.config.service.free_query_auth_token.clone(),
-            }),
+            options
+                .config
+                .subgraphs
+                .network
+                .config
+                .deployment_id
+                .map(|deployment| {
+                    DeploymentDetails::for_graph_node_url(
+                        options.config.graph_node.status_url.clone(),
+                        options.config.graph_node.query_url.clone(),
+                        deployment,
+                    )
+                })
+                .transpose()
+                .expect(
+                    "Failed to parse graph node query endpoint and network subgraph deployment",
+                ),
             DeploymentDetails::for_query_url_with_token(
                 options.config.subgraphs.network.config.query_url.as_ref(),
                 options
@@ -260,12 +271,21 @@ impl IndexerService {
 
         let escrow_subgraph: &'static SubgraphClient = Box::leak(Box::new(SubgraphClient::new(
             http_client,
-            Some(DeploymentDetails {
-                deployment: options.config.subgraphs.escrow.config.deployment_id,
-                status_url: Some(options.config.graph_node.status_url.clone()),
-                query_url: options.config.graph_node.query_url.clone(),
-                query_auth_token: options.config.service.free_query_auth_token.clone(),
-            }),
+            options
+                .config
+                .subgraphs
+                .escrow
+                .config
+                .deployment_id
+                .map(|deployment| {
+                    DeploymentDetails::for_graph_node_url(
+                        options.config.graph_node.status_url.clone(),
+                        options.config.graph_node.query_url.clone(),
+                        deployment,
+                    )
+                })
+                .transpose()
+                .expect("Failed to parse graph node query endpoint and escrow subgraph deployment"),
             DeploymentDetails::for_query_url_with_token(
                 options.config.subgraphs.escrow.config.query_url.as_ref(),
                 options


### PR DESCRIPTION
We had a refactor(#409) that updated the duplication of code in configurations. But while doing that, status_url was misconfigured. With the latest refactor (#428), we crash early if we cannot start some services.

Indexer service on version 1.2.0 is not capable of starting up if you provide local deployment (graph-node + deployment_id)