### PR TITLE
refactor: update check escrow receipt check

### DIFF
--- a/.sqlx/query-f1d8dcf24c9677ef789469d37733f354c5d246db5bb1506839cd7b07cdcc7065.json
+++ b/.sqlx/query-f1d8dcf24c9677ef789469d37733f354c5d246db5bb1506839cd7b07cdcc7065.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT sender_address FROM tap_horizon_denylist\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "sender_address",
+        "type_info": "Bpchar"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "f1d8dcf24c9677ef789469d37733f354c5d246db5bb1506839cd7b07cdcc7065"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,6 +3890,7 @@ dependencies = [
  "base64 0.22.1",
  "bigdecimal",
  "bip39",
+ "bon 3.3.2",
  "build-info",
  "build-info-build",
  "clap",
@@ -3932,7 +3933,6 @@ dependencies = [
  "tower_governor",
  "tracing",
  "tracing-subscriber",
- "typed-builder",
  "uuid",
  "wiremock",
 ]
@@ -7449,13 +7449,13 @@ name = "test-assets"
 version = "0.1.0"
 dependencies = [
  "bip39",
+ "bon 3.3.2",
  "indexer-allocation",
  "lazy_static",
  "tap_core",
  "tap_graph",
  "thegraph-core",
  "tokio",
- "typed-builder",
 ]
 
 [[package]]
@@ -8086,26 +8086,6 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
-]
-
-[[package]]
-name = "typed-builder"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14ed59dc8b7b26cacb2a92bad2e8b1f098806063898ab42a3bd121d7d45e75"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560b82d656506509d43abe30e0ba64c56b1953ab3d4fe7ba5902747a7a3cedd5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ graphql_client = { version = "0.14.0", features = ["reqwest-rustls"] }
 bip39 = "2.0.0"
 rstest = "0.23.0"
 wiremock = "0.6.1"
-typed-builder = "0.20.0"
+bon = "3.3"
 tonic = { version = "0.12.3", features = ["tls-roots", "gzip"] }
 prost = "0.13.4"
 prost-types = "0.13.3"

