### PR TITLE
feat: support multiple operator mnemonics for attestation signing

### DIFF
--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -22,7 +22,21 @@
 
 [indexer]
 indexer_address = "0x1111111111111111111111111111111111111111"
+# Single operator mnemonic (for most setups)
 operator_mnemonic = "celery smart tip orange scare van steel radio dragon joy alarm crane"
+# For key rotation or migration, you can specify multiple mnemonics.
+# All configured mnemonics are tried when creating attestation signers,
+# allowing allocations created with different operator keys to work.
+#
+# Notes:
+# - The first mnemonic (from operator_mnemonic, or first in operator_mnemonics)
+#   is used as the "primary" identity shown on the /info endpoint.
+# - Both fields can be used together; duplicates are automatically ignored.
+# - Order matters: put your current/primary mnemonic first.
+#
+# operator_mnemonics = [
+#     "previous mnemonic phrase here if you rotated keys"
+# ]
 
 [metrics]
 # Port to serve metrics. This one should stay private.

--- a/crates/config/minimal-config-example.toml
+++ b/crates/config/minimal-config-example.toml
@@ -12,7 +12,13 @@
 
 [indexer]
 indexer_address = "0x1111111111111111111111111111111111111111"
+# Single operator mnemonic (for most setups)
 operator_mnemonic = "celery smart tip orange scare van steel radio dragon joy alarm crane"
+# For key rotation or migration, you can specify multiple mnemonics:
+# operator_mnemonics = [
+#     "celery smart tip orange scare van steel radio dragon joy alarm crane",
+#     "previous mnemonic phrase here if you rotated keys"
+# ]
 
 [database]
 # The URL of the Postgres database used for the indexer components. The same database

--- a/crates/service/src/middleware/attestation_signer.rs
+++ b/crates/service/src/middleware/attestation_signer.rs
@@ -61,7 +61,7 @@ mod tests {
         let (_, dispute_manager_rx) = watch::channel(DISPUTE_MANAGER_ADDRESS);
         let attestation_signers = attestation_signers(
             allocations_rx,
-            INDEXER_MNEMONIC.clone(),
+            vec![INDEXER_MNEMONIC.clone()],
             1,
             dispute_manager_rx,
         );

--- a/crates/service/tests/router_test.rs
+++ b/crates/service/tests/router_test.rs
@@ -74,7 +74,8 @@ async fn full_integration_test() {
         })
         .indexer(IndexerConfig {
             indexer_address: test_assets::INDEXER_ADDRESS,
-            operator_mnemonic: test_assets::INDEXER_MNEMONIC.clone(),
+            operator_mnemonic: Some(test_assets::INDEXER_MNEMONIC.clone()),
+            operator_mnemonics: None,
         })
         .service(indexer_config::ServiceConfig {
             serve_network_subgraph: false,


### PR DESCRIPTION
Add support for configuring multiple operator mnemonics to fix 'no attestation' errors for allocations created with different operator keys (e.g., after key rotation or migration).

Changes:
- Add  config field alongside existing
- Update attestation signer to try all configured mnemonics when deriving wallet for an allocation
- Maintain full backward compatibility - existing configs work unchanged

---
Signed off by Joseph Livesey <joseph@semiotic.ai>