### PR TITLE
fix(build): enable ractor tokio-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6221,19 +6221,22 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "ractor"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164cbdac94cb8f5c3bbb031f959643619e7e74f13d94381d69ba6161640f063e"
+checksum = "4234001d2c56c95d57fa4ee5fb8d40bd3a4c217c6bfcd6655f38e5cadfb3e230"
 dependencies = [
  "async-trait",
  "bon 2.3.0",
  "dashmap",
  "futures",
+ "js-sys",
  "once_cell",
  "strum 0.26.3",
  "tokio",
  "tokio_with_wasm",
  "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-time",
 ]
 
@@ -8502,6 +8505,7 @@ dependencies = [
  "slab",
  "socket2 0.6.0",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,9 @@ jsonrpsee = { version = "0.24.0", features = ["http-client", "tracing"] }
 prometheus = "0.13.3"
 prost = "0.13.4"
 prost-types = "0.13.3"
-ractor = { version = "=0.15.6", features = [
+ractor = { version = "0.15.7", features = [
     "async-trait",
+    "tokio_runtime",
 ], default-features = false }
 rand = "0.9.0"
 reqwest = { version = "0.12", features = [


### PR DESCRIPTION
Fixes a breaking change from `ractor` 0.15.6 to 0.15.7 that requires `tokio_runtime` to be enabled.

---
Signed off by Joseph Livesey <joseph@semiotic.ai>