### PR TITLE
ci: revert "ci: use release token for release (#791)"

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -30,7 +30,7 @@ jobs:
         id: release-please
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   builds-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit f686a5a3b2eeb319011694d206b898a2b1962e35.

I don't understand the issue with release-please and the RELEASE_TOKEN Edge & Node provided but for now working around using the GITHUB_TOKEN and being able to release is more important while we figure a longer term solution out.