### PR TITLE
refactor: aggregate ravs depending on allocation type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7031,7 +7031,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tap_aggregator"
 version = "0.4.1"
-source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=e5546a6#e5546a617ec2efcdbf09c465848b609856bef96c"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=9fd4beb#9fd4beb4a8c55114a4e33b851b86d80b71d42a00"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7060,7 +7060,7 @@ dependencies = [
 [[package]]
 name = "tap_core"
 version = "3.0.1"
-source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=e5546a6#e5546a617ec2efcdbf09c465848b609856bef96c"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=9fd4beb#9fd4beb4a8c55114a4e33b851b86d80b71d42a00"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7077,7 +7077,7 @@ dependencies = [
 [[package]]
 name = "tap_eip712_message"
 version = "0.1.0"
-source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=e5546a6#e5546a617ec2efcdbf09c465848b609856bef96c"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=9fd4beb#9fd4beb4a8c55114a4e33b851b86d80b71d42a00"
 dependencies = [
  "alloy",
  "serde",
@@ -7087,7 +7087,7 @@ dependencies = [
 [[package]]
 name = "tap_graph"
 version = "0.2.0"
-source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=e5546a6#e5546a617ec2efcdbf09c465848b609856bef96c"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=9fd4beb#9fd4beb4a8c55114a4e33b851b86d80b71d42a00"
 dependencies = [
  "alloy",
  "rand",
@@ -7100,7 +7100,7 @@ dependencies = [
 [[package]]
 name = "tap_receipt"
 version = "0.1.0"
-source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=e5546a6#e5546a617ec2efcdbf09c465848b609856bef96c"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=9fd4beb#9fd4beb4a8c55114a4e33b851b86d80b71d42a00"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3843,7 +3843,6 @@ dependencies = [
  "reqwest 0.12.9",
  "rstest 0.24.0",
  "ruint",
- "sealed",
  "serde",
  "serde_json",
  "sqlx",
@@ -6172,17 +6171,6 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "sealed"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
 
 [[package]]
 name = "sealed_test"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3843,6 +3843,7 @@ dependencies = [
  "reqwest 0.12.9",
  "rstest 0.24.0",
  "ruint",
+ "sealed",
  "serde",
  "serde_json",
  "sqlx",
@@ -6171,6 +6172,17 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "sealed_test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,12 +85,12 @@ tonic-build = "0.12.3"
 
 [patch.crates-io.tap_core]
 git = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
-rev = "e5546a6"
+rev = "9fd4beb"
 
 [patch.crates-io.tap_aggregator]
 git = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
-rev = "e5546a6"
+rev = "9fd4beb"
 
 [patch.crates-io.tap_graph]
 git = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
-rev = "e5546a6"
+rev = "9fd4beb"

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -51,7 +51,6 @@ tap_aggregator.workspace = true
 futures = { version = "0.3.30", default-features = false }
 bon = "3.3"
 test-assets = { path = "../test-assets", optional = true }
-sealed = "0.6.0"
 
 [dev-dependencies]
 # Release-please breaks with cyclical dependencies if dev-dependencies

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -39,7 +39,6 @@ tracing-subscriber.workspace = true
 tonic.workspace = true
 bigdecimal = { workspace = true, features = ["serde"] }
 graphql_client.workspace = true
-
 ruint = { version = "1.12.3", features = [
     "num-traits",
 ], default-features = false }
@@ -52,6 +51,7 @@ tap_aggregator.workspace = true
 futures = { version = "0.3.30", default-features = false }
 bon = "3.3"
 test-assets = { path = "../test-assets", optional = true }
+sealed = "0.6.0"
 
 [dev-dependencies]
 # Release-please breaks with cyclical dependencies if dev-dependencies

--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -221,17 +221,17 @@ impl State {
             %allocation_id,
             "SenderAccount is creating allocation."
         );
-        let args = SenderAllocationArgs {
-            pgpool: self.pgpool.clone(),
-            allocation_id,
-            sender: self.sender,
-            escrow_accounts: self.escrow_accounts.clone(),
-            escrow_subgraph: self.escrow_subgraph,
-            domain_separator: self.domain_separator.clone(),
-            sender_account_ref: sender_account_ref.clone(),
-            sender_aggregator: self.sender_aggregator.clone(),
-            config: AllocationConfig::from_sender_config(self.config),
-        };
+        let args = SenderAllocationArgs::builder()
+            .pgpool(self.pgpool.clone())
+            .allocation_id(allocation_id)
+            .sender(self.sender)
+            .escrow_accounts(self.escrow_accounts.clone())
+            .escrow_subgraph(self.escrow_subgraph)
+            .domain_separator(self.domain_separator.clone())
+            .sender_account_ref(sender_account_ref.clone())
+            .sender_aggregator(self.sender_aggregator.clone())
+            .config(AllocationConfig::from_sender_config(self.config))
+            .build();
 
         SenderAllocation::spawn_linked(
             Some(self.format_sender_allocation(&allocation_id)),

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -128,6 +128,7 @@ impl Actor for SenderAccountsManager {
             allocation_id
                 .keys()
                 .cloned()
+                // TODO map based on the allocation type returned by the subgraph
                 .map(AllocationId::Legacy)
                 .collect::<HashSet<_>>()
         });

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -39,7 +39,7 @@ use crate::{
     tap::{
         context::{
             checks::{AllocationId, Signature},
-            ReceiptType, TapAgentContext,
+            NetworkVersion, TapAgentContext,
         },
         signers_trimmed, TapReceipt,
     },
@@ -97,13 +97,13 @@ type TapManager<T> = tap_core::manager::Manager<TapAgentContext<T>, TapReceipt>;
 
 /// Manages unaggregated fees and the TAP lifecyle for a specific (allocation, sender) pair.
 pub struct SenderAllocation<T>(PhantomData<T>);
-impl<T: ReceiptType> Default for SenderAllocation<T> {
+impl<T: NetworkVersion> Default for SenderAllocation<T> {
     fn default() -> Self {
         Self(PhantomData)
     }
 }
 
-pub struct SenderAllocationState<T: ReceiptType> {
+pub struct SenderAllocationState<T: NetworkVersion> {
     unaggregated_fees: UnaggregatedReceipts,
     invalid_receipts_fees: UnaggregatedReceipts,
     latest_rav: Option<Eip712SignedMessage<T::Rav>>,
@@ -140,7 +140,7 @@ impl AllocationConfig {
 }
 
 #[derive(bon::Builder)]
-pub struct SenderAllocationArgs<T: ReceiptType> {
+pub struct SenderAllocationArgs<T: NetworkVersion> {
     pub pgpool: PgPool,
     pub allocation_id: Address,
     pub sender: Address,
@@ -165,7 +165,7 @@ pub enum SenderAllocationMessage {
 #[async_trait::async_trait]
 impl<T> Actor for SenderAllocation<T>
 where
-    T: ReceiptType,
+    T: NetworkVersion,
     for<'a> &'a Eip712SignedMessage<T::Rav>: Into<RavInformation>,
     TapAgentContext<T>:
         RavRead<T::Rav> + RavStore<T::Rav> + ReceiptDelete + ReceiptRead<TapReceipt>,
@@ -351,7 +351,7 @@ where
 
 impl<T> SenderAllocationState<T>
 where
-    T: ReceiptType,
+    T: NetworkVersion,
     TapAgentContext<T>:
         RavRead<T::Rav> + RavStore<T::Rav> + ReceiptDelete + ReceiptRead<TapReceipt>,
 {

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -7,8 +7,9 @@ use indexer_monitor::EscrowAccounts;
 use indexer_receipt::TapReceipt;
 use serde::Serialize;
 use sqlx::PgPool;
-use tap_aggregator::grpc::v1::RavRequest as AggregatorRequestV1;
-use tap_aggregator::grpc::v2::RavRequest as AggregatorRequestV2;
+use tap_aggregator::grpc::{
+    v1::RavRequest as AggregatorRequestV1, v2::RavRequest as AggregatorRequestV2,
+};
 use tap_core::{
     receipt::{rav::Aggregate, WithValueAndTimestamp},
     signed_message::Eip712SignedMessage,

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -1,11 +1,19 @@
 // Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::marker::PhantomData;
+use std::{future::Future, marker::PhantomData};
 
 use indexer_monitor::EscrowAccounts;
+use indexer_receipt::TapReceipt;
+use serde::Serialize;
 use sqlx::PgPool;
-use thegraph_core::alloy::primitives::Address;
+use tap_aggregator::grpc::v1::RavRequest as AggregatorRequestV1;
+use tap_aggregator::grpc::v2::RavRequest as AggregatorRequestV2;
+use tap_core::{
+    receipt::{rav::Aggregate, WithValueAndTimestamp},
+    signed_message::Eip712SignedMessage,
+};
+use thegraph_core::alloy::{primitives::Address, sol_types::SolStruct};
 use tokio::sync::watch::Receiver;
 
 pub mod checks;
@@ -15,18 +23,102 @@ mod rav;
 mod receipt;
 
 pub use error::AdapterError;
+use tonic::{transport::Channel, Code, Status};
 
 #[sealed::sealed]
-pub trait ReceiptType {}
+pub trait ReceiptType: Send + Sync + 'static {
+    //type Receipt;
+    type Rav: SolStruct
+        + Aggregate<TapReceipt>
+        + Serialize
+        + Send
+        + Sync
+        + WithValueAndTimestamp
+        + Clone
+        + std::fmt::Debug
+        + PartialEq;
+
+    type AggregatorClient: Send + Sync;
+
+    fn aggregate(
+        _client: &mut Self::AggregatorClient,
+        _valid_receipts: Vec<TapReceipt>,
+        _previous_rav: Option<Eip712SignedMessage<Self::Rav>>,
+    ) -> impl Future<Output = anyhow::Result<Eip712SignedMessage<Self::Rav>>> + Send;
+}
 
 pub enum Legacy {}
 pub enum Horizon {}
 
 #[sealed::sealed]
-impl ReceiptType for Legacy {}
+impl ReceiptType for Legacy {
+    //type Receipt = tap_graph::Receipt;
+    type Rav = tap_graph::ReceiptAggregateVoucher;
+    type AggregatorClient =
+        tap_aggregator::grpc::v1::tap_aggregator_client::TapAggregatorClient<Channel>;
+
+    async fn aggregate(
+        client: &mut Self::AggregatorClient,
+        valid_receipts: Vec<TapReceipt>,
+        previous_rav: Option<Eip712SignedMessage<Self::Rav>>,
+    ) -> anyhow::Result<Eip712SignedMessage<Self::Rav>> {
+        let valid_receipts: Vec<_> = valid_receipts
+            .into_iter()
+            .map(|r| r.as_v1().ok_or(anyhow::anyhow!("Receipt is not legacy")))
+            .collect::<Result<_, _>>()?;
+        let rav_request = AggregatorRequestV1::new(valid_receipts, previous_rav);
+
+        let response =
+            client
+                .aggregate_receipts(rav_request)
+                .await
+                .inspect_err(|status: &Status| {
+                    if status.code() == Code::DeadlineExceeded {
+                        tracing::warn!(
+                            "Rav request is timing out, maybe request_timeout_secs is too \
+                                low in your config file, try adding more secs to the value. \
+                                If the problem persists after doing so please open an issue"
+                        );
+                    }
+                })?;
+        response.into_inner().signed_rav()
+    }
+}
 
 #[sealed::sealed]
-impl ReceiptType for Horizon {}
+impl ReceiptType for Horizon {
+    //type Receipt = tap_graph::v2::Receipt;
+    type Rav = tap_graph::v2::ReceiptAggregateVoucher;
+    type AggregatorClient =
+        tap_aggregator::grpc::v2::tap_aggregator_client::TapAggregatorClient<Channel>;
+
+    async fn aggregate(
+        client: &mut Self::AggregatorClient,
+        valid_receipts: Vec<TapReceipt>,
+        previous_rav: Option<Eip712SignedMessage<Self::Rav>>,
+    ) -> anyhow::Result<Eip712SignedMessage<Self::Rav>> {
+        let valid_receipts: Vec<_> = valid_receipts
+            .into_iter()
+            .map(|r| r.as_v2().ok_or(anyhow::anyhow!("Receipt is not legacy")))
+            .collect::<Result<_, _>>()?;
+        let rav_request = AggregatorRequestV2::new(valid_receipts, previous_rav);
+
+        let response =
+            client
+                .aggregate_receipts(rav_request)
+                .await
+                .inspect_err(|status: &Status| {
+                    if status.code() == Code::DeadlineExceeded {
+                        tracing::warn!(
+                            "Rav request is timing out, maybe request_timeout_secs is too \
+                                low in your config file, try adding more secs to the value. \
+                                If the problem persists after doing so please open an issue"
+                        );
+                    }
+                })?;
+        response.into_inner().signed_rav()
+    }
+}
 
 #[derive(Clone)]
 pub struct TapAgentContext<T> {

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -1,6 +1,8 @@
 // Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::marker::PhantomData;
+
 use indexer_monitor::EscrowAccounts;
 use sqlx::PgPool;
 use thegraph_core::alloy::primitives::Address;
@@ -14,15 +16,28 @@ mod receipt;
 
 pub use error::AdapterError;
 
+#[sealed::sealed]
+pub trait ReceiptType {}
+
+pub enum Legacy {}
+pub enum Horizon {}
+
+#[sealed::sealed]
+impl ReceiptType for Legacy {}
+
+#[sealed::sealed]
+impl ReceiptType for Horizon {}
+
 #[derive(Clone)]
-pub struct TapAgentContext {
+pub struct TapAgentContext<T> {
     pgpool: PgPool,
     allocation_id: Address,
     sender: Address,
     escrow_accounts: Receiver<EscrowAccounts>,
+    _phantom: PhantomData<T>,
 }
 
-impl TapAgentContext {
+impl<T: ReceiptType> TapAgentContext<T> {
     pub fn new(
         pgpool: PgPool,
         allocation_id: Address,
@@ -34,6 +49,7 @@ impl TapAgentContext {
             allocation_id,
             sender,
             escrow_accounts,
+            _phantom: PhantomData,
         }
     }
 }

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -26,8 +26,12 @@ mod receipt;
 pub use error::AdapterError;
 use tonic::{transport::Channel, Code, Status};
 
-#[sealed::sealed]
-pub trait NetworkVersion: Send + Sync + 'static {
+// https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
+mod private {
+    pub trait Sealed {}
+}
+
+pub trait NetworkVersion: Send + Sync + 'static + private::Sealed {
     type Rav: SolStruct
         + Aggregate<TapReceipt>
         + Serialize
@@ -50,7 +54,9 @@ pub trait NetworkVersion: Send + Sync + 'static {
 pub enum Legacy {}
 pub enum Horizon {}
 
-#[sealed::sealed]
+impl private::Sealed for Legacy {}
+impl private::Sealed for Horizon {}
+
 impl NetworkVersion for Legacy {
     type Rav = tap_graph::ReceiptAggregateVoucher;
     type AggregatorClient =
@@ -84,7 +90,6 @@ impl NetworkVersion for Legacy {
     }
 }
 
-#[sealed::sealed]
 impl NetworkVersion for Horizon {
     type Rav = tap_graph::v2::ReceiptAggregateVoucher;
     type AggregatorClient =

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -28,7 +28,6 @@ use tonic::{transport::Channel, Code, Status};
 
 #[sealed::sealed]
 pub trait NetworkVersion: Send + Sync + 'static {
-    //type Receipt;
     type Rav: SolStruct
         + Aggregate<TapReceipt>
         + Serialize
@@ -53,7 +52,6 @@ pub enum Horizon {}
 
 #[sealed::sealed]
 impl NetworkVersion for Legacy {
-    //type Receipt = tap_graph::Receipt;
     type Rav = tap_graph::ReceiptAggregateVoucher;
     type AggregatorClient =
         tap_aggregator::grpc::v1::tap_aggregator_client::TapAggregatorClient<Channel>;
@@ -88,7 +86,6 @@ impl NetworkVersion for Legacy {
 
 #[sealed::sealed]
 impl NetworkVersion for Horizon {
-    //type Receipt = tap_graph::v2::Receipt;
     type Rav = tap_graph::v2::ReceiptAggregateVoucher;
     type AggregatorClient =
         tap_aggregator::grpc::v2::tap_aggregator_client::TapAggregatorClient<Channel>;

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -58,20 +58,20 @@ pub trait NetworkVersion: Send + Sync + 'static {
 
 /// 0-sized marker for legacy network
 ///
-/// By using an enum with no variants, we prevent any instanciation
+/// By using an enum with no variants, we prevent any instantiation
 /// of the network. It also has zero size at runtime and is used only
 /// as a compile-time marker
 ///
-/// A simple `struct Legacy;` would be able to instanciate and pass as
+/// A simple `struct Legacy;` would be able to instantiate and pass as
 /// value, while having size 1.
 pub enum Legacy {}
 /// 0-sized marker for horizon network
 ///
-/// By using an enum with no variants, we prevent any instanciation
+/// By using an enum with no variants, we prevent any instantiation
 /// of the network. It also has zero size at runtime and is used only
 /// as a compile-time marker
 ///
-/// A simple `struct Legacy;` would be able to instanciate and pass as
+/// A simple `struct Legacy;` would be able to instantiate and pass as
 /// value, while having size 1.
 pub enum Horizon {}
 

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -27,7 +27,7 @@ pub use error::AdapterError;
 use tonic::{transport::Channel, Code, Status};
 
 #[sealed::sealed]
-pub trait ReceiptType: Send + Sync + 'static {
+pub trait NetworkVersion: Send + Sync + 'static {
     //type Receipt;
     type Rav: SolStruct
         + Aggregate<TapReceipt>
@@ -52,7 +52,7 @@ pub enum Legacy {}
 pub enum Horizon {}
 
 #[sealed::sealed]
-impl ReceiptType for Legacy {
+impl NetworkVersion for Legacy {
     //type Receipt = tap_graph::Receipt;
     type Rav = tap_graph::ReceiptAggregateVoucher;
     type AggregatorClient =
@@ -87,7 +87,7 @@ impl ReceiptType for Legacy {
 }
 
 #[sealed::sealed]
-impl ReceiptType for Horizon {
+impl NetworkVersion for Horizon {
     //type Receipt = tap_graph::v2::Receipt;
     type Rav = tap_graph::v2::ReceiptAggregateVoucher;
     type AggregatorClient =
@@ -130,7 +130,7 @@ pub struct TapAgentContext<T> {
     _phantom: PhantomData<T>,
 }
 
-impl<T: ReceiptType> TapAgentContext<T> {
+impl<T: NetworkVersion> TapAgentContext<T> {
     pub fn new(
         pgpool: PgPool,
         allocation_id: Address,

--- a/crates/tap-agent/src/tap/context/escrow.rs
+++ b/crates/tap-agent/src/tap/context/escrow.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use tap_core::manager::adapters::SignatureChecker;
 use thegraph_core::alloy::primitives::Address;
 
-use super::{error::AdapterError, TapAgentContext};
+use super::{error::AdapterError, ReceiptType, TapAgentContext};
 
 // Conversion from eventuals::error::Closed to AdapterError::EscrowEventualError
 impl From<eventuals::error::Closed> for AdapterError {
@@ -22,7 +22,7 @@ impl From<eventuals::error::Closed> for AdapterError {
 // In any case, we don't want to fail a receipt because of this.
 // The receipt is fine, just the escrow account that is not.
 #[async_trait]
-impl SignatureChecker for TapAgentContext {
+impl<T: ReceiptType + Send + Sync> SignatureChecker for TapAgentContext<T> {
     type AdapterError = AdapterError;
 
     async fn verify_signer(&self, signer: Address) -> Result<bool, Self::AdapterError> {

--- a/crates/tap-agent/src/tap/context/escrow.rs
+++ b/crates/tap-agent/src/tap/context/escrow.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use tap_core::manager::adapters::SignatureChecker;
 use thegraph_core::alloy::primitives::Address;
 
-use super::{error::AdapterError, ReceiptType, TapAgentContext};
+use super::{error::AdapterError, NetworkVersion, TapAgentContext};
 
 // Conversion from eventuals::error::Closed to AdapterError::EscrowEventualError
 impl From<eventuals::error::Closed> for AdapterError {
@@ -22,7 +22,7 @@ impl From<eventuals::error::Closed> for AdapterError {
 // In any case, we don't want to fail a receipt because of this.
 // The receipt is fine, just the escrow account that is not.
 #[async_trait]
-impl<T: ReceiptType + Send + Sync> SignatureChecker for TapAgentContext<T> {
+impl<T: NetworkVersion + Send + Sync> SignatureChecker for TapAgentContext<T> {
     type AdapterError = AdapterError;
 
     async fn verify_signer(&self, signer: Address) -> Result<bool, Self::AdapterError> {

--- a/crates/tap-agent/src/tap/context/escrow.rs
+++ b/crates/tap-agent/src/tap/context/escrow.rs
@@ -16,11 +16,7 @@ impl From<eventuals::error::Closed> for AdapterError {
     }
 }
 
-// we don't need these checks anymore because there are being done before triggering
-// a rav request.
-//
-// In any case, we don't want to fail a receipt because of this.
-// The receipt is fine, just the escrow account that is not.
+/// Implements the SignatureChecker for any [NetworkVersion]
 #[async_trait]
 impl<T: NetworkVersion + Send + Sync> SignatureChecker for TapAgentContext<T> {
     type AdapterError = AdapterError;

--- a/crates/tap-agent/src/tap/context/rav.rs
+++ b/crates/tap-agent/src/tap/context/rav.rs
@@ -14,10 +14,10 @@ use tap_graph::{ReceiptAggregateVoucher, SignedRav};
 use thegraph_core::alloy::signers::Signature;
 use thegraph_core::alloy::{hex::ToHexExt, primitives::Address};
 
-use super::{error::AdapterError, TapAgentContext};
+use super::{error::AdapterError, Horizon, Legacy, TapAgentContext};
 
 #[async_trait::async_trait]
-impl RavRead<ReceiptAggregateVoucher> for TapAgentContext {
+impl RavRead<ReceiptAggregateVoucher> for TapAgentContext<Legacy> {
     type AdapterError = AdapterError;
 
     async fn last_rav(&self) -> Result<Option<SignedRav>, Self::AdapterError> {
@@ -87,7 +87,7 @@ impl RavRead<ReceiptAggregateVoucher> for TapAgentContext {
 }
 
 #[async_trait::async_trait]
-impl RavStore<ReceiptAggregateVoucher> for TapAgentContext {
+impl RavStore<ReceiptAggregateVoucher> for TapAgentContext<Legacy> {
     type AdapterError = AdapterError;
 
     async fn update_last_rav(&self, rav: SignedRav) -> Result<(), Self::AdapterError> {
@@ -126,6 +126,27 @@ impl RavStore<ReceiptAggregateVoucher> for TapAgentContext {
             error: e.to_string(),
         })?;
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl RavRead<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon> {
+    type AdapterError = AdapterError;
+
+    async fn last_rav(&self) -> Result<Option<tap_graph::v2::SignedRav>, Self::AdapterError> {
+        unimplemented!()
+    }
+}
+
+#[async_trait::async_trait]
+impl RavStore<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon> {
+    type AdapterError = AdapterError;
+
+    async fn update_last_rav(
+        &self,
+        _rav: tap_graph::v2::SignedRav,
+    ) -> Result<(), Self::AdapterError> {
+        unimplemented!()
     }
 }
 

--- a/crates/tap-agent/src/tap/context/rav.rs
+++ b/crates/tap-agent/src/tap/context/rav.rs
@@ -16,6 +16,11 @@ use thegraph_core::alloy::{hex::ToHexExt, primitives::Address};
 
 use super::{error::AdapterError, Horizon, Legacy, TapAgentContext};
 
+/// Implements a [RavRead] for [tap_graph::ReceiptAggregateVoucher]
+/// in case [super::NetworkVersion] is [Legacy]
+///
+/// This is important because RAVs for each network version
+/// are stored in a different database table
 #[async_trait::async_trait]
 impl RavRead<ReceiptAggregateVoucher> for TapAgentContext<Legacy> {
     type AdapterError = AdapterError;
@@ -86,6 +91,11 @@ impl RavRead<ReceiptAggregateVoucher> for TapAgentContext<Legacy> {
     }
 }
 
+/// Implements a [RavStore] for [tap_graph::ReceiptAggregateVoucher]
+/// in case [super::NetworkVersion] is [Legacy]
+///
+/// This is important because RAVs for each network version
+/// are stored in a different database table
 #[async_trait::async_trait]
 impl RavStore<ReceiptAggregateVoucher> for TapAgentContext<Legacy> {
     type AdapterError = AdapterError;
@@ -129,6 +139,11 @@ impl RavStore<ReceiptAggregateVoucher> for TapAgentContext<Legacy> {
     }
 }
 
+/// Implements a [RavRead] for [tap_graph::v2::ReceiptAggregateVoucher]
+/// in case [super::NetworkVersion] is [Horizon]
+///
+/// This is important because RAVs for each network version
+/// are stored in a different database table
 #[async_trait::async_trait]
 impl RavRead<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon> {
     type AdapterError = AdapterError;
@@ -138,6 +153,11 @@ impl RavRead<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon
     }
 }
 
+/// Implements a [RavStore] for [tap_graph::v2::ReceiptAggregateVoucher]
+/// in case [super::NetworkVersion] is [Horizon]
+///
+/// This is important because RAVs for each network version
+/// are stored in a different database table
 #[async_trait::async_trait]
 impl RavStore<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon> {
     type AdapterError = AdapterError;

--- a/crates/tap-agent/src/tap/context/receipt.rs
+++ b/crates/tap-agent/src/tap/context/receipt.rs
@@ -70,7 +70,7 @@ fn rangebounds_to_pgrange<R: RangeBounds<u64>>(range: R) -> PgRange<BigDecimal> 
 }
 
 #[async_trait::async_trait]
-impl ReceiptRead<TapReceipt> for TapAgentContext<Legacy> {
+impl<T: Send + Sync> ReceiptRead<TapReceipt> for TapAgentContext<T> {
     type AdapterError = AdapterError;
 
     async fn retrieve_receipts_in_timestamp_range<R: RangeBounds<u64> + Send>(
@@ -244,8 +244,12 @@ mod test {
         ))
         .1;
 
-        let storage_adapter =
-            TapAgentContext::new(pgpool, ALLOCATION_ID_0, SENDER.1, escrow_accounts.clone());
+        let storage_adapter = TapAgentContext::<Legacy>::new(
+            pgpool,
+            ALLOCATION_ID_0,
+            SENDER.1,
+            escrow_accounts.clone(),
+        );
 
         let received_receipt =
             create_received_receipt(&ALLOCATION_ID_0, &SIGNER.0, u64::MAX, u64::MAX, u128::MAX);
@@ -459,7 +463,7 @@ mod test {
         ))
         .1;
 
-        let storage_adapter = TapAgentContext::new(
+        let storage_adapter = TapAgentContext::<Legacy>::new(
             pgpool.clone(),
             ALLOCATION_ID_0,
             SENDER.1,
@@ -527,7 +531,7 @@ mod test {
         ))
         .1;
 
-        let storage_adapter = TapAgentContext::new(
+        let storage_adapter = TapAgentContext::<Legacy>::new(
             pgpool.clone(),
             ALLOCATION_ID_0,
             SENDER.1,

--- a/crates/tap-agent/src/tap/context/receipt.rs
+++ b/crates/tap-agent/src/tap/context/receipt.rs
@@ -70,7 +70,7 @@ fn rangebounds_to_pgrange<R: RangeBounds<u64>>(range: R) -> PgRange<BigDecimal> 
 }
 
 #[async_trait::async_trait]
-impl<T: Send + Sync> ReceiptRead<TapReceipt> for TapAgentContext<T> {
+impl ReceiptRead<TapReceipt> for TapAgentContext<Legacy> {
     type AdapterError = AdapterError;
 
     async fn retrieve_receipts_in_timestamp_range<R: RangeBounds<u64> + Send>(
@@ -184,6 +184,19 @@ impl ReceiptDelete for TapAgentContext<Legacy> {
         .execute(&self.pgpool)
         .await?;
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
+    type AdapterError = AdapterError;
+
+    async fn retrieve_receipts_in_timestamp_range<R: RangeBounds<u64> + Send>(
+        &self,
+        _timestamp_range_ns: R,
+        _receipts_limit: Option<u64>,
+    ) -> Result<Vec<CheckingReceipt>, Self::AdapterError> {
+        unimplemented!()
     }
 }
 

--- a/crates/tap-agent/src/tap/context/receipt.rs
+++ b/crates/tap-agent/src/tap/context/receipt.rs
@@ -69,6 +69,11 @@ fn rangebounds_to_pgrange<R: RangeBounds<u64>>(range: R) -> PgRange<BigDecimal> 
     ))
 }
 
+/// Implements a [ReceiptRead] for [TapReceipt]
+/// in case [super::NetworkVersion] is [Legacy]
+///
+/// This is important because receipts for each network version
+/// are stored in a different database table
 #[async_trait::async_trait]
 impl ReceiptRead<TapReceipt> for TapAgentContext<Legacy> {
     type AdapterError = AdapterError;
@@ -157,6 +162,11 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Legacy> {
     }
 }
 
+/// Implements a [ReceiptDelete] for [TapReceipt]
+/// in case [super::NetworkVersion] is [Legacy]
+///
+/// This is important because receipts for each network version
+/// are stored in a different database table
 #[async_trait::async_trait]
 impl ReceiptDelete for TapAgentContext<Legacy> {
     type AdapterError = AdapterError;
@@ -187,6 +197,11 @@ impl ReceiptDelete for TapAgentContext<Legacy> {
     }
 }
 
+/// Implements a [ReceiptRead] for [TapReceipt]
+/// in case [super::NetworkVersion] is [Horizon]
+///
+/// This is important because receipts for each network version
+/// are stored in a different database table
 #[async_trait::async_trait]
 impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
     type AdapterError = AdapterError;
@@ -200,6 +215,11 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
     }
 }
 
+/// Implements a [ReceiptDelete] for [TapReceipt]
+/// in case [super::NetworkVersion] is [Horizon]
+///
+/// This is important because receipts for each network version
+/// are stored in a different database table
 #[async_trait::async_trait]
 impl ReceiptDelete for TapAgentContext<Horizon> {
     type AdapterError = AdapterError;

--- a/crates/tap-agent/src/test.rs
+++ b/crates/tap-agent/src/test.rs
@@ -41,7 +41,8 @@ use crate::{
             SenderAccount, SenderAccountArgs, SenderAccountConfig, SenderAccountMessage,
         },
         sender_accounts_manager::{
-            SenderAccountsManager, SenderAccountsManagerArgs, SenderAccountsManagerMessage,
+            AllocationId, SenderAccountsManager, SenderAccountsManagerArgs,
+            SenderAccountsManagerMessage,
         },
     },
     tap::{context::AdapterError, CheckingReceipt},
@@ -86,7 +87,7 @@ pub fn get_sender_account_config() -> &'static SenderAccountConfig {
 #[bon::builder]
 pub async fn create_sender_account(
     pgpool: PgPool,
-    #[builder(default = HashSet::new())] initial_allocation: HashSet<Address>,
+    #[builder(default = HashSet::new())] initial_allocation: HashSet<AllocationId>,
     #[builder(default = TRIGGER_VALUE)] rav_request_trigger_value: u128,
     #[builder(default = TRIGGER_VALUE)] max_amount_willing_to_lose_grt: u128,
     escrow_subgraph_endpoint: Option<&str>,

--- a/crates/tap-agent/src/test.rs
+++ b/crates/tap-agent/src/test.rs
@@ -730,7 +730,7 @@ pub mod actors {
                                     last_id: 0,
                                     counter: 0,
                                 },
-                                Ok(Some(signed_rav)),
+                                Ok(Some(signed_rav.into())),
                             )),
                         ))?;
                     }

--- a/crates/tap-agent/tests/sender_account_manager_test.rs
+++ b/crates/tap-agent/tests/sender_account_manager_test.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use indexer_tap_agent::{
     agent::{
         sender_account::SenderAccountMessage,
-        sender_accounts_manager::SenderAccountsManagerMessage,
+        sender_accounts_manager::{AllocationId, SenderAccountsManagerMessage},
         sender_allocation::SenderAllocationMessage,
     },
     test::{
@@ -88,7 +88,9 @@ async fn sender_account_manager_layer_test(pgpool: PgPool) {
         .clone()
         .unwrap()
         .cast(SenderAccountMessage::UpdateAllocationIds(
-            vec![ALLOCATION_ID_0].into_iter().collect(),
+            vec![AllocationId::Legacy(ALLOCATION_ID_0)]
+                .into_iter()
+                .collect(),
         ))
         .unwrap();
     flush_messages(&notify).await;

--- a/crates/tap-agent/tests/sender_account_test.rs
+++ b/crates/tap-agent/tests/sender_account_test.rs
@@ -4,7 +4,7 @@
 use std::collections::HashSet;
 
 use indexer_tap_agent::{
-    agent::sender_account::SenderAccountMessage,
+    agent::{sender_account::SenderAccountMessage, sender_accounts_manager::AllocationId},
     test::{create_received_receipt, create_sender_account, store_receipt},
 };
 use ractor::concurrency::Duration;
@@ -50,7 +50,9 @@ async fn sender_account_layer_test(pgpool: PgPool) {
     // we expect it to create a sender allocation
     sender_account
         .cast(SenderAccountMessage::UpdateAllocationIds(
-            vec![ALLOCATION_ID_0].into_iter().collect(),
+            vec![AllocationId::Legacy(ALLOCATION_ID_0)]
+                .into_iter()
+                .collect(),
         ))
         .unwrap();
     notify.notified().await;


### PR DESCRIPTION
- Create `NetworkVersion` trait used to define what kind of allocation we are handling.
- Add Generic for TapContext over NetworkVersion.
- Add Legacy and Horizon that implement `NetworkVersion`
- Wrap allocation Id address with new `AllocationId` enum.
- Create TapManager version depending on the allocation id variant.
- Implement aggregation within NetworkVersion trait.
- Add aggregator_v2 connection for SenderAccount.

TODO for future PRs:
- Implement all unimplemented traits for database queries.
- Test more extensively different types of allocations running.

### Note
tap-agent is not well organized and we have a few files with 1k+ lines. Suggestions on how to organize are accepted.