### PR TITLE
refactor(tap-agent): use insta for snapshot testing messages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,6 +110,7 @@ jobs:
       image: rust:1.81-bookworm
     env:
       DATABASE_URL: postgres://postgres@postgres:5432
+      CI: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Cache dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,7 +3500,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4018,6 +4018,7 @@ dependencies = [
  "indexer-receipt",
  "indexer-tap-agent",
  "indexer-watcher",
+ "insta",
  "itertools 0.14.0",
  "jsonrpsee",
  "lazy_static",
@@ -4086,13 +4087,14 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "insta"
-version = "1.41.1"
+version = "1.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
 dependencies = [
  "console",
- "lazy_static",
  "linked-hash-map",
+ "once_cell",
+ "pin-project 1.1.9",
  "similar",
 ]
 
@@ -8599,7 +8601,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,9 @@ rev = "9fd4beb"
 [patch.crates-io.tap_graph]
 git = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
 rev = "9fd4beb"
+
+# Insta benefits from being compiled in release mode, even as dev dependency
+# see https://insta.rs/docs/quickstart
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -67,3 +67,4 @@ test-assets = { path = "../test-assets" }
 test-log.workspace = true
 rstest = "0.24.0"
 stdext = "0.3.3"
+insta = "1.42.2"

--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -1527,10 +1527,7 @@ pub mod tests {
             ))
             .unwrap();
         let message = msg_receiver.recv().await.expect("Channel failed");
-        assert_eq!(
-            message,
-            SenderAccountMessage::UpdateAllocationIds(allocation_ids)
-        );
+        insta::assert_debug_snapshot!(message);
 
         // verify if create sender account
         let sender_allocation_id = format!("{}:{}:{}", prefix.clone(), SENDER.1, ALLOCATION_ID_0);
