### PR TITLE
refactor(clippy): fix updated warnings for rust 1.88

### DIFF
--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -22,7 +22,7 @@ pub fn derive_key_pair(
     deployment: &DeploymentId,
     index: u64,
 ) -> Result<PrivateKeySigner, anyhow::Error> {
-    let mut derivation_path = format!("m/{}/", epoch);
+    let mut derivation_path = format!("m/{epoch}/");
     derivation_path.push_str(
         &deployment
             .to_string()
@@ -32,7 +32,7 @@ pub fn derive_key_pair(
             .collect::<Vec<String>>()
             .join("/"),
     );
-    derivation_path.push_str(format!("/{}", index).as_str());
+    derivation_path.push_str(format!("/{index}").as_str());
 
     Ok(MnemonicBuilder::<English>::default()
         .derivation_path(&derivation_path)

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -87,7 +87,7 @@ impl Config {
 
         if let Some(path) = filename {
             let mut config_content = std::fs::read_to_string(path)
-                .map_err(|e| format!("Failed to read config file: {}", e))?;
+                .map_err(|e| format!("Failed to read config file: {e}"))?;
             config_content = Self::substitute_env_vars(config_content)?;
             figment_config = figment_config.merge(Toml::string(&config_content));
         }
@@ -134,7 +134,7 @@ impl Config {
                         Ok(value) => value,
                         Err(_) => {
                             missing_vars.push(var_name.to_string());
-                            format!("${{{}}}", var_name)
+                            format!("${{{var_name}}}")
                         }
                     }
                 });
@@ -264,7 +264,7 @@ impl DatabaseConfig {
                 password,
                 database,
             } => {
-                let postgres_url_str = format!("postgres://{}@{}/{}", user, host, database);
+                let postgres_url_str = format!("postgres://{user}@{host}/{database}");
                 let mut postgres_url =
                     Url::parse(&postgres_url_str).expect("Failed to parse database_url");
                 postgres_url

--- a/crates/dips/src/database.rs
+++ b/crates/dips/src/database.rs
@@ -22,7 +22,7 @@ pub struct PsqlAgreementStore {
 
 fn uint256_to_bigdecimal(value: &uint256, field: &str) -> Result<BigDecimal, DipsError> {
     BigDecimal::from_str(&value.to_string())
-        .map_err(|e| DipsError::InvalidVoucher(format!("{}: {}", field, e)))
+        .map_err(|e| DipsError::InvalidVoucher(format!("{field}: {e}")))
 }
 
 #[async_trait]

--- a/crates/dips/src/ipfs.rs
+++ b/crates/dips/src/ipfs.rs
@@ -48,12 +48,12 @@ impl IpfsFetcher for IpfsClient {
             .await
             .map_err(|e| {
                 tracing::warn!("Failed to fetch subgraph manifest {}: {}", file, e);
-                DipsError::SubgraphManifestUnavailable(format!("{}: {}", file, e))
+                DipsError::SubgraphManifestUnavailable(format!("{file}: {e}"))
             })?;
 
         let manifest: GraphManifest = serde_yaml::from_slice(&content).map_err(|e| {
             tracing::warn!("Failed to parse subgraph manifest {}: {}", file, e);
-            DipsError::InvalidSubgraphManifest(format!("{}: {}", file, e))
+            DipsError::InvalidSubgraphManifest(format!("{file}: {e}"))
         })?;
 
         Ok(manifest)

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -176,7 +176,7 @@ pub enum DipsError {
 #[cfg(feature = "rpc")]
 impl From<DipsError> for tonic::Status {
     fn from(value: DipsError) -> Self {
-        tonic::Status::internal(format!("{}", value))
+        tonic::Status::internal(format!("{value}"))
     }
 }
 
@@ -679,7 +679,7 @@ mod test {
 
             let res = signed.validate(&domain, &payer_addr);
             match error {
-                Some(_err) => assert!(matches!(res.unwrap_err(), _err), "case: {}", name),
+                Some(_err) => assert!(matches!(res.unwrap_err(), _err), "case: {name}"),
                 None => assert!(res.is_ok(), "case: {}, err: {}", name, res.unwrap_err()),
             }
         }
@@ -904,7 +904,7 @@ mod test {
             match (out, result) {
                 (Ok(a), Ok(b)) => assert_eq!(a.into_bytes(), b),
                 (Err(a), Err(b)) => assert_eq!(a.to_string(), b.to_string()),
-                (a, b) => panic!("{:?} did not match {:?}", a, b),
+                (a, b) => panic!("{a:?} did not match {b:?}"),
             }
         }
 

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -128,22 +128,16 @@ impl IndexerDipsService for DipsServer {
             Err(e) => match e {
                 // Invalid signature/authorization errors
                 DipsError::InvalidSignature(msg) => Err(Status::invalid_argument(format!(
-                    "invalid signature: {}",
-                    msg
+                    "invalid signature: {msg}"
                 ))),
                 DipsError::PayerNotAuthorised(addr) => Err(Status::invalid_argument(format!(
-                    "payer {} not authorized",
-                    addr
+                    "payer {addr} not authorized"
                 ))),
-                DipsError::UnexpectedPayee { expected, actual } => {
-                    Err(Status::invalid_argument(format!(
-                        "voucher payee {} does not match expected address {}",
-                        actual, expected
-                    )))
-                }
+                DipsError::UnexpectedPayee { expected, actual } => Err(Status::invalid_argument(
+                    format!("voucher payee {actual} does not match expected address {expected}"),
+                )),
                 DipsError::SignerNotAuthorised(addr) => Err(Status::invalid_argument(format!(
-                    "signer {} not authorized",
-                    addr
+                    "signer {addr} not authorized"
                 ))),
 
                 // Deployment/manifest related errors - these should return Reject
@@ -159,8 +153,7 @@ impl IndexerDipsService for DipsServer {
 
                 // Other errors
                 DipsError::AbiDecoding(msg) => Err(Status::invalid_argument(format!(
-                    "invalid request voucher: {}",
-                    msg
+                    "invalid request voucher: {msg}"
                 ))),
                 _ => Err(Status::internal(e.to_string())),
             },

--- a/crates/monitor/src/client/subgraph_client.rs
+++ b/crates/monitor/src/client/subgraph_client.rs
@@ -83,10 +83,7 @@ impl DeploymentClient {
                     monitor_deployment_status(deployment, url)
                         .await
                         .unwrap_or_else(|_| {
-                            panic!(
-                                "Failed to initialize monitoring for deployment `{}`",
-                                deployment
-                            )
+                            panic!("Failed to initialize monitoring for deployment `{deployment}`")
                         }),
                 ),
                 None => None,
@@ -119,7 +116,7 @@ impl DeploymentClient {
             .json(&body);
 
         if let Some(token) = self.query_auth_token.as_ref() {
-            req = req.header(header::AUTHORIZATION, format!("Bearer {}", token));
+            req = req.header(header::AUTHORIZATION, format!("Bearer {token}"));
         }
 
         let reqwest_response = req.send().await?;
@@ -160,7 +157,7 @@ impl DeploymentClient {
             .body(body);
 
         if let Some(token) = self.query_auth_token.as_ref() {
-            req = req.header(header::AUTHORIZATION, format!("Bearer {}", token));
+            req = req.header(header::AUTHORIZATION, format!("Bearer {token}"));
         }
 
         Ok(req.send().await?)
@@ -335,7 +332,7 @@ mod test {
         mock_server_local
             .register(
                 Mock::given(method("POST"))
-                    .and(path(format!("/subgraphs/id/{}", deployment)))
+                    .and(path(format!("/subgraphs/id/{deployment}")))
                     .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                         "data": {
                             "user": {
@@ -350,7 +347,7 @@ mod test {
         mock_server_remote
             .register(
                 Mock::given(method("POST"))
-                    .and(path(format!("/subgraphs/id/{}", deployment)))
+                    .and(path(format!("/subgraphs/id/{deployment}")))
                     .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                         "data": {
                             "user": {
@@ -415,7 +412,7 @@ mod test {
         mock_server_local
             .register(
                 Mock::given(method("POST"))
-                    .and(path(format!("/subgraphs/id/{}", deployment)))
+                    .and(path(format!("/subgraphs/id/{deployment}")))
                     .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                         "data": {
                             "user": {
@@ -430,7 +427,7 @@ mod test {
         mock_server_remote
             .register(
                 Mock::given(method("POST"))
-                    .and(path(format!("/subgraphs/id/{}", deployment)))
+                    .and(path(format!("/subgraphs/id/{deployment}")))
                     .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                         "data": {
                             "user": {
@@ -495,7 +492,7 @@ mod test {
         mock_server_local
             .register(
                 Mock::given(method("POST"))
-                    .and(path(format!("/subgraphs/id/{}", deployment)))
+                    .and(path(format!("/subgraphs/id/{deployment}")))
                     .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                         "data": {
                             "user": {
@@ -510,7 +507,7 @@ mod test {
         mock_server_remote
             .register(
                 Mock::given(method("POST"))
-                    .and(path(format!("/subgraphs/id/{}", deployment)))
+                    .and(path(format!("/subgraphs/id/{deployment}")))
                     .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                         "data": {
                             "user": {

--- a/crates/monitor/src/escrow_accounts.rs
+++ b/crates/monitor/src/escrow_accounts.rs
@@ -133,7 +133,7 @@ async fn get_escrow_accounts_v1(
     // payments in the name of the sender.
     let response = escrow_subgraph
         .query::<EscrowAccountQuery, _>(escrow_account::Variables {
-            indexer: format!("{:x?}", indexer_address),
+            indexer: format!("{indexer_address:x?}"),
             thaw_end_timestamp: if reject_thawing_signers {
                 U256::ZERO.to_string()
             } else {

--- a/crates/profiler/src/lib.rs
+++ b/crates/profiler/src/lib.rs
@@ -74,7 +74,7 @@ fn generate_filename(
     // Format the datetime (YYYY-MM-DD-HH_MM_SS)
     let formatted_time = datetime.format("%Y-%m-%d-%H_%M_%S").to_string();
 
-    let filename = format!("{}-{}-{}.{}", prefix, formatted_time, counter, extension);
+    let filename = format!("{prefix}-{formatted_time}-{counter}.{extension}");
     Ok(Path::new(base_path).join(filename))
 }
 

--- a/crates/service/src/metrics.rs
+++ b/crates/service/src/metrics.rs
@@ -52,7 +52,7 @@ pub fn serve_metrics(host_and_port: SocketAddr) {
                         tracing::error!("Error encoding metrics: {}", e);
                         (
                             StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("Error encoding metrics: {}", e),
+                            format!("Error encoding metrics: {e}"),
                         )
                     }
                 }

--- a/crates/service/src/middleware/auth.rs
+++ b/crates/service/src/middleware/auth.rs
@@ -77,7 +77,7 @@ mod tests {
         let mut req = Request::new(Default::default());
         req.headers_mut().insert(
             header::AUTHORIZATION,
-            format!("Bearer {}", BEARER_TOKEN).parse().unwrap(),
+            format!("Bearer {BEARER_TOKEN}").parse().unwrap(),
         );
         let res = service.call(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::OK);

--- a/crates/service/src/middleware/auth/bearer.rs
+++ b/crates/service/src/middleware/auth/bearer.rs
@@ -23,7 +23,7 @@ impl<ResBody> Bearer<ResBody> {
         ResBody: Default,
     {
         Self {
-            header_value: format!("Bearer {}", token)
+            header_value: format!("Bearer {token}")
                 .parse()
                 .expect("token is not a valid header value"),
             _ty: PhantomData,

--- a/crates/service/src/middleware/deployment.rs
+++ b/crates/service/src/middleware/deployment.rs
@@ -55,7 +55,7 @@ mod tests {
         let res = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/{}", deployment))
+                    .uri(format!("/{deployment}"))
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -135,7 +135,7 @@ pub async fn run() -> anyhow::Result<()> {
             additional_networks,
         } = dips;
 
-        let addr = format!("{}:{}", host, port)
+        let addr = format!("{host}:{port}")
             .parse()
             .expect("invalid dips host port");
 

--- a/crates/service/src/tap/receipt_store.rs
+++ b/crates/service/src/tap/receipt_store.rs
@@ -88,7 +88,7 @@ impl InnerContext {
             }
             Err(e) => {
                 // Create error message once
-                let err_msg = format!("Failed to store {} receipts: {}", version, e);
+                let err_msg = format!("Failed to store {version} receipts: {e}");
                 tracing::error!("{}", err_msg);
                 for sender in senders {
                     // Convert to AdapterError for each sender

--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -844,7 +844,7 @@ impl Actor for SenderAccount {
                                         .iter()
                                         .map(|rav| rav.0.to_string())
                                         .collect::<Vec<_>>(),
-                                    sender: format!("{:x?}", sender_id),
+                                    sender: format!("{sender_id:x?}"),
                                 },
                             )
                             .await
@@ -882,7 +882,7 @@ impl Actor for SenderAccount {
                         ))
                     })
                     .filter(|(allocation, _value)| {
-                        !redeemed_ravs_allocation_ids.contains(&format!("{:x?}", allocation))
+                        !redeemed_ravs_allocation_ids.contains(&format!("{allocation:x?}"))
                     })
                     .collect::<HashMap<_, _>>();
 

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -514,7 +514,7 @@ impl State {
             SenderType::Legacy => "legacy:",
             SenderType::Horizon => "horizon:",
         });
-        sender_allocation_id.push_str(&format!("{}", sender));
+        sender_allocation_id.push_str(&format!("{sender}"));
         sender_allocation_id
     }
 

--- a/crates/tap-agent/src/metrics.rs
+++ b/crates/tap-agent/src/metrics.rs
@@ -17,7 +17,7 @@ async fn handler_metrics() -> (StatusCode, String) {
             tracing::error!("Error encoding metrics: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Error encoding metrics: {}", e),
+                format!("Error encoding metrics: {e}"),
             )
         }
     }
@@ -44,7 +44,7 @@ async fn _run_server(port: u16) {
     tracing::debug!("Metrics server stopped");
 
     if let Err(err) = res {
-        panic!("Metrics server error: {:#?}", err);
+        panic!("Metrics server error: {err:#?}");
     };
 }
 

--- a/crates/tap-agent/src/tap/context/escrow.rs
+++ b/crates/tap-agent/src/tap/context/escrow.rs
@@ -17,7 +17,7 @@ impl<T: NetworkVersion + Send + Sync> SignatureChecker for TapAgentContext<T> {
         let sender = escrow_accounts
             .get_sender_for_signer(&signer)
             .map_err(|_| AdapterError::ValidationError {
-                error: format!("Could not find the sender for the signer {}", signer),
+                error: format!("Could not find the sender for the signer {signer}"),
             })?;
         Ok(sender == self.sender)
     }

--- a/crates/tap-agent/src/tap/context/rav.rs
+++ b/crates/tap-agent/src/tap/context/rav.rs
@@ -53,15 +53,13 @@ impl RavRead<ReceiptAggregateVoucher> for TapAgentContext<Legacy> {
                         .try_into()
                         .map_err(|e| AdapterError::RavRead {
                             error: format!(
-                                "Error decoding signature while retrieving RAV from database: {}",
-                                e
+                                "Error decoding signature while retrieving RAV from database: {e}"
                             ),
                         })?;
                 let allocation_id =
                     Address::from_str(&row.allocation_id).map_err(|e| AdapterError::RavRead {
                         error: format!(
-                            "Error decoding allocation_id while retrieving RAV from database: {}",
-                            e
+                            "Error decoding allocation_id while retrieving RAV from database: {e}"
                         ),
                     })?;
                 let timestamp_ns = row.timestamp_ns.to_u64().ok_or(AdapterError::RavRead {
@@ -189,30 +187,26 @@ impl RavRead<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon
                         .try_into()
                         .map_err(|e| AdapterError::RavRead {
                             error: format!(
-                                "Error decoding signature while retrieving RAV from database: {}",
-                                e
+                                "Error decoding signature while retrieving RAV from database: {e}"
                             ),
                         })?;
                 let allocation_id =
                     Address::from_str(&row.allocation_id).map_err(|e| AdapterError::RavRead {
                         error: format!(
-                            "Error decoding allocation_id while retrieving RAV from database: {}",
-                            e
+                            "Error decoding allocation_id while retrieving RAV from database: {e}"
                         ),
                     })?;
 
                 let payer = Address::from_str(&row.payer).map_err(|e| AdapterError::RavRead {
                     error: format!(
-                        "Error decoding payer while retrieving receipt from database: {}",
-                        e
+                        "Error decoding payer while retrieving receipt from database: {e}"
                     ),
                 })?;
 
                 let data_service = Address::from_str(&row.data_service).map_err(|e| {
                     AdapterError::RavRead {
                         error: format!(
-                            "Error decoding data_service while retrieving receipt from database: {}",
-                            e
+                            "Error decoding data_service while retrieving receipt from database: {e}"
                         ),
                     }
                 })?;
@@ -220,8 +214,7 @@ impl RavRead<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon
                 let service_provider = Address::from_str(&row.service_provider).map_err(|e| {
                     AdapterError::RavRead {
                         error: format!(
-                            "Error decoding service_provider while retrieving receipt from database: {}",
-                            e
+                            "Error decoding service_provider while retrieving receipt from database: {e}"
                         ),
                     }
                 })?;

--- a/crates/tap-agent/src/tap/context/receipt.rs
+++ b/crates/tap-agent/src/tap/context/receipt.rs
@@ -87,7 +87,7 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Legacy> {
         let signers = signers_trimmed(self.escrow_accounts.clone(), self.sender)
             .await
             .map_err(|e| AdapterError::ReceiptRead {
-                error: format!("{:?}.", e),
+                error: format!("{e:?}."),
             })?;
 
         let receipts_limit = receipts_limit.map_or(1000, |limit| limit);
@@ -114,15 +114,13 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Legacy> {
                 let signature = record.signature.as_slice().try_into()
                     .map_err(|e| AdapterError::ReceiptRead {
                         error: format!(
-                            "Error decoding signature while retrieving receipt from database: {}",
-                            e
+                            "Error decoding signature while retrieving receipt from database: {e}"
                         ),
                     })?;
                 let allocation_id = Address::from_str(&record.allocation_id).map_err(|e| {
                     AdapterError::ReceiptRead {
                         error: format!(
-                            "Error decoding allocation_id while retrieving receipt from database: {}",
-                            e
+                            "Error decoding allocation_id while retrieving receipt from database: {e}"
                         ),
                     }
                 })?;
@@ -179,7 +177,7 @@ impl ReceiptDelete for TapAgentContext<Legacy> {
         let signers = signers_trimmed(self.escrow_accounts.clone(), self.sender)
             .await
             .map_err(|e| AdapterError::ReceiptDelete {
-                error: format!("{:?}.", e),
+                error: format!("{e:?}."),
             })?;
 
         sqlx::query!(
@@ -217,7 +215,7 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
         let signers = signers_trimmed(self.escrow_accounts.clone(), self.sender)
             .await
             .map_err(|e| AdapterError::ReceiptRead {
-                error: format!("{:?}.", e),
+                error: format!("{e:?}."),
             })?;
 
         // TODO filter by data_service when we have multiple data services
@@ -259,23 +257,20 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
                 let signature = record.signature.as_slice().try_into()
                     .map_err(|e| AdapterError::ReceiptRead {
                         error: format!(
-                            "Error decoding signature while retrieving receipt from database: {}",
-                            e
+                            "Error decoding signature while retrieving receipt from database: {e}"
                         ),
                     })?;
                 let allocation_id = Address::from_str(&record.allocation_id).map_err(|e| {
                     AdapterError::ReceiptRead {
                         error: format!(
-                            "Error decoding allocation_id while retrieving receipt from database: {}",
-                            e
+                            "Error decoding allocation_id while retrieving receipt from database: {e}"
                         ),
                     }
                 })?;
                 let payer = Address::from_str(&record.payer).map_err(|e| {
                     AdapterError::ReceiptRead {
                         error: format!(
-                            "Error decoding payer while retrieving receipt from database: {}",
-                            e
+                            "Error decoding payer while retrieving receipt from database: {e}"
                         ),
                     }
                 })?;
@@ -283,8 +278,7 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
                 let data_service = Address::from_str(&record.data_service).map_err(|e| {
                     AdapterError::ReceiptRead {
                         error: format!(
-                            "Error decoding data_service while retrieving receipt from database: {}",
-                            e
+                            "Error decoding data_service while retrieving receipt from database: {e}"
                         ),
                     }
                 })?;
@@ -292,8 +286,7 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
                 let service_provider = Address::from_str(&record.service_provider).map_err(|e| {
                     AdapterError::ReceiptRead {
                         error: format!(
-                            "Error decoding service_provider while retrieving receipt from database: {}",
-                            e
+                            "Error decoding service_provider while retrieving receipt from database: {e}"
                         ),
                     }
                 })?;
@@ -354,7 +347,7 @@ impl ReceiptDelete for TapAgentContext<Horizon> {
         let signers = signers_trimmed(self.escrow_accounts.clone(), self.sender)
             .await
             .map_err(|e| AdapterError::ReceiptDelete {
-                error: format!("{:?}.", e),
+                error: format!("{e:?}."),
             })?;
 
         sqlx::query!(

--- a/crates/tap-agent/src/test.rs
+++ b/crates/tap-agent/src/test.rs
@@ -639,7 +639,7 @@ pub async fn store_rav(
 // TODO use static and check for possible errors with connection refused
 pub async fn get_grpc_url() -> String {
     let (_, addr) = create_grpc_aggregator().await;
-    format!("http://{}", addr)
+    format!("http://{addr}")
 }
 
 /// Function to start a aggregator server for testing
@@ -962,7 +962,7 @@ pub mod actors {
         let (mock_sender_allocation, triggered_rav_request, next_unaggregated_fees) =
             MockSenderAllocation::new_with_triggered_rav_request(sender_actor);
 
-        let name = format!("{}:{}:{}", prefix, sender, allocation);
+        let name = format!("{prefix}:{sender}:{allocation}");
         let (sender_account, _) =
             MockSenderAllocation::spawn(Some(name), mock_sender_allocation, ())
                 .await

--- a/integration-tests/src/load_test.rs
+++ b/integration-tests/src/load_test.rs
@@ -59,7 +59,7 @@ pub async fn receipt_handler_load_test(num_receipts: usize, concurrency: usize) 
                 // Check if the send was Ok
                 if let Err(e) = send_result {
                     failed_sends += 1;
-                    eprintln!("Receipt {} failed to send: {:?}", index, e); // Log the specific error
+                    eprintln!("Receipt {index} failed to send: {e:?}"); // Log the specific error
                 } else {
                     successful_sends += 1;
                 }
@@ -67,27 +67,21 @@ pub async fn receipt_handler_load_test(num_receipts: usize, concurrency: usize) 
             Err(join_error) => {
                 // The task panicked or was cancelled
                 failed_sends += 1;
-                eprintln!(
-                    "Receipt {} task execution failed (e.g., panic): {:?}",
-                    index, join_error
-                );
+                eprintln!("Receipt {index} task execution failed (e.g., panic): {join_error:?}");
             }
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "Completed processing {} requests in {:?}",
-        num_receipts, duration
-    );
+    println!("Completed processing {num_receipts} requests in {duration:?}");
     if num_receipts > 0 {
         println!(
             "Average time per request: {:?}",
             duration / num_receipts as u32
         );
     }
-    println!("Successfully sent receipts: {}", successful_sends);
-    println!("Failed receipts: {}", failed_sends);
+    println!("Successfully sent receipts: {successful_sends}");
+    println!("Failed receipts: {failed_sends}");
 
     if failed_sends > 0 {
         return Err(anyhow::anyhow!(
@@ -115,7 +109,7 @@ async fn create_and_send_receipts(
     let receipt_json = serde_json::to_string(&receipt).unwrap();
     let response = create_request(
         &http_client,
-        format!("{}/subgraphs/id/{}", INDEXER_URL, SUBGRAPH_ID).as_str(),
+        format!("{INDEXER_URL}/subgraphs/id/{SUBGRAPH_ID}").as_str(),
         &receipt_json,
         &json!({
             "query": "{ _meta { block { number } } }"

--- a/integration-tests/src/metrics.rs
+++ b/integration-tests/src/metrics.rs
@@ -28,17 +28,17 @@ impl MetricsData {
     // the allocation_id is not exactly the key
     // allocation="0xE8B99E1fD28791fefd421aCB081a8c31Da6f10DA",sender="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
     pub fn ravs_created_by_allocation(&self, allocation_id: &str) -> u32 {
-        let key = format!("allocation=\"{}\"", allocation_id);
+        let key = format!("allocation=\"{allocation_id}\"");
         get_value(&self.ravs_created, &key)
     }
 
     pub fn _ravs_created_by_sender(&self, sender: &str) -> u32 {
-        let key = format!("sender=\"{}\"", sender);
+        let key = format!("sender=\"{sender}\"");
         get_value(&self.ravs_created, &key)
     }
 
     pub fn unaggregated_fees_by_allocation(&self, allocation_id: &str) -> f64 {
-        let key = format!("allocation=\"{}\"", allocation_id);
+        let key = format!("allocation=\"{allocation_id}\"");
         get_value(&self.unaggregated_fees, &key)
     }
 }
@@ -120,9 +120,9 @@ fn parse_metric_line(line: &str, map: &mut HashMap<String, f64>) {
                     if !map.contains_key(&key) || map[&key] != value {
                         if map.contains_key(&key) {
                             let old_value = map[&key];
-                            println!("📈 Metric changed: {} ({} → {})", key, old_value, value);
+                            println!("📈 Metric changed: {key} ({old_value} → {value})");
                         } else {
-                            println!("📈 New metric: {} = {}", key, value);
+                            println!("📈 New metric: {key} = {value}");
                         }
                         map.insert(key, value);
                     }

--- a/integration-tests/src/rav_tests.rs
+++ b/integration-tests/src/rav_tests.rs
@@ -47,8 +47,7 @@ pub async fn test_tap_rav_v1() -> Result<()> {
         initial_metrics.unaggregated_fees_by_allocation(&allocation_id.to_string());
 
     println!(
-        "\n=== Initial metrics: RAVs created: {}, Unaggregated fees: {} ===",
-        initial_ravs_created, initial_unaggregated
+        "\n=== Initial metrics: RAVs created: {initial_ravs_created}, Unaggregated fees: {initial_unaggregated} ==="
     );
 
     println!("\n=== STAGE 1: Sending large receipt batches with small pauses ===");
@@ -65,9 +64,9 @@ pub async fn test_tap_rav_v1() -> Result<()> {
 
         for i in 0..NUM_RECEIPTS {
             let response = http_client
-                .post(format!("{}/api/subgraphs/id/{}", GATEWAY_URL, SUBGRAPH_ID))
+                .post(format!("{GATEWAY_URL}/api/subgraphs/id/{SUBGRAPH_ID}"))
                 .header("Content-Type", "application/json")
-                .header("Authorization", format!("Bearer {}", GATEWAY_API_KEY))
+                .header("Authorization", format!("Bearer {GATEWAY_API_KEY}"))
                 .json(&json!({
                     "query": "{ _meta { block { number } } }"
                 }))
@@ -112,9 +111,9 @@ pub async fn test_tap_rav_v1() -> Result<()> {
         println!("Sending trigger query {}/{}...", i + 1, MAX_TRIGGERS);
 
         let response = http_client
-            .post(format!("{}/api/subgraphs/id/{}", GATEWAY_URL, SUBGRAPH_ID))
+            .post(format!("{GATEWAY_URL}/api/subgraphs/id/{SUBGRAPH_ID}"))
             .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {}", GATEWAY_API_KEY))
+            .header("Authorization", format!("Bearer {GATEWAY_API_KEY}"))
             .json(&json!({
                 "query": "{ _meta { block { number } } }"
             }))
@@ -151,23 +150,21 @@ pub async fn test_tap_rav_v1() -> Result<()> {
         // If we've succeeded, exit early
         if current_ravs_created > initial_ravs_created {
             println!(
-                "✅ TEST PASSED: RAVs created increased from {} to {}!",
-                initial_ravs_created, current_ravs_created
+                "✅ TEST PASSED: RAVs created increased from {initial_ravs_created} to {current_ravs_created}!"
             );
             return Ok(());
         }
 
         if current_unaggregated < initial_unaggregated * 0.9 {
             println!(
-                "✅ TEST PASSED: Unaggregated fees decreased significantly from {} to {}!",
-                initial_unaggregated, current_unaggregated
+                "✅ TEST PASSED: Unaggregated fees decreased significantly from {initial_unaggregated} to {current_unaggregated}!"
             );
             return Ok(());
         }
     }
 
     println!("\n=== Summary ===");
-    println!("Total queries sent successfully: {}", total_successful);
+    println!("Total queries sent successfully: {total_successful}");
 
     // If we got here, test failed
     println!("❌ TEST FAILED: No RAV generation detected");
@@ -182,7 +179,7 @@ pub async fn test_invalid_chain_id() -> Result<()> {
     let allocation_id = find_allocation(http_client.clone(), GRAPH_URL).await?;
 
     let allocation_id = Address::from_str(&allocation_id)?;
-    println!("Found allocation ID: {}", allocation_id);
+    println!("Found allocation ID: {allocation_id}");
 
     let receipt = create_tap_receipt(
         MAX_RECEIPT_VALUE,
@@ -195,7 +192,7 @@ pub async fn test_invalid_chain_id() -> Result<()> {
     let receipt_json = serde_json::to_string(&receipt).unwrap();
     let response = create_request(
         &http_client,
-        format!("{}/subgraphs/id/{}", INDEXER_URL, SUBGRAPH_ID).as_str(),
+        format!("{INDEXER_URL}/subgraphs/id/{SUBGRAPH_ID}").as_str(),
         &receipt_json,
         &json!({
             "query": "{ _meta { block { number } } }"


### PR DESCRIPTION
If you update your Rust version with `rustup update` you'll start getting a lot of warnings, which this takes care of 👍 

Signed off by Joseph Livesey <joseph@semiotic.ai>