### PR TITLE
test(setup-test-network): use semiotic-ai local-network fork

### DIFF
--- a/setup-test-network.sh
+++ b/setup-test-network.sh
@@ -114,10 +114,10 @@ pwd
 
 # Clone local-network repo if it doesn't exist
 if [ ! -d "local-network" ]; then
-    git clone https://github.com/edgeandnode/local-network.git
+    git clone https://github.com/semiotic-ai/local-network.git
     cd local-network
-    # Checkout to a specific commit that is known to work
-    git checkout ad98716661b033dd5e4cb9f09cebb80dba954c2d
+    # Checkout to a branch with no dipper
+    git checkout suchapalaver/main-no-dipper
     cd ..
 fi
 


### PR DESCRIPTION
This PR updates our local testing infrastructure to use a [`semiotic-ai/local-network` fork](https://github.com/semiotic-ai/local-network/tree/suchapalaver/main-no-dipper) of `edgeandnode/local-network`.

Until now, we’ve been pinning to a specific commit to maintain compatibility. Moving to a fork based on main gives us a cleaner foundation and puts us in a better position to track upstream changes—especially the `horizon` branch—while also fixing broken components and improving support for private submodules. With every team maintaining their own branches anyway, this gets us unblocked and contributing to a more functional baseline.

SIgned off by Joseph Livesey <joseph@semiotic.ai>

--

Tested locally on PopOS:

```terminal
All services are now running!
You can enjoy your new local network setup for testing.
============ FINAL DISK USAGE ============
Docker directory usage:  111G
Images size: N/A
Containers size: N/A
Volumes size: N/A
===========================================
```

Changes to `local-network` in our fork include:

- [chore(dipper): tear out the dipper](https://github.com/edgeandnode/local-network/commit/510da4b13ea1134c3f10e4975334f15925b6a5db)
- [build(tap-contracts): update node version in Dockerfile](https://github.com/edgeandnode/local-network/commit/bbca1a3aaec11ca2b84e09196b06c9234dfbeb45)
- [fix(tap-contracts): remove duplicate version labeling](https://github.com/edgeandnode/local-network/commit/c77dcfee83085b33ddc9d80b35dd996bdeef3302)
- [build(block-oracle): use pnpm instead of yarn in Dockerfile](https://github.com/edgeandnode/local-network/commit/b466bb0f93449ca769e8ca0d94d3bbd7eb2699f7)
- [fix(block-oracle): use pnpm instead of yarn](https://github.com/edgeandnode/local-network/commit/3f9c4835ff5d19cbe6183fd60e7acd7e9fbd695e)
