### PR TITLE
fix: retain headers in attestation middleware

### DIFF
--- a/crates/service/src/middleware/attestation.rs
+++ b/crates/service/src/middleware/attestation.rs
@@ -66,7 +66,9 @@ pub async fn attestation_middleware(
         attestation,
     })?;
 
-    Ok(Response::new(response.into()))
+    let mut response = Response::new(response.into());
+    *response.headers_mut() = parts.headers;
+    Ok(response)
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
The indexer-service has not been properly forwarding the `graph-indexed` header because the attestation middleware discarded all headers set by the handler.