### PR TITLE
chore(deps): enable the right thegraph-graphql-http feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3772,12 +3772,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
-
-[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6831,22 +6825,17 @@ dependencies = [
  "alloy-signer",
  "alloy-sol-types",
  "bs58",
- "indoc",
- "reqwest 0.12.9",
  "serde",
- "serde_json",
  "serde_with",
- "thegraph-graphql-http",
  "thiserror 1.0.69",
- "tracing",
  "url",
 ]
 
 [[package]]
 name = "thegraph-graphql-http"
-version = "0.2.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3b675ae2fd6e213fa1b428ba44009b309338b6e9b7e6205a674ccecd5d67d4"
+checksum = "80bff1bad9a7c3b210876b5601460cab05d8fa6e8f52481472427ed18bc33975"
 dependencies = [
  "async-trait",
  "reqwest 0.12.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [workspace]
 members = [
-  "crates/allocation",
-  "crates/attestation",
-  "crates/config",
-  "crates/dips",
-  "crates/monitor",
-  "crates/query",
-  "crates/service",
-  "crates/tap-agent",
-  "crates/test-assets",
-  "crates/watcher",
+    "crates/allocation",
+    "crates/attestation",
+    "crates/config",
+    "crates/dips",
+    "crates/monitor",
+    "crates/query",
+    "crates/service",
+    "crates/tap-agent",
+    "crates/test-assets",
+    "crates/watcher",
 ]
 resolver = "2"
 
@@ -18,21 +18,21 @@ opt-level = 3
 
 [workspace.dependencies]
 alloy = { version = "=0.5.4", features = [
-  "kzg",
-  "signer-mnemonic",
-  "dyn-abi",
-  "sol-types",
-  "signer-local",
-  "eip712",
-  "rlp",
-  "signers",
+    "kzg",
+    "signer-mnemonic",
+    "dyn-abi",
+    "sol-types",
+    "signer-local",
+    "eip712",
+    "rlp",
+    "signers",
 ], default-features = false }
 clap = "4.4.3"
 lazy_static = "1.4.0"
 axum = { version = "0.7.9", default-features = false, features = [
-  "tokio",
-  "http1",
-  "http2",
+    "tokio",
+    "http1",
+    "http2",
 ] }
 tokio = "1.40"
 prometheus = "0.13.3"
@@ -42,21 +42,21 @@ async-trait = "0.1.72"
 eventuals = "0.6.7"
 base64 = "0.22.1"
 reqwest = { version = "0.12", features = [
-  "charset",
-  "h2",
+    "charset",
+    "h2",
 ], default-features = false }
 serde = { version = "1.0.206", default-features = false }
 serde_json = "1.0.124"
 sqlx = { version = "0.8.2", features = [
-  "bigdecimal",
-  "chrono",
-  "json",
-  "macros",
-  "migrate",
-  "postgres",
-  "runtime-tokio",
-  "rust_decimal",
-  "uuid",
+    "bigdecimal",
+    "chrono",
+    "json",
+    "macros",
+    "migrate",
+    "postgres",
+    "runtime-tokio",
+    "rust_decimal",
+    "uuid",
 ], default-features = false }
 uuid = { version = "1.11.0", features = ["v7"] }
 tracing = { version = "0.1.40", default-features = false }
@@ -65,14 +65,12 @@ build-info = "0.0.39"
 tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", rev = "61b47b3", default-features = false }
 tap_aggregator = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", rev = "61b47b3", default-features = false }
 tracing-subscriber = { version = "0.3", features = [
-  "json",
-  "env-filter",
-  "ansi",
+    "json",
+    "env-filter",
+    "ansi",
 ], default-features = false }
-thegraph-core = { git = "https://github.com/edgeandnode/toolshed", rev = "1663534fc1738e2db1b11cb54b5bb478ee970d40", features = [
-  "subgraph-client",
-] }
-thegraph-graphql-http = "0.2.0"
+thegraph-core = { git = "https://github.com/edgeandnode/toolshed", rev = "1663534fc1738e2db1b11cb54b5bb478ee970d40" }
+thegraph-graphql-http = { version = "0.3.2", features = ["reqwest"] }
 graphql_client = { version = "0.14.0", features = ["reqwest-rustls"] }
 bip39 = "2.0.0"
 rstest = "0.23.0"


### PR DESCRIPTION
This pull request includes updates to dependencies in the `Cargo.toml` file. The most significant changes involve updating versions and modifying feature sets for specific dependencies.

Dependency updates:

* Updated `thegraph-graphql-http` to version `0.3.2` and added the `reqwest` feature.
* Removed the `subgraph-client` feature from `thegraph-core`.