### PR TITLE
chore(deps): remove unused eventuals dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,12 +1794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "by_address"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
-
-[[package]]
 name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,18 +2728,6 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
-]
-
-[[package]]
-name = "eventuals"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0450e5c57135f799007162ff8beba7b2809d4a018cf9cdcbca2c319a73d9d8ee"
-dependencies = [
- "by_address",
- "futures",
- "never",
- "tokio",
 ]
 
 [[package]]
@@ -4016,7 +3998,6 @@ dependencies = [
  "bon 3.6.3",
  "clap",
  "educe",
- "eventuals",
  "futures",
  "futures-util",
  "graphql_client",
@@ -4884,12 +4865,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "never"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
 
 [[package]]
 name = "nix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ build-info-build = { version = "0.0.40", default-features = false }
 clap = "4.4.3"
 educe = "0.6.0"
 env_logger = { version = "0.11.0", default-features = false }
-eventuals = "0.6.7"
 futures = "0.3"
 futures-util = { version = "0.3.28", default-features = false }
 graphql_client = { version = "0.14.0", features = ["reqwest-rustls"] }

--- a/crates/tap-agent/Cargo.toml
+++ b/crates/tap-agent/Cargo.toml
@@ -28,7 +28,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-eventuals.workspace = true
 tracing.workspace = true
 prometheus.workspace = true
 axum.workspace = true

--- a/crates/tap-agent/src/tap/context/escrow.rs
+++ b/crates/tap-agent/src/tap/context/escrow.rs
@@ -7,15 +7,6 @@ use thegraph_core::alloy::primitives::Address;
 
 use super::{error::AdapterError, NetworkVersion, TapAgentContext};
 
-// Conversion from eventuals::error::Closed to AdapterError::EscrowEventualError
-impl From<eventuals::error::Closed> for AdapterError {
-    fn from(e: eventuals::error::Closed) -> Self {
-        AdapterError::EscrowEventualError {
-            error: format!("{:?}", e),
-        }
-    }
-}
-
 /// Implements the SignatureChecker for any [NetworkVersion]
 #[async_trait]
 impl<T: NetworkVersion + Send + Sync> SignatureChecker for TapAgentContext<T> {


### PR DESCRIPTION
This pull request removes dependencies on the `eventuals` crate across multiple files in the codebase. The changes focus on simplifying dependency management and cleaning up related code.

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L46): Removed the `eventuals` crate from the list of dependencies.
* [`crates/tap-agent/Cargo.toml`](diffhunk://#diff-55620f2415b448f360a0b2b57af01c0a82af8f6d72accaf538ae943d5bc0b2cdL31): Removed the workspace inclusion of the `eventuals` crate.
* [`crates/tap-agent/src/tap/context/escrow.rs`](diffhunk://#diff-15306b269d86aadb97a617615433e839e5386cbe74c591261bea7e8c014329c9L10-L18): Removed the implementation of the `From` trait for converting `eventuals::error::Closed` to `AdapterError::EscrowEventualError`, along with associated code.