### PR TITLE
refactor: implement receipt traits for horizon

### DIFF
--- a/.sqlx/query-10bd83671f30f7bc2096e9158be60023577bbbdbab7a83788204d066bdd9fec5.json
+++ b/.sqlx/query-10bd83671f30f7bc2096e9158be60023577bbbdbab7a83788204d066bdd9fec5.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                DELETE FROM tap_horizon_receipts\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "10bd83671f30f7bc2096e9158be60023577bbbdbab7a83788204d066bdd9fec5"
+}

--- a/.sqlx/query-5f0c42c9a92a446d37b2971175df6ed0cd31da6b57918a2d600ef90adce1345d.json
+++ b/.sqlx/query-5f0c42c9a92a446d37b2971175df6ed0cd31da6b57918a2d600ef90adce1345d.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT count(*)\n                FROM tap_horizon_receipts\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "5f0c42c9a92a446d37b2971175df6ed0cd31da6b57918a2d600ef90adce1345d"
+}

--- a/.sqlx/query-6ce2133a20924d5098fa2e27f897e871955e9eb8a0a6f8b9f23a3f38597793f6.json
+++ b/.sqlx/query-6ce2133a20924d5098fa2e27f897e871955e9eb8a0a6f8b9f23a3f38597793f6.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT \n                    signature,\n                    allocation_id,\n                    payer,\n                    data_service,\n                    service_provider,\n                    timestamp_ns,\n                    nonce,\n                    value\n                FROM tap_horizon_receipts\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "signature",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 1,
+        "name": "allocation_id",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "payer",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "data_service",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "service_provider",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "timestamp_ns",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 6,
+        "name": "nonce",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 7,
+        "name": "value",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "6ce2133a20924d5098fa2e27f897e871955e9eb8a0a6f8b9f23a3f38597793f6"
+}

--- a/.sqlx/query-8b904cecdd8e9c5dd0cd8a0dbc2e8a19c2197f08d576e5cbf978e39432bb3d5a.json
+++ b/.sqlx/query-8b904cecdd8e9c5dd0cd8a0dbc2e8a19c2197f08d576e5cbf978e39432bb3d5a.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO tap_horizon_receipts (\n                signer_address,\n                signature,\n                allocation_id,\n                payer,\n                data_service,\n                service_provider,\n                timestamp_ns,\n                nonce,\n                value\n            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n            RETURNING id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar",
+        "Bytea",
+        "Bpchar",
+        "Bpchar",
+        "Bpchar",
+        "Bpchar",
+        "Numeric",
+        "Numeric",
+        "Numeric"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8b904cecdd8e9c5dd0cd8a0dbc2e8a19c2197f08d576e5cbf978e39432bb3d5a"
+}

--- a/.sqlx/query-b94514ce9abc8be15ba3b5a67f33ead0d83e409210ce5e711932bcb32888f2bf.json
+++ b/.sqlx/query-b94514ce9abc8be15ba3b5a67f33ead0d83e409210ce5e711932bcb32888f2bf.json
@@ -1,0 +1,75 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT \n                    id,\n                    signature,\n                    allocation_id,\n                    payer,\n                    data_service,\n                    service_provider,\n                    timestamp_ns,\n                    nonce,\n                    value\n                FROM tap_horizon_receipts\n                WHERE\n                    allocation_id = $1\n                    AND payer = $2\n                    AND service_provider = $3\n                    AND signer_address IN (SELECT unnest($4::text[]))\n                AND $5::numrange @> timestamp_ns\n                ORDER BY timestamp_ns ASC\n                LIMIT $6\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "signature",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 2,
+        "name": "allocation_id",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "payer",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "data_service",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "service_provider",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "timestamp_ns",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 7,
+        "name": "nonce",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 8,
+        "name": "value",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar",
+        "Bpchar",
+        "Bpchar",
+        "TextArray",
+        "NumRange",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b94514ce9abc8be15ba3b5a67f33ead0d83e409210ce5e711932bcb32888f2bf"
+}

--- a/.sqlx/query-cd279b9b74e3efdb79ece086b1e6713d2fc766e6553568df8c6ab1d39a5282f6.json
+++ b/.sqlx/query-cd279b9b74e3efdb79ece086b1e6713d2fc766e6553568df8c6ab1d39a5282f6.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                DELETE FROM tap_horizon_receipts\n                WHERE\n                    allocation_id = $1\n                    AND signer_address IN (SELECT unnest($2::text[]))\n                    AND $3::numrange @> timestamp_ns\n                    AND payer = $4\n                    AND service_provider = $5\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bpchar",
+        "TextArray",
+        "NumRange",
+        "Bpchar",
+        "Bpchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cd279b9b74e3efdb79ece086b1e6713d2fc766e6553568df8c6ab1d39a5282f6"
+}

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -466,6 +466,7 @@ where
         let context = TapAgentContext::new(
             pgpool.clone(),
             allocation_id,
+            config.indexer_address,
             sender,
             escrow_accounts.clone(),
         );

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -155,6 +155,7 @@ pub struct TapAgentContext<T> {
     pgpool: PgPool,
     allocation_id: Address,
     sender: Address,
+    indexer_address: Address,
     escrow_accounts: Receiver<EscrowAccounts>,
     /// We use phantom data as a marker since it's
     /// only used to define what methods are available
@@ -168,12 +169,14 @@ impl<T: NetworkVersion> TapAgentContext<T> {
     pub fn new(
         pgpool: PgPool,
         allocation_id: Address,
+        indexer_address: Address,
         sender: Address,
         escrow_accounts: Receiver<EscrowAccounts>,
     ) -> Self {
         Self {
             pgpool,
             allocation_id,
+            indexer_address,
             sender,
             escrow_accounts,
             _phantom: PhantomData,

--- a/crates/tap-agent/src/tap/context/rav.rs
+++ b/crates/tap-agent/src/tap/context/rav.rs
@@ -178,7 +178,7 @@ mod test {
     use tokio::sync::watch;
 
     use super::*;
-    use crate::test::{create_rav, ALLOCATION_ID_0};
+    use crate::test::{create_rav, ALLOCATION_ID_0, INDEXER};
 
     #[derive(Debug)]
     struct TestableRav(SignedRav);
@@ -199,6 +199,7 @@ mod test {
         let context = TapAgentContext::new(
             pool.clone(),
             ALLOCATION_ID_0,
+            INDEXER.1,
             SENDER.1,
             watch::channel(EscrowAccounts::default()).1,
         );

--- a/crates/tap-agent/src/test.rs
+++ b/crates/tap-agent/src/test.rs
@@ -263,7 +263,11 @@ pub fn create_rav(
     .unwrap()
 }
 
+/// Generic implementation of create_received_receipt
 pub trait CreateReceipt {
+    /// This might seem weird at first glance since [Horizon] and [Legacy] implementation have the same
+    /// function signature and don't require &self. The reason is that we can not match over T to get
+    /// all variants because T is a trait and not an enum.
     fn create_received_receipt(
         allocation_id: Address,
         signer_wallet: &PrivateKeySigner,


### PR DESCRIPTION
- Simply filling the gaps that was missing with unimplemented!()
- Using rstest to provide different fixtures with different contexts to the same test