### PR TITLE
fix: check allocation id blocked before sending rav req

### DIFF
--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -775,7 +775,11 @@ impl Actor for SenderAccount {
                             "Total fee greater than the trigger value. Triggering RAV request"
                         );
                         state.rav_request_for_heaviest_allocation().await
-                    } else if counter_greater_receipt_limit {
+                    } else if counter_greater_receipt_limit
+                        && !state
+                            .sender_fee_tracker
+                            .is_allocation_id_blocked(&allocation_id)
+                    {
                         tracing::debug!(
                             total_counter_for_allocation,
                             rav_request_receipt_limit = state.config.rav_request_receipt_limit,

--- a/crates/tap-agent/src/tracker/generic_tracker.rs
+++ b/crates/tap-agent/src/tracker/generic_tracker.rs
@@ -214,6 +214,13 @@ where
         });
     }
 
+    pub fn is_allocation_id_blocked(&self, address: &Address) -> bool {
+        self.id_to_fee
+            .get(address)
+            .map(|v| v.blocked)
+            .expect("Allocation ID not found")
+    }
+
     pub fn can_trigger_rav(&self, allocation_id: Address) -> bool {
         self.id_to_fee
             .get(&allocation_id)


### PR DESCRIPTION
Fixes #598