### PR TITLE
feat: add escape hatch to trusted senders

### DIFF
--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -124,6 +124,11 @@ max_receipt_value_grt = "0.001" # 0.001 GRT. We use strings to prevent rounding 
 # max_amount_willing_to_lose_grt = "0.1"
 max_amount_willing_to_lose_grt = 20
 
+# List of Senders that are allowed to spend up to `max_amount_willing_to_lose_grt`
+# over the escrow balance
+trusted_senders = ["0xdeadbeefcafebabedeadbeefcafebabedeadbeef"]
+
+
 # Receipts query timeout
 sender_timeout_secs = 30
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     path::PathBuf,
@@ -382,6 +382,11 @@ pub struct TapConfig {
     pub sender_timeout_secs: Duration,
 
     pub sender_aggregator_endpoints: HashMap<Address, Url>,
+
+    /// Senders that are allowed to spend up to `max_amount_willing_to_lose_grt`
+    /// over the escrow balance
+    #[serde(default)]
+    pub trusted_senders: HashSet<Address>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -431,11 +436,11 @@ pub struct RavRequestConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, fs, path::PathBuf, str::FromStr};
+    use std::{collections::HashSet, env, fs, path::PathBuf, str::FromStr};
 
     use figment::value::Uncased;
     use sealed_test::prelude::*;
-    use thegraph_core::alloy::primitives::{Address, FixedBytes};
+    use thegraph_core::alloy::primitives::{address, Address, FixedBytes};
     use tracing_test::traced_test;
 
     use super::{DatabaseConfig, SHARED_PREFIX};
@@ -458,6 +463,8 @@ mod tests {
             Some(PathBuf::from("minimal-config-example.toml")).as_ref(),
         )
         .unwrap();
+        max_config.tap.trusted_senders =
+            HashSet::from([address!("deadbeefcafebabedeadbeefcafebabedeadbeef")]);
         max_config.dips = Some(crate::DipsConfig {
             allowed_payers: vec![Address(
                 FixedBytes::<20>::from_str("0x3333333333333333333333333333333333333333").unwrap(),

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -373,6 +373,7 @@ mod test {
         time::{Duration, SystemTime, UNIX_EPOCH},
     };
 
+    use rand::{distr::Alphanumeric, Rng};
     use thegraph_core::alloy::{
         primitives::{Address, FixedBytes, U256},
         signers::local::PrivateKeySigner,
@@ -386,8 +387,6 @@ mod test {
         price::PriceCalculator, CancellationRequest, DipsError, IndexingAgreementVoucher,
         SignedIndexingAgreementVoucher, SubgraphIndexingVoucherMetadata,
     };
-    use rand::distr::Alphanumeric;
-    use rand::Rng;
 
     #[tokio::test]
     async fn test_validate_and_create_agreement() -> anyhow::Result<()> {

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -4,8 +4,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use thegraph_core::alloy::primitives::Address;
-use thegraph_core::alloy::sol_types::Eip712Domain;
+use thegraph_core::alloy::{primitives::Address, sol_types::Eip712Domain};
 use tonic::{Request, Response, Status};
 
 use crate::{

--- a/crates/tap-agent/tests/tap_agent_test.rs
+++ b/crates/tap-agent/tests/tap_agent_test.rs
@@ -1,7 +1,12 @@
 // Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use indexer_monitor::{DeploymentDetails, EscrowAccounts, SubgraphClient};
 use indexer_tap_agent::{
@@ -87,6 +92,7 @@ pub async fn start_agent(
         indexer_address: INDEXER_ADDRESS,
         escrow_polling_interval: Duration::from_secs(10),
         tap_sender_timeout: Duration::from_secs(30),
+        trusted_senders: HashSet::new(),
     }));
 
     let args = SenderAccountsManagerArgs {


### PR DESCRIPTION
Add feature for configuration that allows some senders to spend up to `max_amount_willing_to_lose` over the balance.