### PR TITLE
Fix: Temporarily disable Horizon, enhance agent stability and logging

### DIFF
--- a/crates/service/src/tap/receipt_store.rs
+++ b/crates/service/src/tap/receipt_store.rs
@@ -112,7 +112,7 @@ impl InnerContext {
         .execute(&self.pgpool)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to store receipt: {}", e);
+            tracing::error!("Failed to store V1 receipt: {}", e);
             anyhow!(e)
         })?;
 
@@ -180,7 +180,7 @@ impl InnerContext {
         .execute(&self.pgpool)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to store receipt: {}", e);
+            tracing::error!("Failed to store V2 receipt: {}", e);
             anyhow!(e)
         })?;
 

--- a/crates/tap-agent/src/agent.rs
+++ b/crates/tap-agent/src/agent.rs
@@ -177,7 +177,7 @@ pub async fn start_agent() -> (ActorRef<SenderAccountsManagerMessage>, JoinHandl
     let config = Box::leak(Box::new({
         let mut config = SenderAccountConfig::from_config(&CONFIG);
         // FIXME: This is a temporary measure to disable
-        // Horizon, even if enable through our configuration file.
+        // Horizon, even if enabled through our configuration file.
         // Force disable Horizon support
         config.horizon_enabled = false;
         // Add a warning log so operators know their setting was ignore

--- a/crates/tap-agent/src/agent.rs
+++ b/crates/tap-agent/src/agent.rs
@@ -174,7 +174,21 @@ pub async fn start_agent() -> (ActorRef<SenderAccountsManagerMessage>, JoinHandl
     .await
     .expect("Error creating escrow_accounts channel");
 
-    let config = Box::leak(Box::new(SenderAccountConfig::from_config(&CONFIG)));
+    let config = Box::leak(Box::new({
+        let mut config = SenderAccountConfig::from_config(&CONFIG);
+        // FIXME: This is a temporary measure to disable
+        // Horizon, even if enable through our configuration file.
+        // Force disable Horizon support
+        config.horizon_enabled = false;
+        // Add a warning log so operators know their setting was ignore
+        if CONFIG.horizon.enabled {
+            tracing::warn!(
+            "Horizon support is configured as enabled but has been forcibly disabled as it's not fully supported yet. \
+            This is a temporary measure until Horizon support is stable."
+        );
+        }
+        config
+    }));
 
     let args = SenderAccountsManagerArgs {
         config,

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -679,7 +679,6 @@ impl State {
             } else {
                 // Log the case when allocation_ids is NULL
                 tracing::warn!(
-                    sender_address = %row.sender_address,
                     "Found NULL allocation_ids. This may indicate all RAVs are finalized."
                 );
             }
@@ -783,7 +782,6 @@ impl State {
             } else {
                 // Log the case when allocation_ids is NULL
                 tracing::warn!(
-                    sender_address = %row.sender_address,
                     "Found NULL allocation_ids. This may indicate all RAVs are finalized."
                 );
             }

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -654,7 +654,8 @@ impl State {
 
         for row in nonfinal_ravs_sender_allocations_in_db {
             // Check if allocation_ids is Some before processing,
-            // as ARRAY_AGG with FILTER can return NULL
+            // as ARRAY_AGG with FILTER returns NULL
+            // instead of an empty array
             if let Some(allocation_id_strings) = row.allocation_ids {
                 let allocation_ids = allocation_id_strings
                     .iter()
@@ -675,6 +676,12 @@ impl State {
                         .or_default()
                         .extend(allocation_ids);
                 }
+            } else {
+                // Log the case when allocation_ids is NULL
+                tracing::warn!(
+                    sender_address = %row.sender_address,
+                    "Found NULL allocation_ids. This may indicate all RAVs are finalized."
+                );
             }
         }
         unfinalized_sender_allocations_map
@@ -751,9 +758,10 @@ impl State {
 
         for row in nonfinal_ravs_sender_allocations_in_db {
             // Check if allocation_ids is Some before processing,
-            // as ARRAY_AGG with FILTER can return NULL
+            // as ARRAY_AGG with FILTER returns NULL instead of an
+            // empty array
             if let Some(allocation_id_strings) = row.allocation_ids {
-                let allocation_ids = allocation_id_strings // Use the unwrapped Vec<String>
+                let allocation_ids = allocation_id_strings
                     .iter()
                     .map(|allocation_id| {
                         AllocationId::Legacy(
@@ -772,6 +780,12 @@ impl State {
                         .or_default()
                         .extend(allocation_ids);
                 }
+            } else {
+                // Log the case when allocation_ids is NULL
+                tracing::warn!(
+                    sender_address = %row.sender_address,
+                    "Found NULL allocation_ids. This may indicate all RAVs are finalized."
+                );
             }
         }
         unfinalized_sender_allocations_map


### PR DESCRIPTION
This PR temporarily disables Horizon support within the TAP agent to prevent potential issues due to its incomplete implementation. It also includes several improvements to enhance overall agent stability, error handling, and logging clarity.

Key Changes:

1.  **Forcibly Disable Horizon:** Overrides the `horizon_enabled` configuration setting to `false` in `agent.rs` upon startup, ensuring Horizon features remain inactive regardless of the user's config file settings.
2.  **Operator Warning for Override:** Adds a `tracing::warn!` message to notify operators if Horizon was enabled in their configuration, explaining that it has been forcibly disabled temporarily.
3.  **Conditional Horizon Components:** Prevents the creation and initialization of Horizon-specific components (like `pglistener_v2`, the V2 escrow accounts `watch_pipe`, and the V2 new receipts watcher) if `horizon_enabled` is false.
4.  **Prevent Horizon Actor Restarts:** Stops the `SenderAccountsManager` from attempting to restart failed actors of type `SenderType::Horizon` when Horizon support is disabled.
5.  **Safer Database Result Handling:** Introduces checks (`if let Some(...)`, `is_empty()`) when processing aggregated `allocation_ids` from the database (for both V1 and V2 unfinalized RAVs) to gracefully handle cases where the `ARRAY_AGG` might return `NULL` (no matching rows), preventing potential panics.
6.  **Improved Logging Specificity:** Enhances various `tracing::error!` and `.expect()` messages related to receipt storage, database queries, and sender timeouts by adding explicit "V1" or "V2" identifiers, making it easier to diagnose issues related to legacy vs. Horizon paths.