### PR TITLE
test: add rstest and fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1046,34 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
 ]
 
 [[package]]
@@ -1105,6 +1166,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.3.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1243,12 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1675,6 +1799,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -2752,12 +2889,28 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -2987,6 +3140,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3114,6 +3280,18 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "governor"
@@ -3354,6 +3532,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -3898,6 +4082,7 @@ dependencies = [
  "indexer-query",
  "indexer-watcher",
  "reqwest 0.12.9",
+ "rstest 0.24.0",
  "serde",
  "serde_json",
  "test-assets",
@@ -3937,6 +4122,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-axum",
+ "async-std",
  "async-trait",
  "autometrics",
  "axum",
@@ -3999,6 +4185,7 @@ name = "indexer-tap-agent"
 version = "1.9.1"
 dependencies = [
  "anyhow",
+ "async-std",
  "async-trait",
  "axum",
  "bigdecimal",
@@ -4028,6 +4215,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "stdext",
  "tap_aggregator",
  "tap_core",
  "tap_graph",
@@ -4407,6 +4595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4526,6 +4723,9 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -4966,7 +5166,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -5343,6 +5543,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5368,6 +5579,21 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -7027,7 +7253,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener",
+ "event-listener 5.3.1",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
@@ -7226,6 +7452,12 @@ name = "static_assertions_next"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
+name = "stdext"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4af28eeb7c18ac2dbdb255d40bee63f203120e1db6b0024b177746ebec7049c1"
 
 [[package]]
 name = "stringprep"
@@ -7510,6 +7742,9 @@ dependencies = [
  "bon 3.3.2",
  "indexer-allocation",
  "lazy_static",
+ "rstest 0.24.0",
+ "sqlx",
+ "stdext",
  "tap_core",
  "tap_graph",
  "thegraph-core",
@@ -8329,6 +8564,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,39 +1003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,34 +1013,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -1166,63 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-io"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener 5.3.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,12 +1125,6 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1799,19 +1675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel 2.3.1",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -2889,28 +2752,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
-dependencies = [
- "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -3140,19 +2987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,18 +3114,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "governor"
@@ -3532,12 +3354,6 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -4122,7 +3938,6 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-axum",
- "async-std",
  "async-trait",
  "autometrics",
  "axum",
@@ -4185,7 +4000,6 @@ name = "indexer-tap-agent"
 version = "1.9.1"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "axum",
  "bigdecimal",
@@ -4595,15 +4409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4723,9 +4528,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru"
@@ -5166,7 +4968,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -5543,17 +5345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5579,21 +5370,6 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
-
-[[package]]
-name = "polling"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.4.0",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -7253,7 +7029,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.3.1",
+ "event-listener",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
@@ -8564,12 +8340,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "value-bag"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 
 [[package]]
 name = "vcpkg"

--- a/crates/monitor/Cargo.toml
+++ b/crates/monitor/Cargo.toml
@@ -25,4 +25,5 @@ env_logger = { version = "0.11.0", default-features = false }
 test-log = { version = "0.2.12", default-features = false }
 wiremock.workspace = true
 test-assets = { path = "../test-assets" }
+rstest = "0.24.0"
 test-with = "0.14.6"

--- a/crates/monitor/src/client/monitor.rs
+++ b/crates/monitor/src/client/monitor.rs
@@ -72,8 +72,14 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    async fn test_parses_synced_and_healthy_response() {
+    struct MonitorMock {
+        mock_server: MockServer,
+        status_url: Url,
+        deployment: DeploymentId,
+    }
+
+    #[rstest::fixture]
+    async fn monitor_mock() -> MonitorMock {
         let mock_server = MockServer::start().await;
         let status_url: Url = mock_server
             .uri()
@@ -82,7 +88,16 @@ mod tests {
             .join("/status")
             .unwrap();
         let deployment = deployment_id!("QmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        MonitorMock {
+            mock_server,
+            status_url,
+            deployment,
+        }
+    }
 
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn test_parses_synced_and_healthy_response(#[future(awt)] monitor_mock: MonitorMock) {
         Mock::given(method("POST"))
             .and(path("/status"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -95,10 +110,10 @@ mod tests {
                     ]
                 }
             })))
-            .mount(&mock_server)
+            .mount(&monitor_mock.mock_server)
             .await;
 
-        let status = monitor_deployment_status(deployment, status_url)
+        let status = monitor_deployment_status(monitor_mock.deployment, monitor_mock.status_url)
             .await
             .unwrap();
 
@@ -111,17 +126,9 @@ mod tests {
         );
     }
 
+    #[rstest::rstest]
     #[tokio::test]
-    async fn test_parses_not_synced_and_healthy_response() {
-        let mock_server = MockServer::start().await;
-        let status_url: Url = mock_server
-            .uri()
-            .parse::<Url>()
-            .unwrap()
-            .join("/status")
-            .unwrap();
-        let deployment = deployment_id!("QmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
+    async fn test_parses_not_synced_and_healthy_response(#[future(awt)] monitor_mock: MonitorMock) {
         Mock::given(method("POST"))
             .and(path("/status"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -134,10 +141,10 @@ mod tests {
                     ]
                 }
             })))
-            .mount(&mock_server)
+            .mount(&monitor_mock.mock_server)
             .await;
 
-        let status = monitor_deployment_status(deployment, status_url)
+        let status = monitor_deployment_status(monitor_mock.deployment, monitor_mock.status_url)
             .await
             .unwrap();
 
@@ -150,17 +157,9 @@ mod tests {
         );
     }
 
+    #[rstest::rstest]
     #[tokio::test]
-    async fn test_parses_synced_and_unhealthy_response() {
-        let mock_server = MockServer::start().await;
-        let status_url: Url = mock_server
-            .uri()
-            .parse::<Url>()
-            .unwrap()
-            .join("/status")
-            .unwrap();
-        let deployment = deployment_id!("QmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
+    async fn test_parses_synced_and_unhealthy_response(#[future(awt)] monitor_mock: MonitorMock) {
         Mock::given(method("POST"))
             .and(path("/status"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -173,10 +172,10 @@ mod tests {
                     ]
                 }
             })))
-            .mount(&mock_server)
+            .mount(&monitor_mock.mock_server)
             .await;
 
-        let status = monitor_deployment_status(deployment, status_url)
+        let status = monitor_deployment_status(monitor_mock.deployment, monitor_mock.status_url)
             .await
             .unwrap();
 
@@ -189,17 +188,9 @@ mod tests {
         );
     }
 
+    #[rstest::rstest]
     #[tokio::test]
-    async fn test_parses_synced_and_failed_response() {
-        let mock_server = MockServer::start().await;
-        let status_url: Url = mock_server
-            .uri()
-            .parse::<Url>()
-            .unwrap()
-            .join("/status")
-            .unwrap();
-        let deployment = deployment_id!("QmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
+    async fn test_parses_synced_and_failed_response(#[future(awt)] monitor_mock: MonitorMock) {
         Mock::given(method("POST"))
             .and(path("/status"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -212,10 +203,10 @@ mod tests {
                     ]
                 }
             })))
-            .mount(&mock_server)
+            .mount(&monitor_mock.mock_server)
             .await;
 
-        let status = monitor_deployment_status(deployment, status_url)
+        let status = monitor_deployment_status(monitor_mock.deployment, monitor_mock.status_url)
             .await
             .unwrap();
 

--- a/crates/monitor/src/client/monitor.rs
+++ b/crates/monitor/src/client/monitor.rs
@@ -124,7 +124,7 @@ mod tests {
         assert_eq!(
             status.borrow().clone(),
             DeploymentStatus {
-                synced: synced,
+                synced,
                 health: health.to_string()
             }
         );

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -74,7 +74,6 @@ tokio-test = "0.4.4"
 wiremock.workspace = true
 insta = "1.41.1"
 test-log.workspace = true
-async-std = { version = "1.12.0", features = ["attributes"] }
 
 [build-dependencies]
 build-info-build = { version = "0.0.40", default-features = false }

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -74,6 +74,7 @@ tokio-test = "0.4.4"
 wiremock.workspace = true
 insta = "1.41.1"
 test-log.workspace = true
+async-std = { version = "1.12.0", features = ["attributes"] }
 
 [build-dependencies]
 build-info-build = { version = "0.0.40", default-features = false }

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -66,3 +66,5 @@ wiremock-grpc = "0.0.3-alpha3"
 test-assets = { path = "../test-assets" }
 test-log.workspace = true
 rstest = "0.24.0"
+stdext = "0.3.3"
+async-std = { version = "1.12.0", features = ["attributes"] }

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -67,4 +67,3 @@ test-assets = { path = "../test-assets" }
 test-log.workspace = true
 rstest = "0.24.0"
 stdext = "0.3.3"
-async-std = { version = "1.12.0", features = ["attributes"] }

--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -1423,10 +1423,11 @@ pub mod tests {
     use serde_json::json;
     use sqlx::PgPool;
     use test_assets::{
-        flush_messages, ALLOCATION_ID_0, ALLOCATION_ID_1, TAP_SENDER as SENDER,
+        flush_messages, pgpool, ALLOCATION_ID_0, ALLOCATION_ID_1, TAP_SENDER as SENDER,
         TAP_SIGNER as SIGNER,
     };
     use thegraph_core::alloy::{hex::ToHexExt, primitives::U256};
+    use tokio::sync::mpsc;
     use wiremock::{
         matchers::{body_string_contains, method},
         Mock, MockServer, ResponseTemplate,
@@ -1466,6 +1467,22 @@ pub mod tests {
                 )
                 .await;
         mock_escrow_subgraph_server
+    }
+    struct TestSenderAccount {
+        sender_account: ActorRef<SenderAccountMessage>,
+        msg_receiver: mpsc::Receiver<SenderAccountMessage>,
+        prefix: String,
+    }
+
+    #[rstest::fixture]
+    async fn basic_sender_account(#[future(awt)] pgpool: PgPool) -> TestSenderAccount {
+        let (sender_account, msg_receiver, prefix, _) =
+            create_sender_account().pgpool(pgpool).call().await;
+        TestSenderAccount {
+            sender_account,
+            msg_receiver,
+            prefix,
+        }
     }
 
     #[rstest::rstest]
@@ -1688,20 +1705,22 @@ pub mod tests {
             .as_nanos() as u64
     }
 
-    #[sqlx::test(migrations = "../../migrations")]
-    async fn test_update_receipt_fees_no_rav(pgpool: PgPool) {
-        let (sender_account, _, prefix, _) = create_sender_account().pgpool(pgpool).call().await;
-
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn test_update_receipt_fees_no_rav(
+        #[future(awt)] basic_sender_account: TestSenderAccount,
+    ) {
         // create a fake sender allocation
         let (triggered_rav_request, _, _) = create_mock_sender_allocation(
-            prefix,
+            basic_sender_account.prefix,
             SENDER.1,
             ALLOCATION_ID_0,
-            sender_account.clone(),
+            basic_sender_account.sender_account.clone(),
         )
         .await;
 
-        sender_account
+        basic_sender_account
+            .sender_account
             .cast(SenderAccountMessage::UpdateReceiptFees(
                 ALLOCATION_ID_0,
                 ReceiptFees::NewReceipt(TRIGGER_VALUE - 1, get_current_timestamp_u64_ns()),
@@ -1714,40 +1733,42 @@ pub mod tests {
         assert_not_triggered!(&triggered_rav_request);
     }
 
-    #[sqlx::test(migrations = "../../migrations")]
-    async fn test_update_receipt_fees_trigger_rav(pgpool: PgPool) {
-        let (sender_account, mut msg_receiver, prefix, _) =
-            create_sender_account().pgpool(pgpool).call().await;
-
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn test_update_receipt_fees_trigger_rav(
+        #[future(awt)] mut basic_sender_account: TestSenderAccount,
+    ) {
         // create a fake sender allocation
         let (triggered_rav_request, _, _) = create_mock_sender_allocation(
-            prefix,
+            basic_sender_account.prefix,
             SENDER.1,
             ALLOCATION_ID_0,
-            sender_account.clone(),
+            basic_sender_account.sender_account.clone(),
         )
         .await;
 
-        sender_account
+        basic_sender_account
+            .sender_account
             .cast(SenderAccountMessage::UpdateReceiptFees(
                 ALLOCATION_ID_0,
                 ReceiptFees::NewReceipt(TRIGGER_VALUE, get_current_timestamp_u64_ns()),
             ))
             .unwrap();
 
-        flush_messages(&mut msg_receiver).await;
+        flush_messages(&mut basic_sender_account.msg_receiver).await;
         assert_not_triggered!(&triggered_rav_request);
 
         // wait for it to be outside buffer
         tokio::time::sleep(BUFFER_DURATION).await;
 
-        sender_account
+        basic_sender_account
+            .sender_account
             .cast(SenderAccountMessage::UpdateReceiptFees(
                 ALLOCATION_ID_0,
                 ReceiptFees::Retry,
             ))
             .unwrap();
-        flush_messages(&mut msg_receiver).await;
+        flush_messages(&mut basic_sender_account.msg_receiver).await;
 
         assert_triggered!(&triggered_rav_request);
     }
@@ -1837,8 +1858,9 @@ pub mod tests {
     }
 
     /// Test that the deny status is correctly loaded from the DB at the start of the actor
-    #[sqlx::test(migrations = "../../migrations")]
-    async fn test_init_deny(pgpool: PgPool) {
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn test_init_deny(#[future(awt)] pgpool: PgPool) {
         sqlx::query!(
             r#"
                 INSERT INTO scalar_tap_denylist (sender_address)

--- a/crates/test-assets/Cargo.toml
+++ b/crates/test-assets/Cargo.toml
@@ -11,4 +11,7 @@ tap_core.workspace = true
 tap_graph.workspace = true
 thegraph-core.workspace = true
 bon.workspace = true
+sqlx.workspace = true
 tokio.workspace = true
+rstest = "0.24.0"
+stdext = "0.3.3"


### PR DESCRIPTION
Added `rstest`:

- with this several tests have been refactored to only receive fixtures created on `rstest`


this PR aims to make the tests more easy reading and only focusing on the important bits per test

Due to the nature of async fixtures some tests could use them since the test itself needed to be in some order for it to work as intended.