### PR TITLE
refactor: use educe instead of manually implementing traits for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,6 +2600,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +2656,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,7 +2715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3951,6 +3983,7 @@ dependencies = [
  "bigdecimal",
  "bon 3.3.2",
  "clap",
+ "educe",
  "eventuals",
  "futures",
  "futures-util",
@@ -5529,7 +5562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -5677,7 +5710,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.8",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7445,7 +7478,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8529,7 +8562,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -53,6 +53,7 @@ bon.workspace = true
 test-assets = { path = "../test-assets", optional = true }
 rand = { version = "0.8", optional = true }
 itertools = "0.14.0"
+educe = "0.6.0"
 
 [dev-dependencies]
 # Release-please breaks with cyclical dependencies if dev-dependencies

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -406,15 +406,14 @@ where
                 } else {
                     Err(anyhow!("Unaggregated fee equals zero"))
                 };
-                let rav_response = (
-                    state.unaggregated_fees,
-                    rav_result.map(|res| res.map(Into::into)),
-                );
                 state
                     .sender_account_ref
                     .cast(SenderAccountMessage::UpdateReceiptFees(
                         state.allocation_id,
-                        ReceiptFees::RavRequestResponse(rav_response),
+                        ReceiptFees::RavRequestResponse(
+                            state.unaggregated_fees,
+                            rav_result.map(|res| res.map(Into::into)),
+                        ),
                     ))?;
             }
             #[cfg(any(test, feature = "test"))]
@@ -1672,7 +1671,7 @@ pub mod tests {
 
         assert!(matches!(
             message_receiver.recv().await.unwrap(),
-            SenderAccountMessage::UpdateReceiptFees(_, ReceiptFees::RavRequestResponse(_))
+            SenderAccountMessage::UpdateReceiptFees(_, ReceiptFees::RavRequestResponse(_, _))
         ));
     }
 
@@ -2106,9 +2105,9 @@ pub mod tests {
         match rav_response_message {
             SenderAccountMessage::UpdateReceiptFees(
                 _,
-                ReceiptFees::RavRequestResponse(rav_response),
+                ReceiptFees::RavRequestResponse(_, rav_response),
             ) => {
-                assert!(rav_response.1.is_err());
+                assert!(rav_response.is_err());
             }
             v => panic!("Expecting RavRequestResponse as last message, found: {v:?}"),
         }
@@ -2207,9 +2206,9 @@ pub mod tests {
         match rav_response_message {
             SenderAccountMessage::UpdateReceiptFees(
                 _,
-                ReceiptFees::RavRequestResponse(rav_response),
+                ReceiptFees::RavRequestResponse(_, rav_response),
             ) => {
-                assert!(rav_response.1.is_err());
+                assert!(rav_response.is_err());
             }
             v => panic!("Expecting RavRequestResponse as last message, found: {v:?}"),
         }

--- a/crates/tap-agent/src/test.rs
+++ b/crates/tap-agent/src/test.rs
@@ -703,6 +703,11 @@ pub mod actors {
         unaggregated_receipts::UnaggregatedReceipts,
     };
 
+    #[cfg(test)]
+    pub fn clone_rpc_reply<T>(_: &ractor::RpcReplyPort<T>) -> ractor::RpcReplyPort<T> {
+        ractor::concurrency::oneshot().0.into()
+    }
+
     pub struct DummyActor;
 
     impl DummyActor {
@@ -917,14 +922,14 @@ pub mod actors {
                         );
                         sender_account.cast(SenderAccountMessage::UpdateReceiptFees(
                             ALLOCATION_ID_0,
-                            ReceiptFees::RavRequestResponse((
+                            ReceiptFees::RavRequestResponse(
                                 UnaggregatedReceipts {
                                     value: *self.next_unaggregated_fees_value.borrow(),
                                     last_id: 0,
                                     counter: 0,
                                 },
                                 Ok(Some(signed_rav.into())),
-                            )),
+                            ),
                         ))?;
                     }
                 }


### PR DESCRIPTION
Remove the manual implementation of PartialEq/Eq for tests to use the [`educe`](https://docs.rs/educe/latest/educe/) crate.
This makes the code well organized.