--- a/crates/monitor/src/escrow_accounts.rs
+++ b/crates/monitor/src/escrow_accounts.rs
@@ -88,7 +88,7 @@ impl EscrowAccounts {
 
 pub type EscrowAccountsWatcher = Receiver<EscrowAccounts>;
 
-pub async fn escrow_accounts(
+pub async fn escrow_accounts_v1(
     escrow_subgraph: &'static SubgraphClient,
     indexer_address: Address,
     interval: Duration,
@@ -243,7 +243,7 @@ mod tests {
             );
         mock_server.register(mock).await;
 
-        let mut accounts = escrow_accounts(
+        let mut accounts = escrow_accounts_v1(
             escrow_subgraph,
             test_assets::INDEXER_ADDRESS,
             Duration::from_secs(60),

--- a/crates/monitor/src/lib.rs
+++ b/crates/monitor/src/lib.rs
@@ -15,7 +15,7 @@ pub use crate::{
     deployment_to_allocation::{deployment_to_allocation, DeploymentToAllocationWatcher},
     dispute_manager::{dispute_manager, DisputeManagerWatcher},
     escrow_accounts::{
-        escrow_accounts, escrow_accounts_v2, EscrowAccounts, EscrowAccountsError,
+        escrow_accounts_v1, escrow_accounts_v2, EscrowAccounts, EscrowAccountsError,
         EscrowAccountsWatcher,
     },
 };

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -40,7 +40,7 @@ graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3
 tap_core.workspace = true
 tap_graph.workspace = true
 uuid.workspace = true
-typed-builder.workspace = true
+bon.workspace = true
 tower_governor = { version = "0.5.0", features = ["axum"] }
 governor = "0.8.0"
 tower-http = { version = "0.6.2", features = [

--- a/crates/service/src/tap.rs
+++ b/crates/service/src/tap.rs
@@ -48,13 +48,17 @@ impl IndexerTapContext {
     pub async fn get_checks(
         pgpool: PgPool,
         indexer_allocations: Receiver<HashMap<Address, Allocation>>,
-        escrow_accounts: Receiver<EscrowAccounts>,
+        escrow_accounts_v1: Receiver<EscrowAccounts>,
+        escrow_accounts_v2: Receiver<EscrowAccounts>,
         timestamp_error_tolerance: Duration,
         receipt_max_value: u128,
     ) -> Vec<ReceiptCheck<TapReceipt>> {
         vec![
             Arc::new(AllocationEligible::new(indexer_allocations)),
-            Arc::new(SenderBalanceCheck::new(escrow_accounts)),
+            Arc::new(SenderBalanceCheck::new(
+                escrow_accounts_v1,
+                escrow_accounts_v2,
+            )),
             Arc::new(TimestampCheck::new(timestamp_error_tolerance)),
             Arc::new(DenyListCheck::new(pgpool.clone()).await),
             Arc::new(ReceiptMaxValueCheck::new(receipt_max_value)),

--- a/crates/service/src/tap/checks/sender_balance_check.rs
+++ b/crates/service/src/tap/checks/sender_balance_check.rs
@@ -13,30 +13,45 @@ use crate::{
 };
 
 pub struct SenderBalanceCheck {
-    escrow_accounts: Receiver<EscrowAccounts>,
+    escrow_accounts_v1: Receiver<EscrowAccounts>,
+    escrow_accounts_v2: Receiver<EscrowAccounts>,
 }
 
 impl SenderBalanceCheck {
-    pub fn new(escrow_accounts: Receiver<EscrowAccounts>) -> Self {
-        Self { escrow_accounts }
+    pub fn new(
+        escrow_accounts_v1: Receiver<EscrowAccounts>,
+        escrow_accounts_v2: Receiver<EscrowAccounts>,
+    ) -> Self {
+        Self {
+            escrow_accounts_v1,
+            escrow_accounts_v2,
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl Check<TapReceipt> for SenderBalanceCheck {
-    async fn check(&self, ctx: &tap_core::receipt::Context, _: &CheckingReceipt) -> CheckResult {
-        let escrow_accounts_snapshot = self.escrow_accounts.borrow();
+    async fn check(
+        &self,
+        ctx: &tap_core::receipt::Context,
+        receipt: &CheckingReceipt,
+    ) -> CheckResult {
+        let escrow_accounts_snapshot_v1 = self.escrow_accounts_v1.borrow();
+        let escrow_accounts_snapshot_v2 = self.escrow_accounts_v2.borrow();
 
         let Sender(receipt_sender) = ctx
             .get::<Sender>()
             .ok_or(CheckError::Failed(anyhow::anyhow!("Could not find sender")))?;
 
+        // get balance for escrow account given receipt type
+        let balance_result = match receipt.signed_receipt() {
+            TapReceipt::V1(_) => escrow_accounts_snapshot_v1.get_balance_for_sender(receipt_sender),
+            TapReceipt::V2(_) => escrow_accounts_snapshot_v2.get_balance_for_sender(receipt_sender),
+        };
+
         // Check that the sender has a non-zero balance -- more advanced accounting is done in
         // `tap-agent`.
-        if !escrow_accounts_snapshot
-            .get_balance_for_sender(receipt_sender)
-            .is_ok_and(|balance| balance > U256::ZERO)
-        {
+        if !balance_result.is_ok_and(|balance| balance > U256::ZERO) {
             return Err(CheckError::Failed(anyhow!(
                 "Receipt sender `{}` does not have a sufficient balance",
                 receipt_sender,

--- a/crates/service/tests/router_test.rs
+++ b/crates/service/tests/router_test.rs
@@ -90,7 +90,8 @@ async fn full_integration_test(database: PgPool) {
             receipts_verifier_address: test_assets::VERIFIER_ADDRESS,
         })
         .timestamp_buffer_secs(Duration::from_secs(10))
-        .escrow_accounts(escrow_accounts)
+        .escrow_accounts_v1(escrow_accounts.clone())
+        .escrow_accounts_v2(escrow_accounts)
         .dispute_manager(dispute_manager)
         .allocations(allocations)
         .build();

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -49,7 +49,7 @@ ractor = { version = "0.14", features = [
 ], default-features = false }
 tap_aggregator.workspace = true
 futures = { version = "0.3.30", default-features = false }
-bon = "3.3"
+bon.workspace = true
 test-assets = { path = "../test-assets", optional = true }
 rand = { version = "0.8", optional = true }
 itertools = "0.14.0"
@@ -64,5 +64,4 @@ wiremock.workspace = true
 wiremock-grpc = "0.0.3-alpha3"
 test-assets = { path = "../test-assets" }
 test-log = { version = "0.2.12", features = ["trace"] }
-bon = "3.3"
 rstest = "0.24.0"

--- a/crates/tap-agent/src/agent.rs
+++ b/crates/tap-agent/src/agent.rs
@@ -40,7 +40,7 @@ use indexer_config::{
     SubgraphConfig, SubgraphsConfig, TapConfig,
 };
 use indexer_monitor::{
-    escrow_accounts, escrow_accounts_v2, indexer_allocations, DeploymentDetails, SubgraphClient,
+    escrow_accounts_v1, escrow_accounts_v2, indexer_allocations, DeploymentDetails, SubgraphClient,
 };
 use ractor::{concurrency::JoinHandle, Actor, ActorRef};
 use sender_account::SenderAccountConfig;
@@ -156,7 +156,7 @@ pub async fn start_agent() -> (ActorRef<SenderAccountsManagerMessage>, JoinHandl
         .await,
     ));
 
-    let escrow_accounts_v1 = escrow_accounts(
+    let escrow_accounts_v1 = escrow_accounts_v1(
         escrow_subgraph,
         *indexer_address,
         *escrow_sync_interval,

--- a/crates/test-assets/Cargo.toml
+++ b/crates/test-assets/Cargo.toml
@@ -10,5 +10,5 @@ lazy_static.workspace = true
 tap_core.workspace = true
 tap_graph.workspace = true
 thegraph-core.workspace = true
-typed-builder.workspace = true
+bon.workspace = true
 tokio.workspace = true

--- a/crates/test-assets/src/lib.rs
+++ b/crates/test-assets/src/lib.rs
@@ -21,7 +21,6 @@ use thegraph_core::{
     deployment_id, DeploymentId,
 };
 use tokio::sync::Notify;
-use typed_builder::TypedBuilder;
 
 /// Assert something is true while sleeping and retrying
 ///
@@ -310,16 +309,16 @@ lazy_static! {
     );
 }
 
-#[derive(TypedBuilder)]
+#[derive(bon::Builder)]
 pub struct SignedReceiptRequest {
     #[builder(default = Address::ZERO)]
     allocation_id: Address,
     #[builder(default)]
     nonce: u64,
-    #[builder(default_code = r#"SystemTime::now()
+    #[builder(default = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_nanos() as u64"#)]
+            .as_nanos() as u64)]
     timestamp_ns: u64,
     #[builder(default = 1)]
     value: u128,

--- a/migrations/20250212211337_tap_horizon_sender_denylist.down.sql
+++ b/migrations/20250212211337_tap_horizon_sender_denylist.down.sql
@@ -1,2 +1,6 @@
 -- Add down migration script here
+DROP TRIGGER IF EXISTS deny_update ON tap_horizon_deny CASCADE;
+
+DROP FUNCTION IF EXISTS tap_horizon_deny_notify() CASCADE;
+
 DROP TABLE IF EXISTS tap_horizon_denylist CASCADE;

--- a/migrations/20250212211337_tap_horizon_sender_denylist.up.sql
+++ b/migrations/20250212211337_tap_horizon_sender_denylist.up.sql
@@ -2,3 +2,25 @@
 CREATE TABLE IF NOT EXISTS tap_horizon_denylist (
      sender_address CHAR(40) PRIMARY KEY
 );
+
+
+CREATE FUNCTION tap_horizon_deny_notify()
+RETURNS trigger AS
+$$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        PERFORM pg_notify('tap_horizon_deny_notification', format('{"tg_op": "DELETE", "sender_address": "%s"}', OLD.sender_address));
+        RETURN OLD;
+    ELSIF TG_OP = 'INSERT' THEN
+        PERFORM pg_notify('tap_horizon_deny_notification', format('{"tg_op": "INSERT", "sender_address": "%s"}', NEW.sender_address));
+        RETURN NEW;
+    ELSE -- UPDATE OR TRUNCATE, should never happen
+        PERFORM pg_notify('tap_horizon_deny_notification', format('{"tg_op": "%s", "sender_address": null}', TG_OP, NEW.sender_address));
+        RETURN NEW;
+    END IF;
+END;
+$$ LANGUAGE 'plpgsql';
+
+CREATE TRIGGER deny_update AFTER INSERT OR UPDATE OR DELETE
+    ON tap_horizon_denylist
+    FOR EACH ROW EXECUTE PROCEDURE tap_horizon_deny_notify();


### PR DESCRIPTION
- Add denylist pgnotify for horizon tables
- Update service test to listen to horizon tables
- Remove typed_builder in favor of bon
- Rename `indexer_monitor::escrow_accounts` to `indexer_monitor::escrow_accounts_v1`
- Update service router to receive v1 and v2 escrow account watchers
- Add router creation of escrow account v2 if not provided
- Update SenderBalanceCheck to route between v1 and v2 accordingly
- Update sender middleware to use the correct escrow_account monitor