### PR TITLE
fix(ipfs): use from_str IPFS client constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,6 @@ dependencies = [
  "indexer-monitor",
  "indexer-watcher",
  "ipfs-api-backend-hyper",
- "ipfs-api-prelude",
  "prost",
  "rand 0.9.0",
  "serde",

--- a/crates/dips/Cargo.toml
+++ b/crates/dips/Cargo.toml
@@ -26,7 +26,6 @@ futures = "0.3"
 http = "0.2"
 prost = { workspace = true, optional = true }
 ipfs-api-backend-hyper = { version = "0.6.0", features = ["with-send-sync", "with-hyper-tls"] }
-ipfs-api-prelude = { version = "0.6.0", features = ["with-send-sync"] }
 serde_yaml.workspace = true
 serde.workspace = true
 sqlx = { workspace = true, optional = true }

--- a/crates/dips/src/ipfs.rs
+++ b/crates/dips/src/ipfs.rs
@@ -1,15 +1,13 @@
 // Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use derivative::Derivative;
 use futures::TryStreamExt;
-use http::Uri;
-use ipfs_api_prelude::{IpfsApi, TryFromUri};
+use ipfs_api_backend_hyper::{IpfsApi, TryFromUri};
 use serde::Deserialize;
-use tracing;
 
 use crate::DipsError;
 
@@ -34,11 +32,8 @@ pub struct IpfsClient {
 
 impl IpfsClient {
     pub fn new(url: &str) -> anyhow::Result<Self> {
-        Ok(Self {
-            client: ipfs_api_backend_hyper::IpfsClient::build_with_base_uri(
-                Uri::from_str(url).map_err(anyhow::Error::from)?,
-            ),
-        })
+        let client = ipfs_api_backend_hyper::IpfsClient::from_str(url)?;
+        Ok(Self { client })
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `crates/dips` project to update dependencies and refactor the IPFS client implementation. The most important changes include modifying the dependency versions in `Cargo.toml`, updating the import statements in `ipfs.rs`, and refactoring the `IpfsClient` struct.

* [`crates/dips/Cargo.toml`](diffhunk://#diff-271b41f6df2e65a887a3a18cd20536fb075df359339939c77d15843c117a070cL29): Removed the `ipfs-api-prelude` dependency.
* [`crates/dips/src/ipfs.rs`](diffhunk://#diff-ca88c155ef694ceb70a734514fba168b1bd873c4efc481be50c7b8dab0b59aaaL4-L12): Removed unused imports (`http::Uri`, `ipfs_api_prelude::{IpfsApi, TryFromUri}`, and `tracing`). Updated the imports to use `ipfs_api_backend_hyper::{IpfsApi, TryFromUri}`.
* [`crates/dips/src/ipfs.rs`](diffhunk://#diff-ca88c155ef694ceb70a734514fba168b1bd873c4efc481be50c7b8dab0b59aaaL37-R36): Refactored the `IpfsClient::new` method to simplify the creation of the IPFS client by directly using `ipfs_api_backend_hyper::IpfsClient::from_str(url)`.