### PR TITLE
organize dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2717,8 +2717,6 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
- "anstream",
- "anstyle",
  "env_filter",
  "log",
 ]
@@ -3093,14 +3091,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3513,7 +3511,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -3923,7 +3921,7 @@ dependencies = [
  "indexer-query",
  "indexer-watcher",
  "reqwest 0.12.15",
- "rstest 0.24.0",
+ "rstest",
  "serde",
  "serde_json",
  "test-assets",
@@ -3994,7 +3992,7 @@ dependencies = [
  "prometheus",
  "prost",
  "reqwest 0.12.15",
- "rstest 0.23.0",
+ "rstest",
  "serde",
  "serde_json",
  "sqlx",
@@ -4048,9 +4046,9 @@ dependencies = [
  "jsonrpsee",
  "prometheus",
  "ractor",
- "rand 0.8.5",
+ "rand 0.9.1",
  "reqwest 0.12.15",
- "rstest 0.24.0",
+ "rstest",
  "ruint",
  "serde",
  "serde_json",
@@ -4129,7 +4127,7 @@ dependencies = [
  "anyhow",
  "bip39",
  "indexer-receipt",
- "rand 0.8.5",
+ "rand 0.9.1",
  "reqwest 0.12.15",
  "serde",
  "serde_json",
@@ -5447,7 +5445,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5643,7 +5641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -5804,6 +5802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "ractor"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5844,7 +5848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5864,7 +5868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5878,12 +5882,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
- "zerocopy 0.8.17",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -6223,44 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
-dependencies = [
- "futures",
- "futures-timer",
- "rstest_macros 0.23.0",
- "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "rstest"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
 dependencies = [
  "futures-timer",
  "futures-util",
- "rstest_macros 0.24.0",
+ "rstest_macros",
  "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version 0.4.1",
- "syn 2.0.100",
- "unicode-ident",
 ]
 
 [[package]]
@@ -7564,7 +7537,7 @@ dependencies = [
  "bip39",
  "bon 3.3.2",
  "indexer-allocation",
- "rstest 0.24.0",
+ "rstest",
  "sqlx",
  "stdext",
  "tap_core",
@@ -7579,7 +7552,6 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
 dependencies = [
- "env_logger",
  "test-log-macros",
  "tracing-subscriber",
 ]
@@ -8447,9 +8419,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -8652,7 +8624,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9110,9 +9082,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -9194,16 +9166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
-dependencies = [
- "zerocopy-derive 0.8.17",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -9211,17 +9174,6 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,25 +19,33 @@ resolver = "2"
 opt-level = 3
 
 [workspace.dependencies]
-clap = "4.4.3"
+anyhow = { version = "1.0.72" }
+async-trait = "0.1.83"
 axum = { version = "0.7.9", default-features = false, features = [
     "tokio",
     "http1",
     "http2",
 ] }
-tokio = "1.40"
-prometheus = "0.13.3"
-anyhow = { version = "1.0.72" }
-thiserror = "1.0.49"
-async-trait = "0.1.83"
-eventuals = "0.6.7"
 base64 = "0.22.1"
+bigdecimal = "0.4.3"
+bip39 = "2.0.0"
+bon = "3.3"
+build-info = "0.0.40"
+clap = "4.4.3"
+eventuals = "0.6.7"
+graphql_client = { version = "0.14.0", features = ["reqwest-rustls"] }
+graph-networks-registry = "0.6.1"
+prometheus = "0.13.3"
+prost = "0.13.4"
+prost-types = "0.13.3"
 reqwest = { version = "0.12", features = [
     "charset",
     "h2",
 ], default-features = false }
+rstest = "0.23.0"
 serde = { version = "1.0.206", default-features = false }
 serde_json = "1.0.124"
+serde_yaml = "0.9.21"
 sqlx = { version = "0.8.2", features = [
     "bigdecimal",
     "chrono",
@@ -49,18 +57,10 @@ sqlx = { version = "0.8.2", features = [
     "rust_decimal",
     "uuid",
 ], default-features = false }
-uuid = { version = "1.11.0", features = ["v7"] }
-tracing = { version = "0.1.40", default-features = false }
-bigdecimal = "0.4.3"
-build-info = "0.0.40"
-tap_core = { version = "3.0.0", default-features = false }
 tap_aggregator = { version = "0.4.0", default-features = false }
+tap_core = { version = "3.0.0", default-features = false }
 tap_graph = { version = "0.2.0", features = ["v2"] }
-tracing-subscriber = { version = "0.3", features = [
-    "json",
-    "env-filter",
-    "ansi",
-], default-features = false }
+test-log = { version = "0.2.12", features = ["trace"] }
 thegraph-core = { version = "0.11.0", features = [
     "attestation",
     "alloy-eip712",
@@ -72,18 +72,18 @@ thegraph-core = { version = "0.11.0", features = [
     "serde",
 ] }
 thegraph-graphql-http = { version = "0.3.2", features = ["reqwest"] }
-graphql_client = { version = "0.14.0", features = ["reqwest-rustls"] }
-bip39 = "2.0.0"
-rstest = "0.23.0"
-wiremock = "0.6.1"
+thiserror = "1.0.49"
+tokio = "1.40"
 tonic = { version = "0.12.3", features = ["tls-roots", "gzip"] }
-prost = "0.13.4"
-prost-types = "0.13.3"
 tonic-build = "0.12.3"
-serde_yaml = "0.9.21"
-bon = "3.3"
-test-log = { version = "0.2.12", features = ["trace"] }
-graph-networks-registry = "0.6.1"
+tracing = { version = "0.1.40", default-features = false }
+tracing-subscriber = { version = "0.3", features = [
+    "json",
+    "env-filter",
+    "ansi",
+], default-features = false }
+uuid = { version = "1.11.0", features = ["v7"] }
+wiremock = "0.6.1"
 
 [patch.crates-io.tap_core]
 git = "https://github.com/semiotic-ai/timeline-aggregation-protocol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,18 +31,34 @@ bigdecimal = "0.4.3"
 bip39 = "2.0.0"
 bon = "3.3"
 build-info = "0.0.40"
+build-info-build = { version = "0.0.40", default-features = false }
 clap = "4.4.3"
+educe = "0.6.0"
+env_logger = { version = "0.11.0", default-features = false }
 eventuals = "0.6.7"
+futures = "0.3"
+futures-util = { version = "0.3.28", default-features = false }
 graphql_client = { version = "0.14.0", features = ["reqwest-rustls"] }
 graph-networks-registry = "0.6.1"
+hex-literal = "0.4.1"
+insta = "1.42.2"
+itertools = "0.14.0"
+jsonrpsee = { version = "0.24.0", features = ["http-client", "tracing"] }
 prometheus = "0.13.3"
 prost = "0.13.4"
 prost-types = "0.13.3"
+ractor = { version = "0.14", features = [
+    "async-trait",
+], default-features = false }
+rand = "0.9.0"
 reqwest = { version = "0.12", features = [
     "charset",
     "h2",
 ], default-features = false }
-rstest = "0.23.0"
+rstest = "0.24.0"
+ruint = { version = "1.12.3", features = [
+    "num-traits",
+], default-features = false }
 serde = { version = "1.0.206", default-features = false }
 serde_json = "1.0.124"
 serde_yaml = "0.9.21"
@@ -57,10 +73,13 @@ sqlx = { version = "0.8.2", features = [
     "rust_decimal",
     "uuid",
 ], default-features = false }
+stdext = "0.3.3"
 tap_aggregator = { version = "0.4.0", default-features = false }
 tap_core = { version = "3.0.0", default-features = false }
 tap_graph = { version = "0.2.0", features = ["v2"] }
-test-log = { version = "0.2.12", features = ["trace"] }
+tempfile = "3.8.0"
+test-log = { version = "0.2.12", default-features = false }
+test-with = "0.14.6"
 thegraph-core = { version = "0.11.0", features = [
     "attestation",
     "alloy-eip712",
@@ -74,8 +93,11 @@ thegraph-core = { version = "0.11.0", features = [
 thegraph-graphql-http = { version = "0.3.2", features = ["reqwest"] }
 thiserror = "1.0.49"
 tokio = "1.40"
+tokio-test = "0.4.4"
 tonic = { version = "0.12.3", features = ["tls-roots", "gzip"] }
 tonic-build = "0.12.3"
+tower-service = "0.3.3"
+tower-test = "0.4.0"
 tracing = { version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3", features = [
     "json",
@@ -84,6 +106,7 @@ tracing-subscriber = { version = "0.3", features = [
 ], default-features = false }
 uuid = { version = "1.11.0", features = ["v7"] }
 wiremock = "0.6.1"
+wiremock-grpc = "0.0.3-alpha3"
 
 [patch.crates-io.tap_core]
 git = "https://github.com/semiotic-ai/timeline-aggregation-protocol"

--- a/crates/allocation/Cargo.toml
+++ b/crates/allocation/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow.workspace = true
 indexer-query = { path = "../query" }
 serde = { workspace = true, features = ["derive"] }
 thegraph-core.workspace = true
-anyhow.workspace = true

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow.workspace = true
 indexer-allocation = { path = "../allocation" }
 thegraph-core.workspace = true
-anyhow.workspace = true
 
 
 [dev-dependencies]
-test-log = { version = "0.2.12", default-features = false }
 test-assets = { path = "../test-assets" }
+test-log.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -4,17 +4,17 @@ version = "1.3.1"
 edition = "2021"
 
 [dependencies]
-serde.workspace = true
-thegraph-core.workspace = true
-tracing.workspace = true
 bigdecimal = { workspace = true, features = ["serde"] }
 bip39 = { version = "2.0.0", features = ["rand"] }
 figment = { version = "0.10.19", features = ["env", "toml"] }
+regex = "1.11.0"
+serde.workspace = true
+serde_ignored = "0.1.10"
 serde_with = { version = "3.8.1", default-features = false }
 serde_repr = "0.1.19"
-serde_ignored = "0.1.10"
+thegraph-core.workspace = true
+tracing.workspace = true
 url = { version = "2.5.0", features = ["serde"] }
-regex = "1.11.0"
 
 [dev-dependencies]
 sealed_test = "1.1.0"

--- a/crates/dips/Cargo.toml
+++ b/crates/dips/Cargo.toml
@@ -23,7 +23,7 @@ graph-networks-registry.workspace = true
 bytes = { version = "1.10.0", optional = true }
 derivative = "2.2.0"
 
-futures = "0.3"
+futures.workspace = true
 http = "0.2"
 prost = { workspace = true, optional = true }
 ipfs-api-backend-hyper = { version = "0.6.0", features = [
@@ -37,7 +37,7 @@ tonic = { workspace = true, optional = true }
 serde_json.workspace = true
 
 [dev-dependencies]
-rand = "0.9.0"
+rand.workspace = true
 indexer-watcher = { path = "../watcher" }
 
 [build-dependencies]

--- a/crates/monitor/Cargo.toml
+++ b/crates/monitor/Cargo.toml
@@ -21,9 +21,9 @@ tokio.workspace = true
 bip39.workspace = true
 
 [dev-dependencies]
-env_logger = { version = "0.11.0", default-features = false }
-test-log = { version = "0.2.12", default-features = false }
-wiremock.workspace = true
+env_logger.workspace = true
+rstest.workspace = true
 test-assets = { path = "../test-assets" }
-rstest = "0.24.0"
-test-with = "0.14.6"
+test-log.workspace = true
+test-with.workspace = true
+wiremock.workspace = true

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -65,17 +65,17 @@ graph-networks-registry.workspace = true
 
 
 [dev-dependencies]
-hex-literal = "0.4.1"
-test-assets = { path = "../test-assets" }
-sqlx = { workspace = true, features = ["migrate"] }
+futures.workspace = true
+hex-literal.workspace = true
+insta.workspace = true
 rstest.workspace = true
-tower-test = "0.4.0"
-tower-service = "0.3.3"
-tokio-test = "0.4.4"
+sqlx = { workspace = true, features = ["migrate"] }
+test-assets = { path = "../test-assets" }
+test-log = { workspace = true, features = ["trace"] }
+tower-test.workspace = true
+tower-service.workspace = true
+tokio-test.workspace = true
 wiremock.workspace = true
-insta = "1.41.1"
-test-log.workspace = true
-futures = "0.3.31"
 
 [build-dependencies]
-build-info-build = { version = "0.0.40", default-features = false }
+build-info-build.workspace = true

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -38,32 +38,28 @@ tracing-subscriber.workspace = true
 tonic.workspace = true
 bigdecimal = { workspace = true, features = ["serde"] }
 graphql_client.workspace = true
-ruint = { version = "1.12.3", features = [
-    "num-traits",
-], default-features = false }
-futures-util = { version = "0.3.28", default-features = false }
-jsonrpsee = { version = "0.24.0", features = ["http-client", "tracing"] }
-ractor = { version = "0.14", features = [
-    "async-trait",
-], default-features = false }
+ruint.workspace = true
+futures-util.workspace = true
+jsonrpsee.workspace = true
+ractor.workspace = true
 tap_aggregator.workspace = true
-futures = { version = "0.3.30", default-features = false }
+futures.workspace = true
 bon.workspace = true
 test-assets = { path = "../test-assets", optional = true }
-rand = { version = "0.8", optional = true }
-itertools = "0.14.0"
-educe = "0.6.0"
+rand = { workspace = true, optional = true }
+itertools.workspace = true
+educe.workspace = true
 
 [dev-dependencies]
 # Release-please breaks with cyclical dependencies if dev-dependencies
 # import the current crate. For testing we import the current crate with the `test`
 # feature enabled in order to enable test-only infrastructure within our app when running tests.
 my-crate = { package = "indexer-tap-agent", path = ".", features = ["test"] }
-tempfile = "3.8.0"
+tempfile.workspace = true
 wiremock.workspace = true
-wiremock-grpc = "0.0.3-alpha3"
+wiremock-grpc.workspace = true
 test-assets = { path = "../test-assets" }
-test-log.workspace = true
-rstest = "0.24.0"
-stdext = "0.3.3"
-insta = "1.42.2"
+test-log = { workspace = true, features = ["trace"] }
+rstest.workspace = true
+stdext.workspace = true
+insta.workspace = true

--- a/crates/tap-agent/src/test.rs
+++ b/crates/tap-agent/src/test.rs
@@ -15,7 +15,7 @@ use bigdecimal::num_bigint::BigInt;
 use indexer_monitor::{DeploymentDetails, EscrowAccounts, SubgraphClient};
 use indexer_receipt::TapReceipt;
 use ractor::{concurrency::JoinHandle, Actor, ActorRef};
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use rand::{distr::Alphanumeric, rng, Rng};
 use reqwest::Url;
 use sqlx::{types::BigDecimal, PgPool};
 use tap_aggregator::server::run_server;
@@ -73,7 +73,7 @@ const ESCROW_POLLING_INTERVAL: Duration = Duration::from_secs(30);
 /// Generates a random prefix to be used for actor registry
 pub fn generate_random_prefix() -> String {
     const SIZE: usize = 16;
-    thread_rng()
+    rng()
         .sample_iter(&Alphanumeric)
         .take(SIZE)
         .map(char::from)

--- a/crates/test-assets/Cargo.toml
+++ b/crates/test-assets/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 indexer-allocation = { path = "../allocation" }
-bip39 = "2.0.0"
+bip39.workspace = true
 tap_core.workspace = true
 tap_graph.workspace = true
 thegraph-core.workspace = true
 bon.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
-rstest = "0.24.0"
-stdext = "0.3.3"
+rstest.workspace = true
+stdext.workspace = true

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -20,6 +20,6 @@ thegraph-core = { workspace = true, features = [
 ] }
 bip39 = { workspace = true }
 
-rand = "0.8"
+rand.workspace = true
 
 indexer-receipt = { path = "../crates/indexer-receipt" }

--- a/integration-tests/src/receipt.rs
+++ b/integration-tests/src/receipt.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use rand::Rng;
+use rand::{rng, Rng};
 use std::str::FromStr;
 use std::time::SystemTime;
 
@@ -16,7 +16,7 @@ pub fn create_tap_receipt(
     escrow_contract: &str,
     wallet: &PrivateKeySigner,
 ) -> Result<Eip712SignedMessage<Receipt>> {
-    let nonce = rand::thread_rng().gen::<u64>();
+    let nonce = rng().random::<u64>();
 
     // Get timestamp in nanoseconds
     let timestamp = SystemTime::now()


### PR DESCRIPTION
- alphabetize the workspace dependencies
- use the workspace where feasible
- where `dips` dependencies have been touched the `dips` version has been used in the workspace version
