### PR TITLE
fix: invalid serialization of CheckHealthError

### DIFF
--- a/crates/service/src/routes/health.rs
+++ b/crates/service/src/routes/health.rs
@@ -36,7 +36,7 @@ impl IntoResponse for CheckHealthError {
             CheckHealthError::RequestFailed => StatusCode::BAD_GATEWAY,
         };
         let body = serde_json::json!({
-            "error": self.to_string(),
+            "errors": [self.to_string()],
         });
         (status, Json(body)).into_response()
     }

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -98,7 +98,7 @@ curl http://localhost:7600/subgraphs/health/QmacQnSgia4iDPWHpeY6aWxesRFdb8o5DKZU
 
 ```json
 {
-    "error": "Deployment not found"
+    "errors": ["Deployment not found"]
 }
 ```
 


### PR DESCRIPTION
This fixes a response payload previously using an `error` field, which is invalid for GraphQL over HTTP.