### PR TITLE
test(sender-account): fix db isolation issue

### DIFF
--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -1765,8 +1765,10 @@ pub mod tests {
     }
 
     #[rstest::rstest]
-    #[tokio::test]
+    #[sqlx::test(migrations = "../../migrations")]
+    #[serial]
     async fn test_update_receipt_fees_trigger_rav(
+        #[ignore] _pgpool: PgPool,
         #[future(awt)] mut basic_sender_account: TestSenderAccount,
     ) {
         // create a fake sender allocation


### PR DESCRIPTION
Fixes db isolation that shouldve been fixed previously in one test.

Signed off by Joseph Livesey <joseph@semiotic.ai>