### PR TITLE
fix: add receipts timeout config

### DIFF
--- a/crates/config/default_values.toml
+++ b/crates/config/default_values.toml
@@ -19,9 +19,11 @@ max_receipt_value_grt = "0.001" # We use strings to prevent rounding errors
 
 [tap]
 max_amount_willing_to_lose_grt = 20
+sender_timeout_secs = 30
 
 [tap.rav_request]
 trigger_value_divisor = 10
 timestamp_buffer_secs = 60
 request_timeout_secs = 5
 max_receipts_per_request = 10000
+

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -124,6 +124,9 @@ max_receipt_value_grt = "0.001" # 0.001 GRT. We use strings to prevent rounding 
 # max_amount_willing_to_lose_grt = "0.1"
 max_amount_willing_to_lose_grt = 20
 
+# Receipts query timeout
+sender_timeout_secs = 30
+
 [tap.rav_request]
 # Trigger value is the amount used to trigger a rav request
 # The dividor is used to define the trigger value of a RAV request using
@@ -148,3 +151,4 @@ max_receipts_per_request = 10000
 
 [dips]
 allowed_payers = ["0x3333333333333333333333333333333333333333"]
+

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -373,12 +373,16 @@ pub struct ServiceTapConfig {
     pub max_receipt_value_grt: NonZeroGRT,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct TapConfig {
     /// what is the maximum amount the indexer is willing to lose in grt
     pub max_amount_willing_to_lose_grt: NonZeroGRT,
     pub rav_request: RavRequestConfig,
+
+    #[serde_as(as = "DurationSecondsWithFrac<f64>")]
+    pub sender_timeout_secs: Duration,
 
     pub sender_aggregator_endpoints: HashMap<Address, Url>,
 }
@@ -578,7 +582,7 @@ mod tests {
             key1 = "${TEST_VAR1}"
             key2 = "${TEST_VAR-default}"
             key3 = "{{TEST_VAR3}}"
-            
+
             [section2]
             key4 = "prefix_${TEST_VAR1}_${TEST_VAR-default}_suffix"
             key5 = "a_key_without_substitution"
@@ -590,7 +594,7 @@ mod tests {
             key1 = "changed_value_1"
             key2 = "${TEST_VAR-default}"
             key3 = "{{TEST_VAR3}}"
-            
+
             [section2]
             key4 = "prefix_changed_value_1_${TEST_VAR-default}_suffix"
             key5 = "a_key_without_substitution"

--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -190,6 +190,7 @@ pub struct SenderAccountConfig {
     pub rav_request_receipt_limit: u64,
     pub indexer_address: Address,
     pub escrow_polling_interval: Duration,
+    pub tap_sender_timeout: Duration,
 }
 
 impl SenderAccountConfig {
@@ -202,6 +203,7 @@ impl SenderAccountConfig {
             max_amount_willing_to_lose_grt: config.tap.max_amount_willing_to_lose_grt.get_value(),
             trigger_value: config.tap.get_trigger_value(),
             rav_request_timeout: config.tap.rav_request.request_timeout_secs,
+            tap_sender_timeout: config.tap.sender_timeout_secs,
         }
     }
 }
@@ -1147,6 +1149,7 @@ pub mod tests {
             rav_request_receipt_limit,
             indexer_address: INDEXER.1,
             escrow_polling_interval: Duration::default(),
+            tap_sender_timeout: Duration::default(),
         }));
 
         let network_subgraph = Box::leak(Box::new(
@@ -2058,3 +2061,4 @@ pub mod tests {
         sender_account.stop_and_wait(None, None).await.unwrap();
     }
 }
+

--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -1149,7 +1149,7 @@ pub mod tests {
             rav_request_receipt_limit,
             indexer_address: INDEXER.1,
             escrow_polling_interval: Duration::default(),
-            tap_sender_timeout: Duration::default(),
+            tap_sender_timeout: Duration::from_secs(30),
         }));
 
         let network_subgraph = Box::leak(Box::new(
@@ -2061,4 +2061,3 @@ pub mod tests {
         sender_account.stop_and_wait(None, None).await.unwrap();
     }
 }
-

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -643,6 +643,7 @@ mod tests {
             rav_request_receipt_limit: 1000,
             indexer_address: INDEXER.1,
             escrow_polling_interval: Duration::default(),
+            tap_sender_timeout: Duration::default(),
         }))
     }
 
@@ -968,3 +969,4 @@ mod tests {
         join_handle.await.unwrap();
     }
 }
+

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -142,7 +142,7 @@ impl Actor for SenderAccountsManager {
         };
         let sender_allocation = select! {
             sender_allocation = state.get_pending_sender_allocation_id() => sender_allocation,
-            _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+            _ = tokio::time::sleep(state.config.tap_sender_timeout) => {
                 panic!("Timeout while getting pending sender allocation ids");
             }
         };
@@ -252,7 +252,7 @@ impl Actor for SenderAccountsManager {
 
                 let mut sender_allocation = select! {
                     sender_allocation = state.get_pending_sender_allocation_id() => sender_allocation,
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    _ = tokio::time::sleep(state.config.tap_sender_timeout) => {
                         tracing::error!("Timeout while getting pending sender allocation ids");
                         return Ok(());
                     }
@@ -643,7 +643,7 @@ mod tests {
             rav_request_receipt_limit: 1000,
             indexer_address: INDEXER.1,
             escrow_polling_interval: Duration::default(),
-            tap_sender_timeout: Duration::default(),
+            tap_sender_timeout: Duration::from_secs(30),
         }))
     }
 
@@ -969,4 +969,3 @@ mod tests {
         join_handle.await.unwrap();
     }
 }
-


### PR DESCRIPTION
This PR fixes this issue https://github.com/graphprotocol/indexer-rs/issues/532

I've tested the image by building it and pushing to docker hub.

This screenshot is without the config (failing):
![Screenshot 2024-12-11 at 11 28 44](https://github.com/user-attachments/assets/2ccb9a6b-935d-4a6a-ae99-c98ef9a41334)

This screenshot is with the config (success):
```
[tap]
sender_timeout_secs = 120
```
![Screenshot 2024-12-11 at 11 36 39](https://github.com/user-attachments/assets/291c2c1f-ac52-498e-9531-ff6e47684d66)

