### PR TITLE
test: use gateway in local network testing

### DIFF
--- a/contrib/indexer-service/start.sh
+++ b/contrib/indexer-service/start.sh
@@ -69,7 +69,7 @@ receipts_verifier_address = "${GRAPH_TALLY_VERIFIER}"
 
 [service]
 free_query_auth_token = "freestuff"
-host_and_port = "0.0.0.0:7600"
+host_and_port = "0.0.0.0:7601"
 url_prefix = "/"
 serve_network_subgraph = false
 serve_escrow_subgraph = false

--- a/integration-tests/src/constants.rs
+++ b/integration-tests/src/constants.rs
@@ -17,6 +17,9 @@ pub const TAP_AGENT_METRICS_URL: &str = "http://localhost:7300/metrics";
 // and the signing key account0_secret
 // they must match otherwise receipts would be rejected
 pub const TAP_VERIFIER_CONTRACT: &str = "0xC9a43158891282A2B1475592D5719c001986Aaec";
+
+// V2 GraphTallyCollector contract address (for Horizon receipts)
+pub const GRAPH_TALLY_COLLECTOR_CONTRACT: &str = "0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07";
 pub const ACCOUNT0_SECRET: &str =
     "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 pub const CHAIN_ID: u64 = 1337;

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -5,6 +5,7 @@ mod constants;
 mod load_test;
 mod metrics;
 mod rav_tests;
+mod signature_test;
 mod utils;
 
 use anyhow::Result;
@@ -39,6 +40,9 @@ enum Commands {
         #[clap(long, short, value_parser)]
         num_receipts: usize,
     },
+
+    #[clap(name = "debug")]
+    Debug,
 }
 
 #[tokio::main]
@@ -64,6 +68,10 @@ async fn main() -> Result<()> {
         Commands::LoadServiceV2 { num_receipts } => {
             let concurrency = num_cpus::get();
             receipt_handler_load_test_v2(num_receipts, concurrency).await?;
+        }
+        // cargo run -- debug
+        Commands::Debug => {
+            signature_test::test_v2_signature_recovery().await?;
         }
     }
 

--- a/integration-tests/src/rav_tests.rs
+++ b/integration-tests/src/rav_tests.rs
@@ -21,12 +21,12 @@ use crate::{
 };
 
 const WAIT_TIME_BATCHES: u64 = 40;
-const NUM_RECEIPTS: u32 = 3;
+const NUM_RECEIPTS: u32 = 30; // Increased to 30 receipts per batch
 
 // Send receipts in batches with a delay in between
 // to ensure some receipts get outside the timestamp buffer
