### PR TITLE
refactor: use correct db tables in sender allocation

### DIFF
--- a/.sqlx/query-9a11e8e814e42113c91050acf54c2e847f24a2e086abcbe8e7be618f84d58f78.json
+++ b/.sqlx/query-9a11e8e814e42113c91050acf54c2e847f24a2e086abcbe8e7be618f84d58f78.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE tap_horizon_ravs\n                    SET last = true\n                WHERE \n                    allocation_id = $1\n                    AND payer = $2\n                    AND service_provider = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bpchar",
+        "Bpchar",
+        "Bpchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9a11e8e814e42113c91050acf54c2e847f24a2e086abcbe8e7be618f84d58f78"
+}

--- a/.sqlx/query-b467894d499541f2bca15965f38ee551ece8619860f3fbcb184ebded33898cbd.json
+++ b/.sqlx/query-b467894d499541f2bca15965f38ee551ece8619860f3fbcb184ebded33898cbd.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                MAX(id),\n                SUM(value),\n                COUNT(*)\n            FROM\n                tap_horizon_receipts_invalid\n            WHERE\n                allocation_id = $1\n                AND signer_address IN (SELECT unnest($2::text[]))\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "max",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "sum",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 2,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "b467894d499541f2bca15965f38ee551ece8619860f3fbcb184ebded33898cbd"
+}

--- a/.sqlx/query-f65b5a6c2149155d69fb1f187ebb4e24c08d5763d97da4e2ec759c30d6170a68.json
+++ b/.sqlx/query-f65b5a6c2149155d69fb1f187ebb4e24c08d5763d97da4e2ec759c30d6170a68.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO tap_horizon_receipts_invalid (\n                signer_address,\n                signature,\n                allocation_id,\n                payer,\n                data_service,\n                service_provider,\n                timestamp_ns,\n                nonce,\n                value,\n                error_log\n            ) SELECT * FROM UNNEST(\n                $1::CHAR(40)[],\n                $2::BYTEA[],\n                $3::CHAR(40)[],\n                $4::CHAR(40)[],\n                $5::CHAR(40)[],\n                $6::CHAR(40)[],\n                $7::NUMERIC(20)[],\n                $8::NUMERIC(20)[],\n                $9::NUMERIC(40)[],\n                $10::TEXT[]\n            )",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "BpcharArray",
+        "ByteaArray",
+        "BpcharArray",
+        "BpcharArray",
+        "BpcharArray",
+        "BpcharArray",
+        "NumericArray",
+        "NumericArray",
+        "NumericArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f65b5a6c2149155d69fb1f187ebb4e24c08d5763d97da4e2ec759c30d6170a68"
+}

--- a/.sqlx/query-fa31900971e23fdf98dd48fcd649e04328fb1e758a0b538319c5fb132251a7ed.json
+++ b/.sqlx/query-fa31900971e23fdf98dd48fcd649e04328fb1e758a0b538319c5fb132251a7ed.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                MAX(id),\n                SUM(value),\n                COUNT(*)\n            FROM\n                tap_horizon_receipts\n            WHERE\n                allocation_id = $1\n                AND service_provider = $2\n                AND id <= $3\n                AND signer_address IN (SELECT unnest($4::text[]))\n                AND timestamp_ns > $5\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "max",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "sum",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 2,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar",
+        "Bpchar",
+        "Int8",
+        "TextArray",
+        "Numeric"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "fa31900971e23fdf98dd48fcd649e04328fb1e758a0b538319c5fb132251a7ed"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,6 +3958,7 @@ dependencies = [
  "indexer-receipt",
  "indexer-tap-agent",
  "indexer-watcher",
+ "itertools 0.14.0",
  "jsonrpsee",
  "lazy_static",
  "prometheus",

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -52,6 +52,7 @@ futures = { version = "0.3.30", default-features = false }
 bon = "3.3"
 test-assets = { path = "../test-assets", optional = true }
 rand = { version = "0.8", optional = true }
+itertools = "0.14.0"
 
 [dev-dependencies]
 # Release-please breaks with cyclical dependencies if dev-dependencies

--- a/migrations/20250131122241_tap_horizon_receipts.down.sql
+++ b/migrations/20250131122241_tap_horizon_receipts.down.sql
@@ -1,2 +1,3 @@
 -- Add down migration script here
 DROP TABLE IF EXISTS tap_horizon_receipts CASCADE;
+DROP TABLE IF EXISTS tap_horizon_receipts_invalid CASCADE;

--- a/migrations/20250131122241_tap_horizon_receipts.up.sql
+++ b/migrations/20250131122241_tap_horizon_receipts.up.sql
@@ -16,3 +16,22 @@ CREATE TABLE IF NOT EXISTS tap_horizon_receipts (
 
 CREATE INDEX IF NOT EXISTS scalar_tap_receipts_allocation_id_idx ON scalar_tap_receipts (allocation_id);
 CREATE INDEX IF NOT EXISTS scalar_tap_receipts_timestamp_ns_idx ON scalar_tap_receipts (timestamp_ns);
+
+
+-- This table is used to store invalid receipts (receipts that fail at least one of the checks in the tap-agent).
+-- Used for logging and debugging purposes.
+CREATE TABLE IF NOT EXISTS tap_horizon_receipts_invalid (
+    id BIGSERIAL PRIMARY KEY, -- id being SERIAL is important for the function of tap-agent
+    signer_address CHAR(40) NOT NULL,
+
+    -- Values below are the individual fields of the EIP-712 receipt
+    signature BYTEA NOT NULL,
+    allocation_id CHAR(40) NOT NULL,
+    payer CHAR(40) NOT NULL,
+    data_service CHAR(40) NOT NULL,
+    service_provider CHAR(40) NOT NULL,
+    timestamp_ns NUMERIC(20) NOT NULL,
+    nonce NUMERIC(20) NOT NULL,
+    value NUMERIC(39) NOT NULL,
+    error_log TEXT NOT NULL DEFAULT ''
+);


### PR DESCRIPTION
Create a trait called `DatabaseInteractions`.

All calls to databases are delegated to trait like:
- mark_rav_last
- calculate_fee_until_last_id
- delete_receipts_between

store_invalid_receipts is implemented in two functions and we use `partition_map` to provide the correct Vector for each