### PR TITLE
ci: revert "fix(ci): use dedicated RELEASE_TOKEN for release-please action"

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Release please
         id: release-please
         uses: googleapis/release-please-action@v4
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
 
   builds-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit [5572cd](https://github.com/graphprotocol/indexer-rs/commit/5572cd4683eeef9d906f381255b0ddd589ede752).

While <crates.io> releases will still be blocked this hopefully unblocks our CI pipeline to allow merging to `main`.

Signed off by Joseph Livesey <joseph@semiotic.ai>