### PR TITLE
ci: add release-please concurrency settings

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -13,6 +13,10 @@ env:
 
 jobs:
   release-please:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    concurrency:
+      group: release-please-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write
@@ -31,6 +35,7 @@ jobs:
   builds-linux:
     runs-on: ubuntu-latest
     needs: release-please
+    if: always() && (needs.release-please.result == 'success' || needs.release-please.result == 'skipped')
     strategy:
       matrix:
         target: [indexer-service-rs, indexer-tap-agent]


### PR DESCRIPTION
## 🔧 Summary

This PR fixes CI workflow issues that were preventing `release-please` from running correctly

---

### ✅ Changes

#### 1. Concurrency Control for `release-please`

- Ensures only **one** `release-please` job runs at a time
- **Newer runs cancel older ones** to prevent race conditions
- Hopefully 🤞fixes `"Error updating ref"` permission errors

#### 2. Scope Limited to `main` Branch

- `release-please` now only runs on **pushes to `main`**
- Prevents it from running on pull requests
- Matches expected behavior: **releases are created from `main` only**

#### 3. Fixed PR Build Checks

- Added conditional logic to `builds-linux` job
- Ensures builds run even if `release-please` is skipped

---
Signed off by Joseph Livesey <joseph@semiotic.ai>