@@ -1541,17 +1538,7 @@ pub mod tests {
             .cast(SenderAccountMessage::UpdateAllocationIds(HashSet::new()))
             .unwrap();
         let message = msg_receiver.recv().await.expect("Channel failed");
-        assert_eq!(
-            message,
-            SenderAccountMessage::UpdateReceiptFees(
-                ALLOCATION_ID_0,
-                ReceiptFees::UpdateValue(UnaggregatedReceipts {
-                    value: 0,
-                    last_id: 0,
-                    counter: 0,
-                })
-            )
-        );
+        insta::assert_debug_snapshot!(message);
 
         let actor_ref = ActorRef::<SenderAllocationMessage>::where_is(sender_allocation_id.clone());
         assert!(actor_ref.is_some());
@@ -1582,10 +1569,7 @@ pub mod tests {
             .cast(SenderAccountMessage::UpdateAllocationIds(HashSet::new()))
             .unwrap();
         let msg = msg_receiver.recv().await.expect("Channel failed");
-        assert_eq!(
-            msg,
-            SenderAccountMessage::UpdateAllocationIds(HashSet::new())
-        );
+        insta::assert_debug_snapshot!(msg);
 
         let actor_ref = ActorRef::<SenderAllocationMessage>::where_is(sender_allocation_id.clone());
         assert!(actor_ref.is_none());

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -948,9 +948,7 @@ mod tests {
     use crate::{
         agent::{
             sender_account::SenderAccountMessage,
-            sender_accounts_manager::{
-                handle_notification, AllocationId, NewReceiptNotification, SenderType,
-            },
+            sender_accounts_manager::{handle_notification, NewReceiptNotification, SenderType},
         },
         test::{
             actors::{DummyActor, MockSenderAccount, MockSenderAllocation, TestableActor},
@@ -1316,10 +1314,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            rx.recv().await.unwrap(),
-            SenderAccountMessage::NewAllocationId(AllocationId::Legacy(ALLOCATION_ID_0))
-        );
+        let new_alloc_msg = rx.recv().await.unwrap();
+        insta::assert_debug_snapshot!(new_alloc_msg);
         sender_account.stop_and_wait(None, None).await.unwrap();
         join_handle.await.unwrap();
     }

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_account__tests__update_allocation_ids-2.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_account__tests__update_allocation_ids-2.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tap-agent/src/agent/sender_account.rs
+expression: message
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UpdateValue(
+        UnaggregatedReceipts {
+            value: 0,
+            last_id: 0,
+            counter: 0,
+        },
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_account__tests__update_allocation_ids-3.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_account__tests__update_allocation_ids-3.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tap-agent/src/agent/sender_account.rs
+expression: msg
+---
+UpdateAllocationIds(
+    {},
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_account__tests__update_allocation_ids.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_account__tests__update_allocation_ids.snap
@@ -1,0 +1,11 @@
+---
+source: crates/tap-agent/src/agent/sender_account.rs
+expression: message
+---
+UpdateAllocationIds(
+    {
+        Legacy(
+            0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+        ),
+    },
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_accounts_manager__tests__create_allocation_id.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_accounts_manager__tests__create_allocation_id.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tap-agent/src/agent/sender_accounts_manager.rs
+expression: new_alloc_msg
+---
+NewAllocationId(
+    Legacy(
+        0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__close_allocation_no_pending_fees.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__close_allocation_no_pending_fees.snap
@@ -1,0 +1,16 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: message_receiver.recv().await
+---
+Some(
+    UpdateReceiptFees(
+        0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+        UpdateValue(
+            UnaggregatedReceipts {
+                value: 0,
+                last_id: 0,
+                counter: 0,
+            },
+        ),
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__execute-2.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__execute-2.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: startup_msg
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UpdateValue(
+        UnaggregatedReceipts {
+            value: 499500,
+            last_id: 1000,
+            counter: 1000,
+        },
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__execute.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__execute.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: startup_msg
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UpdateValue(
+        UnaggregatedReceipts {
+            value: 499500,
+            last_id: 1000,
+            counter: 1000,
+        },
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__failed_rav_request-2.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__failed_rav_request-2.snap
@@ -1,0 +1,19 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: rav_response_message
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    RavRequestResponse(
+        UnaggregatedReceipts {
+            value: 45,
+            last_id: 10,
+            counter: 10,
+        },
+        Err(
+            Other(
+                "It looks like there are no valid receipts for the RAV request.This may happen if your `rav_request_trigger_value` is too low and no receipts were found outside the `rav_request_timestamp_buffer_ms`.You can fix this by increasing the `rav_request_trigger_value`.",
+            ),
+        ),
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__failed_rav_request.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__failed_rav_request.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: startup_msg
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UpdateValue(
+        UnaggregatedReceipts {
+            value: 45,
+            last_id: 10,
+            counter: 10,
+        },
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__rav_request_when_all_receipts_invalid-2.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__rav_request_when_all_receipts_invalid-2.snap
@@ -1,0 +1,12 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: invalid_receipts
+---
+UpdateInvalidReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UnaggregatedReceipts {
+        value: 16220184412847561580,
+        last_id: 0,
+        counter: 0,
+    },
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__rav_request_when_all_receipts_invalid-3.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__rav_request_when_all_receipts_invalid-3.snap
@@ -1,0 +1,17 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: rav_error_response_message
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    RavRequestResponse(
+        UnaggregatedReceipts {
+            value: 0,
+            last_id: 0,
+            counter: 0,
+        },
+        Err(
+            AllReceiptsInvalid,
+        ),
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__rav_request_when_all_receipts_invalid.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__rav_request_when_all_receipts_invalid.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: startup_msg
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UpdateValue(
+        UnaggregatedReceipts {
+            value: 16220184412847561580,
+            last_id: 10,
+            counter: 10,
+        },
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__receive_new_receipt.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__receive_new_receipt.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: startup_load_msg
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UpdateValue(
+        UnaggregatedReceipts {
+            value: 0,
+            last_id: 0,
+            counter: 0,
+        },
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__should_return_invalid_receipts_on_startup-2.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__should_return_invalid_receipts_on_startup-2.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: last_message_emitted
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UpdateValue(
+        UnaggregatedReceipts {
+            value: 0,
+            last_id: 0,
+            counter: 0,
+        },
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__should_return_invalid_receipts_on_startup.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__should_return_invalid_receipts_on_startup.snap
@@ -1,0 +1,12 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: update_invalid_msg
+---
+UpdateInvalidReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UnaggregatedReceipts {
+        value: 55,
+        last_id: 10,
+        counter: 10,
+    },
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__should_update_unaggregated_fees_on_start.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__should_update_unaggregated_fees_on_start.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: last_message_emitted
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UpdateValue(
+        UnaggregatedReceipts {
+            value: 55,
+            last_id: 10,
+            counter: 10,
+        },
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__trigger_rav_request-2.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__trigger_rav_request-2.snap
@@ -1,0 +1,12 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: msg
+---
+UpdateInvalidReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UnaggregatedReceipts {
+        value: 45,
+        last_id: 0,
+        counter: 0,
+    },
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__trigger_rav_request-3.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__trigger_rav_request-3.snap
@@ -1,0 +1,22 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: x
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    RavRequestResponse(
+        UnaggregatedReceipts {
+            value: 0,
+            last_id: 0,
+            counter: 0,
+        },
+        Ok(
+            Some(
+                RavInformation {
+                    allocation_id: 0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+                    value_aggregate: 45,
+                },
+            ),
+        ),
+    ),
+)

--- a/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__trigger_rav_request.snap
+++ b/crates/tap-agent/src/agent/snapshots/indexer_tap_agent__agent__sender_allocation__tests__trigger_rav_request.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tap-agent/src/agent/sender_allocation.rs
+expression: startup_msg
+---
+UpdateReceiptFees(
+    0xfa44c72b753a66591f241c7dc04e8178c30e13af,
+    UpdateValue(
+        UnaggregatedReceipts {
+            value: 90,
+            last_id: 20,
+            counter: 20,
+        },
+    ),
+)

--- a/crates/tap-agent/src/tap/context/receipt.rs
+++ b/crates/tap-agent/src/tap/context/receipt.rs
@@ -41,6 +41,7 @@ impl From<serde_json::Error> for AdapterError {
 }
 
 /// convert Bound`<u64>` to Bound`<BigDecimal>`
+#[inline]
 fn u64_bound_to_bigdecimal_bound(bound: Bound<&u64>) -> Bound<BigDecimal> {
     match bound {
         Bound::Included(val) => Bound::Included(BigDecimal::from(*val)),
@@ -473,10 +474,9 @@ mod test {
             .unwrap()[0]
             .clone();
 
-        assert_eq!(
-            received_receipt.signed_receipt().unique_id(),
-            retrieved_receipt.signed_receipt().unique_id(),
-        );
+        let received_id = received_receipt.signed_receipt().unique_id();
+        let retrieved_id = retrieved_receipt.signed_receipt().unique_id();
+        assert_eq!(received_id, retrieved_id);
     }
 
     /// This function compares a local receipts vector filter by timestamp range (we assume that the stdlib
@@ -933,8 +933,6 @@ mod test {
                     .unwrap(),
             );
         }
-
-        // zip the 2 vectors together
 
         macro_rules! test_ranges{
             ($($arg: expr), +) => {

--- a/justfile
+++ b/justfile
@@ -25,6 +25,9 @@ ci:
 test:
     RUST_LOG=debug cargo nextest run
 
+review:
+    RUST_LOG=debug cargo insta review
+
 fmt:
     cargo +nightly fmt
 


### PR DESCRIPTION
Add `insta` for snapshot testing messages instead of constructing the expected result.

Insta will automatically compare the message with the snapshot during `just test` (or `cargo test`, `cargo nextest run`), and fail if the message diverges.

To review changes, it's recommended to use `cargo-insta` CLI, but it's not necessarily needed.

Please, read the create `Getting started` docs for a introduction to the recommended workflow: https://insta.rs/docs/quickstart/