### PR TITLE
ci(containers): use RELEASE_TOKEN for releases

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Release please
         id: release-please
         uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
   builds-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates the CI release workflow to use a RELEASE_TOKEN secret instead of the default GITHUB_TOKEN. The default token cannot trigger workflows that are defined as reusable or that call other actions due to GitHub’s security restrictions. The RELEASE_TOKEN is a personal access token with appropriate scopes, enabling the release workflow to trigger dependent workflows such as Docker image publishing or changelog generation.