-const BATCHES: u32 = 2;
-const MAX_TRIGGERS: usize = 100;
+const BATCHES: u32 = 15; // Increased to 15 batches for total 450 receipts in Stage 1
+const MAX_TRIGGERS: usize = 200; // Increased trigger attempts to 200
 
 // Function to test the tap RAV generation
 pub async fn test_tap_rav_v1() -> Result<()> {
@@ -241,17 +241,23 @@ pub async fn test_tap_rav_v2() -> Result<()> {
         "\n=== V2 Initial metrics: RAVs created: {initial_ravs_created}, Unaggregated fees: {initial_unaggregated} ==="
     );
 
+    // Calculate expected thresholds
+    let trigger_threshold = 2_000_000_000_000_000u128; // 0.002 GRT trigger value
+    let receipts_needed = trigger_threshold / (MAX_RECEIPT_VALUE / 10); // Using trigger receipt value
+    println!("📊 RAV trigger threshold: {trigger_threshold} wei (0.002 GRT)",);
+    let receipt_value = MAX_RECEIPT_VALUE / 10;
+    println!(
+        "📊 Receipts needed for trigger: ~{receipts_needed} receipts at {receipt_value} wei each",
+    );
+
     println!("\n=== V2 STAGE 1: Sending large receipt batches with small pauses ===");
 
     // Send multiple V2 receipts in two batches with a gap between them
     let mut total_successful = 0;
 
     for batch in 0..BATCHES {
-        println!(
-            "Sending V2 batch {} of 2 with {} receipts each...",
-            batch + 1,
-            NUM_RECEIPTS
-        );
+        let batch = batch + 1;
+        println!("Sending V2 batch {batch} of {BATCHES} with {NUM_RECEIPTS} receipts each...",);
 
         for i in 0..NUM_RECEIPTS {
             // Create V2 receipt
@@ -267,16 +273,17 @@ pub async fn test_tap_rav_v2() -> Result<()> {
 
             let receipt_encoded = encode_v2_receipt(&receipt)?;
 
-            let response = create_request(
-                &http_client,
-                &format!("{INDEXER_URL}/subgraphs/id/{SUBGRAPH_ID}"),
-                &receipt_encoded,
-                &json!({
+            let response = http_client
+                .post(format!("{GATEWAY_URL}/api/subgraphs/id/{SUBGRAPH_ID}"))
+                .header("Content-Type", "application/json")
+                .header("Authorization", format!("Bearer {GATEWAY_API_KEY}"))
+                .header("Tap-Receipt", receipt_encoded)
+                .json(&json!({
                     "query": "{ _meta { block { number } } }"
-                }),
-            )
-            .send()
-            .await?;
+                }))
+                .timeout(Duration::from_secs(10))
+                .send()
+                .await?;
 
             if response.status().is_success() {
                 total_successful += 1;
@@ -298,15 +305,22 @@ pub async fn test_tap_rav_v2() -> Result<()> {
 
         // Check metrics after batch
         let batch_metrics = metrics_checker.get_current_metrics().await?;
+        let current_unaggregated =
+            batch_metrics.unaggregated_fees_by_allocation(&allocation_id.to_string());
+        let trigger_threshold = 2_000_000_000_000_000u128;
+        let progress_pct =
+            (current_unaggregated as f64 / trigger_threshold as f64 * 100.0).min(100.0);
+
         println!(
-            "After V2 batch {}: RAVs created: {}, Unaggregated fees: {}",
+            "After V2 batch {}: RAVs created: {}, Unaggregated fees: {} ({:.1}% of trigger threshold)",
             batch + 1,
             batch_metrics.ravs_created_by_allocation(&allocation_id.to_string()),
-            batch_metrics.unaggregated_fees_by_allocation(&allocation_id.to_string())
+            current_unaggregated,
+            progress_pct
         );
 
         // Wait between batches - long enough for first batch to exit buffer
-        if batch < 1 {
+        if batch < BATCHES - 1 {
             println!("Waiting for buffer period + 5s...");
             tokio::time::sleep(Duration::from_secs(WAIT_TIME_BATCHES)).await;
         }
@@ -331,16 +345,17 @@ pub async fn test_tap_rav_v2() -> Result<()> {
 
         let receipt_encoded = encode_v2_receipt(&receipt)?;
 
-        let response = create_request(
-            &http_client,
-            &format!("{INDEXER_URL}/subgraphs/id/{SUBGRAPH_ID}"),
-            &receipt_encoded,
-            &json!({
+        let response = http_client
+            .post(format!("{GATEWAY_URL}/api/subgraphs/id/{SUBGRAPH_ID}"))
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {GATEWAY_API_KEY}"))
+            .header("Tap-Receipt", receipt_encoded)
+            .json(&json!({
                 "query": "{ _meta { block { number } } }"
-            }),
-        )
-        .send()
-        .await?;
+            }))
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await?;
 
         if response.status().is_success() {
             total_successful += 1;
@@ -361,11 +376,17 @@ pub async fn test_tap_rav_v2() -> Result<()> {
         let current_unaggregated =
             current_metrics.unaggregated_fees_by_allocation(&allocation_id.to_string());
 
+        // Calculate progress toward trigger threshold
+        let trigger_threshold = 2_000_000_000_000_000u128;
+        let progress_pct =
+            (current_unaggregated as f64 / trigger_threshold as f64 * 100.0).min(100.0);
+
         println!(
-            "After V2 trigger {}: RAVs created: {}, Unaggregated fees: {}",
+            "After V2 trigger {}: RAVs created: {}, Unaggregated fees: {} ({:.1}% of trigger threshold)",
             i + 1,
             current_ravs_created,
-            current_unaggregated
+            current_unaggregated,
+            progress_pct
         );
 
         // If we've succeeded, exit early

--- a/integration-tests/src/signature_test.rs
+++ b/integration-tests/src/signature_test.rs
@@ -1,0 +1,70 @@
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test to verify V2 signature creation and recovery works correctly
+
+use anyhow::Result;
+use std::str::FromStr;
+use tap_core::{signed_message::Eip712SignedMessage, tap_eip712_domain};
+use tap_graph::v2::Receipt as V2Receipt;
+use thegraph_core::{
+    alloy::{primitives::Address, signers::local::PrivateKeySigner},
+    CollectionId,
+};
+
+use crate::constants::{
+    ACCOUNT0_SECRET, CHAIN_ID, GRAPH_TALLY_COLLECTOR_CONTRACT, TEST_DATA_SERVICE,
+};
+
+pub async fn test_v2_signature_recovery() -> Result<()> {
+    println!("=== V2 Signature Recovery Test ===");
+
+    let wallet: PrivateKeySigner = ACCOUNT0_SECRET.parse()?;
+    let wallet_address = wallet.address();
+    println!("Wallet address: {wallet_address:?}");
+
+    // Create EIP-712 domain - V2 uses GraphTallyCollector
+    let domain = tap_eip712_domain(CHAIN_ID, Address::from_str(GRAPH_TALLY_COLLECTOR_CONTRACT)?);
+    println!("Using domain: chain_id={CHAIN_ID}, verifier={GRAPH_TALLY_COLLECTOR_CONTRACT}");
+
+    // Create a V2 receipt
+    let allocation_id = Address::from_str("0xc172ed1c6470dfa3b12a789317dda50cdd8b85df")?;
+    let collection_id = CollectionId::from(allocation_id);
+    let payer = wallet_address;
+    let service_provider = allocation_id;
+    let data_service = Address::from_str(TEST_DATA_SERVICE)?;
+
+    println!("V2 Receipt parameters:");
+    println!("  Collection ID: {collection_id:?}");
+    println!("  Payer: {payer:?}");
+    println!("  Service provider: {service_provider:?}");
+    println!("  Data service: {data_service:?}");
+
+    let receipt = V2Receipt::new(
+        *collection_id,
+        payer,
+        data_service,
+        service_provider,
+        100_000_000_000_000_000u128, // 0.1 GRT
+    )?;
+
+    // Sign the receipt
+    let signed_receipt = Eip712SignedMessage::new(&domain, receipt, &wallet)?;
+    println!("Receipt signed successfully");
+
+    // Recover the signer
+    let recovered_signer = signed_receipt.recover_signer(&domain)?;
+    println!("Recovered signer: {recovered_signer:?}");
+    println!("Expected signer: {wallet_address:?}");
+
+    // Check if they match
+    if recovered_signer == wallet_address {
+        println!("✅ SUCCESS: Signature recovery matches wallet address");
+        Ok(())
+    } else {
+        println!("❌ FAILURE: Signature recovery mismatch!");
+        println!("  Expected: {wallet_address:?}");
+        println!("  Got:      {recovered_signer:?}");
+        Err(anyhow::anyhow!("Signature recovery failed for V2 receipt"))
+    }
+}

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -19,7 +19,7 @@ use tap_graph::Receipt;
 use thegraph_core::alloy::{primitives::Address, signers::local::PrivateKeySigner};
 use thegraph_core::CollectionId;
 
-use crate::constants::TEST_DATA_SERVICE;
+use crate::constants::{GRAPH_TALLY_COLLECTOR_CONTRACT, TEST_DATA_SERVICE};
 
 pub fn create_tap_receipt(
     value: u128,
@@ -58,8 +58,8 @@ pub fn create_tap_receipt(
 
 pub fn create_tap_receipt_v2(
     value: u128,
-    allocation_id: &Address, // Used to derive collection_id in V2
-    verifier_contract: &str,
+    allocation_id: &Address,  // Used to derive collection_id in V2
+    _verifier_contract: &str, // V2 uses GraphTallyCollector, not TAPVerifier
     chain_id: u64,
     wallet: &PrivateKeySigner,
     payer: &Address,
@@ -77,12 +77,21 @@ pub fn create_tap_receipt_v2(
     // For the migration period, we derive collection_id from allocation_id
     let collection_id = CollectionId::from(*allocation_id);
 
-    // Create domain separator
+    // Create domain separator - V2 uses GraphTallyCollector
     let eip712_domain_separator =
-        tap_eip712_domain(chain_id, Address::from_str(verifier_contract)?);
+        tap_eip712_domain(chain_id, Address::from_str(GRAPH_TALLY_COLLECTOR_CONTRACT)?);
 
+    let wallet_address = wallet.address();
     // Create and sign V2 receipt
     println!("Creating and signing V2 receipt...");
+    println!("V2 Receipt details:");
+    println!("  Payer (from wallet): {payer:?}");
+    println!("  Service provider: {service_provider:?}");
+    println!("  Data service: {TEST_DATA_SERVICE}");
+    println!("  Collection ID: {collection_id:?}");
+    println!("  Wallet address: {wallet_address:?}");
+    println!("  Using GraphTallyCollector: {GRAPH_TALLY_COLLECTOR_CONTRACT}");
+
     let receipt = Eip712SignedMessage::new(
         &eip712_domain_separator,
         tap_graph::v2::Receipt {

--- a/setup-test-network.sh
+++ b/setup-test-network.sh
@@ -260,11 +260,26 @@ source local-network/.env
 docker build -t local-gateway:latest ./local-network/gateway
 
 echo "Running gateway container..."
-# Updated to use the horizon file structure
+# Verify required files exist before starting gateway
+if [ ! -f "local-network/horizon.json" ]; then
+    echo "ERROR: local-network/horizon.json not found!"
+    exit 1
+fi
+if [ ! -f "local-network/tap-contracts.json" ]; then
+    echo "ERROR: local-network/tap-contracts.json not found!"
+    exit 1
+fi
+if [ ! -f "local-network/subgraph-service.json" ]; then
+    echo "ERROR: local-network/subgraph-service.json not found!"
+    exit 1
+fi
+
+# Updated to use the horizon file structure and include tap-contracts.json
 docker run -d --name gateway \
     --network local-network_default \
     -p 7700:7700 \
     -v "$(pwd)/local-network/horizon.json":/opt/horizon.json:ro \
+    -v "$(pwd)/local-network/tap-contracts.json":/opt/tap-contracts.json:ro \
     -v "$(pwd)/local-network/subgraph-service.json":/opt/subgraph-service.json:ro \
     -v "$(pwd)/local-network/.env":/opt/.env:ro \
     -e RUST_LOG=info,graph_gateway=trace \


### PR DESCRIPTION
This integrates the gateway into the local testing infra using local-network.

The indexer service was listening internally in the tests on a different port. We now handle channel closures instead of panicking. We're still debugging issues around receipts and signing when running the local network, so we've added debug logging for those processes. And then this works on our testing infra to integrate testing the gateway in the local testing setup.

**NOTE**: you still need to restart the indexer-service and tap-agent after `just setup` completes

---
Signed off by Joseph Livesey <joseph@semiotic.ai>