### PR TITLE
fix(tap): fix unused v2 deny list check

### DIFF
--- a/crates/service/src/tap/checks/deny_list_check.rs
+++ b/crates/service/src/tap/checks/deny_list_check.rs
@@ -76,7 +76,7 @@ impl DenyListCheck {
         tokio::spawn(Self::sender_denylist_watcher(
             pgpool.clone(),
             pglistener_v2,
-            sender_denylist_v1.clone(),
+            sender_denylist_v2.clone(),
             sender_denylist_watcher_cancel_token.clone(),
             DenyListVersion::V2,
             #[cfg(test)]


### PR DESCRIPTION
This was always placeholder code to map out how the v2 path would look. This fixes an obvious bug in the unused v2 code.

Signed off by Joseph Livesey <joseph@semiotic.ai>