### PR TITLE
feat: improve sender allocation logging

### DIFF
--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -381,6 +381,7 @@ where
                 if id <= unaggregated_fees.last_id {
                     // our world assumption is wrong
                     tracing::warn!(
+                        unaggregated_fees_last_id = %unaggregated_fees.last_id,
                         last_id = %id,
                         "Received a receipt notification that was already calculated."
                     );

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -379,7 +379,7 @@ where
                     ..
                 } = notification;
                 if id <= unaggregated_fees.last_id {
-                    // our world assumption is wrong
+                    // Unexpected: received a receipt with an ID not greater than the last processed one
                     tracing::warn!(
                         unaggregated_fees_last_id = %unaggregated_fees.last_id,
                         last_id = %id,


### PR DESCRIPTION
I've heard from indexers who hit this error and I think it may be helpful to include extra info in the warning log to help them examine their database.