### PR TITLE
fix(ci): use dedicated RELEASE_TOKEN for release-please action

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Release please
         id: release-please
         uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
   builds-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `release-please` job within the Build and upload Docker image workflow (`.github/workflows/containers.yml`) has been updated. Previously, the `googleapis/release-please-action` was implicitly using the default `GITHUB_TOKEN`. This has been changed to explicitly use a dedicated repository secret, `secrets.RELEASE_TOKEN`.