### PR TITLE
refactor: use sender in tap context

### DIFF
--- a/crates/service/src/middleware.rs
+++ b/crates/service/src/middleware.rs
@@ -18,6 +18,6 @@ pub use attestation_signer::{signer_middleware, AttestationState};
 pub use deployment::deployment_middleware;
 pub use labels::labels_middleware;
 pub use prometheus_metrics::PrometheusMetricsMiddlewareLayer;
-pub use sender::{sender_middleware, SenderState};
+pub use sender::{sender_middleware, Sender, SenderState};
 pub use tap_context::context_middleware;
 pub use tap_receipt::receipt_middleware;

--- a/crates/service/src/service/indexer_service.rs
+++ b/crates/service/src/service/indexer_service.rs
@@ -238,7 +238,6 @@ pub async fn run(options: IndexerServiceOptions) -> Result<(), anyhow::Error> {
         database,
         allocations.clone(),
         escrow_accounts.clone(),
-        domain_separator.clone(),
         timestamp_error_tolerance,
         receipt_max_value,
     )

--- a/crates/service/src/tap.rs
+++ b/crates/service/src/tap.rs
@@ -47,18 +47,14 @@ impl IndexerTapContext {
         pgpool: PgPool,
         indexer_allocations: Receiver<HashMap<Address, Allocation>>,
         escrow_accounts: Receiver<EscrowAccounts>,
-        domain_separator: Eip712Domain,
         timestamp_error_tolerance: Duration,
         receipt_max_value: u128,
     ) -> Vec<ReceiptCheck> {
         vec![
             Arc::new(AllocationEligible::new(indexer_allocations)),
-            Arc::new(SenderBalanceCheck::new(
-                escrow_accounts.clone(),
-                domain_separator.clone(),
-            )),
+            Arc::new(SenderBalanceCheck::new(escrow_accounts)),
             Arc::new(TimestampCheck::new(timestamp_error_tolerance)),
-            Arc::new(DenyListCheck::new(pgpool.clone(), escrow_accounts, domain_separator).await),
+            Arc::new(DenyListCheck::new(pgpool.clone()).await),
             Arc::new(ReceiptMaxValueCheck::new(receipt_max_value)),
             Arc::new(MinimumValue::new(pgpool, Duration::from_secs(GRACE_PERIOD)).await),
         ]

--- a/crates/service/src/tap/checks/sender_balance_check.rs
+++ b/crates/service/src/tap/checks/sender_balance_check.rs
@@ -1,7 +1,6 @@
 // Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy::dyn_abi::Eip712Domain;
 use alloy::primitives::U256;
 use anyhow::anyhow;
 use indexer_monitor::EscrowAccounts;
@@ -11,20 +10,16 @@ use tap_core::receipt::{
     ReceiptWithState,
 };
 use tokio::sync::watch::Receiver;
-use tracing::error;
+
+use crate::middleware::Sender;
 
 pub struct SenderBalanceCheck {
     escrow_accounts: Receiver<EscrowAccounts>,
-
-    domain_separator: Eip712Domain,
 }
 
 impl SenderBalanceCheck {
-    pub fn new(escrow_accounts: Receiver<EscrowAccounts>, domain_separator: Eip712Domain) -> Self {
-        Self {
-            escrow_accounts,
-            domain_separator,
-        }
+    pub fn new(escrow_accounts: Receiver<EscrowAccounts>) -> Self {
+        Self { escrow_accounts }
     }
 }
 
@@ -32,34 +27,24 @@ impl SenderBalanceCheck {
 impl Check for SenderBalanceCheck {
     async fn check(
         &self,
-        _: &tap_core::receipt::Context,
-        receipt: &ReceiptWithState<Checking>,
+        ctx: &tap_core::receipt::Context,
+        _: &ReceiptWithState<Checking>,
     ) -> CheckResult {
         let escrow_accounts_snapshot = self.escrow_accounts.borrow();
 
-        let receipt_signer = receipt
-            .signed_receipt()
-            .recover_signer(&self.domain_separator)
-            .inspect_err(|e| {
-                error!("Failed to recover receipt signer: {}", e);
-            })
-            .map_err(|e| CheckError::Failed(e.into()))?;
-
-        // We bail if the receipt signer does not have a corresponding sender in the escrow
-        // accounts.
-        let receipt_sender = escrow_accounts_snapshot
-            .get_sender_for_signer(&receipt_signer)
-            .map_err(|e| CheckError::Failed(e.into()))?;
+        let Sender(receipt_sender) = ctx
+            .get::<Sender>()
+            .ok_or(CheckError::Failed(anyhow::anyhow!("Could not find sender")))?;
 
         // Check that the sender has a non-zero balance -- more advanced accounting is done in
         // `tap-agent`.
         if !escrow_accounts_snapshot
-            .get_balance_for_sender(&receipt_sender)
+            .get_balance_for_sender(receipt_sender)
             .map_or(false, |balance| balance > U256::ZERO)
         {
             return Err(CheckError::Failed(anyhow!(
                 "Receipt sender `{}` does not have a sufficient balance",
-                receipt_signer,
+                receipt_sender,
             )));
         }
         Ok(())


### PR DESCRIPTION
We shouldn't waste computation on things that we already have.