### PR TITLE
chore(dips): add rpc and db feature flags to indexer-dips crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,7 +2683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3804,11 +3804,8 @@ dependencies = [
 name = "indexer-dips"
 version = "0.1.0"
 dependencies = [
- "alloy-rlp",
  "anyhow",
  "async-trait",
- "axum",
- "base64 0.22.1",
  "build-info",
  "bytes",
  "derivative",
@@ -3817,7 +3814,6 @@ dependencies = [
  "ipfs-api-backend-hyper",
  "ipfs-api-prelude",
  "prost",
- "prost-types",
  "rand 0.9.0",
  "serde",
  "serde_yaml",
@@ -5528,7 +5524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -5676,7 +5672,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.8",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7444,7 +7440,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8528,7 +8524,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/dips/Cargo.toml
+++ b/crates/dips/Cargo.toml
@@ -3,33 +3,33 @@ name = "indexer-dips"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-axum.workspace = true
-build-info.workspace = true
-thiserror.workspace = true
-anyhow.workspace = true
-alloy-rlp = "0.3.10"
-thegraph-core.workspace = true
-tonic.workspace = true 
-async-trait.workspace = true 
-prost.workspace = true 
-prost-types.workspace = true 
-uuid.workspace = true
-base64.workspace = true
-tokio.workspace = true
-sqlx.workspace = true
-futures = "0.3"
+[features]
+default = ["rpc", "db"]
+rpc = ["dep:prost", "dep:tonic", "dep:tonic-build", "dep:bytes"]
+db = ["dep:sqlx"]
 
-http = "0.2"
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+build-info.workspace = true
+bytes = { version = "1.10.0", optional = true }
 derivative = "2.2.0"
-ipfs-api-backend-hyper = {version = "0.6.0", features = ["with-send-sync"] }
-ipfs-api-prelude = {version = "0.6.0", features = ["with-send-sync"] }
-bytes = "1.10.0"
-serde_yaml.workspace = true
+futures = "0.3"
+http = "0.2"
+ipfs-api-backend-hyper = { version = "0.6.0", features = ["with-send-sync"] }
+ipfs-api-prelude = { version = "0.6.0", features = ["with-send-sync"] }
+prost = { workspace = true, optional = true }
 serde.workspace = true
+serde_yaml.workspace = true
+sqlx = { workspace = true, optional = true }
+thegraph-core.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tonic = { workspace = true, optional = true }
+uuid.workspace = true
 
 [dev-dependencies]
 rand = "0.9.0"
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-build = { workspace = true, optional = true }

--- a/crates/dips/build.rs
+++ b/crates/dips/build.rs
@@ -2,18 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() {
-    println!("cargo:rerun-if-changed=proto");
-    tonic_build::configure()
-        .out_dir("src/proto")
-        .include_file("indexer.rs")
-        .protoc_arg("--experimental_allow_proto3_optional")
-        .compile_protos(&["proto/indexer.proto"], &["proto/"])
-        .expect("Failed to compile DIPs indexer RPC proto(s)");
+    #[cfg(feature = "rpc")]
+    {
+        println!("cargo:rerun-if-changed=proto");
 
-    tonic_build::configure()
-        .out_dir("src/proto")
-        .include_file("gateway.rs")
-        .protoc_arg("--experimental_allow_proto3_optional")
-        .compile_protos(&["proto/gateway.proto"], &["proto"])
-        .expect("Failed to compile DIPs gateway RPC proto(s)");
+        tonic_build::configure()
+            .out_dir("src/proto")
+            .include_file("indexer.rs")
+            .protoc_arg("--experimental_allow_proto3_optional")
+            .compile_protos(&["proto/indexer.proto"], &["proto/"])
+            .expect("Failed to compile DIPs indexer RPC proto(s)");
+
+        tonic_build::configure()
+            .out_dir("src/proto")
+            .include_file("gateway.rs")
+            .protoc_arg("--experimental_allow_proto3_optional")
+            .compile_protos(&["proto/gateway.proto"], &["proto"])
+            .expect("Failed to compile DIPs gateway RPC proto(s)");
+    }
 }

--- a/crates/dips/src/database.rs
+++ b/crates/dips/src/database.rs
@@ -3,7 +3,7 @@
 
 use std::str::FromStr;
 
-use axum::async_trait;
+use async_trait::async_trait;
 use build_info::chrono::{DateTime, Utc};
 use sqlx::{types::BigDecimal, PgPool};
 use thegraph_core::alloy::{core::primitives::U256 as uint256, hex::ToHexExt, sol_types::SolType};

--- a/crates/dips/src/ipfs.rs
+++ b/crates/dips/src/ipfs.rs
@@ -3,12 +3,12 @@
 
 use std::{str::FromStr, sync::Arc};
 
+use async_trait::async_trait;
 use derivative::Derivative;
 use futures::TryStreamExt;
 use http::Uri;
 use ipfs_api_prelude::{IpfsApi, TryFromUri};
 use serde::Deserialize;
-use tonic::async_trait;
 
 use crate::DipsError;
 

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -13,10 +13,13 @@ use thegraph_core::alloy::{
     sol_types::{eip712_domain, Eip712Domain, SolStruct, SolValue},
 };
 
+#[cfg(feature = "db")]
 pub mod database;
 pub mod ipfs;
 pub mod price;
+#[cfg(feature = "rpc")]
 pub mod proto;
+#[cfg(feature = "rpc")]
 pub mod server;
 pub mod store;
 
@@ -165,6 +168,7 @@ pub enum DipsError {
 }
 
 // TODO: send back messages
+#[cfg(feature = "rpc")]
 impl From<DipsError> for tonic::Status {
     fn from(_val: DipsError) -> Self {
         tonic::Status::internal("unknown errr")


### PR DESCRIPTION
This pull request includes various changes to the `crates/dips` package to introduce feature flags and improve modularity. The key changes involve adding feature flags for optional dependencies, modifying the build script to conditionally compile based on features, and updating imports and module definitions accordingly.

### Feature Flags and Dependencies:
* Added feature flags `rpc` and `db` in `Cargo.toml` to conditionally include dependencies (`[crates/dips/Cargo.tomlR6-R35](diffhunk://#diff-271b41f6df2e65a887a3a18cd20536fb075df359339939c77d15843c117a070cR6-R35)`).
* Updated dependencies in `Cargo.toml` to be optional based on the feature flags (`[crates/dips/Cargo.tomlR6-R35](diffhunk://#diff-271b41f6df2e65a887a3a18cd20536fb075df359339939c77d15843c117a070cR6-R35)`).

### Build Script:
* Modified `build.rs` to conditionally compile proto files if the `rpc` feature is enabled (`[[1]](diffhunk://#diff-708ee7d06e2e6e35b9419c852e467adcc59e77d759acd12bcd6988aab627dba7R5-R8)`, `[[2]](diffhunk://#diff-708ee7d06e2e6e35b9419c852e467adcc59e77d759acd12bcd6988aab627dba7R23)`).

### Codebase Updates:
* Updated imports in `database.rs` and `ipfs.rs` to use `async_trait` from the `async_trait` crate instead of `axum` or `tonic` (`[[1]](diffhunk://#diff-c8af91422fb1ed010565eac4fda150897bfbdba657084c76787d871da0fd27faL6-R6)`, `[[2]](diffhunk://#diff-ca88c155ef694ceb70a734514fba168b1bd873c4efc481be50c7b8dab0b59aaaR6-L11)`).
* Conditionally included modules `database`, `proto`, and `server` in `lib.rs` based on feature flags (`[crates/dips/src/lib.rsR16-R22](diffhunk://#diff-43049e4db6e400dbf78fe60574626cb162e14dbb774b13f92bc9b05b68d08830R16-R22)`).
* Added a conditional implementation of `From<DipsError>` for `tonic::Status` if the `rpc` feature is enabled (`[crates/dips/src/lib.rsR171](diffhunk://#diff-43049e4db6e400dbf78fe60574626cb162e14dbb774b13f92bc9b05b68d08830R171)`).