### PR TITLE
Store full CollectionId in V2 receipt database records

### DIFF
--- a/crates/service/src/tap/receipt_store.rs
+++ b/crates/service/src/tap/receipt_store.rs
@@ -345,9 +345,9 @@ impl DbReceiptV2 {
         receipt: &tap_graph::v2::SignedReceipt,
         separator: &Eip712Domain,
     ) -> anyhow::Result<Self> {
-        let collection_id = thegraph_core::CollectionId::from(receipt.message.collection_id)
-            .as_address()
-            .encode_hex();
+        let collection_id =
+            thegraph_core::CollectionId::from(receipt.message.collection_id).encode_hex();
+
         let payer = receipt.message.payer.encode_hex();
         let data_service = receipt.message.data_service.encode_hex();
         let service_provider = receipt.message.service_provider.encode_hex();


### PR DESCRIPTION
The indexer-service was incorrectly storing V2 (Horizon) receipt CollectionId values in the
database by truncating them from 32 bytes to 20 bytes. This caused TAP agent database notification
parsing to fail.

### Root Cause:
In `crates/service/src/tap/receipt_store.rs:348-350, the DbReceiptV2::from_receipt()` function was
calling `.as_address()` on the CollectionId before encoding:

```
let collection_id = thegraph_core::CollectionId::from(receipt.message.collection_id)
    .as_address()  // ❌ This truncates 32-byte CollectionId to 20-byte address
    .encode_hex();
```

### Solution

Remove `.as_address()` call to store the full 32-byte CollectionId

      
Is this correct?