### PR TITLE
fix: incorrect data_service in Horizon RAV reconciliation query

### DIFF
--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -989,9 +989,10 @@ impl Actor for SenderAccount {
                                 .collect();
 
                             if !collection_ids.is_empty() {
-                                // For V2, use the indexer address as the data service since the indexer
-                                // is providing the data service for the queries
-                                let data_service = config.indexer_address;
+                                // For V2/Horizon: data_service must be the SubgraphService address to match
+                                // on-chain RAV lookups (service_provider is the indexer address)
+                                let data_service =
+                                    config.tap_mode.require_subgraph_service_address();
 
                                 match escrow_subgraph
                                     .query::<LatestRavs, _>(latest_ravs_v2::Variables {


### PR DESCRIPTION
### Problem

  The reconciliation logic for Horizon/V2 was using `indexer_address` as the `data_service` parameter when querying the Escrow Subgraph for latest RAVs.
  This is inconsistent with the rest of the codebase and the on-chain data structure, where `data_service` represents the **SubgraphService** address.

  This caused the reconciliation query to return empty results, preventing proper detection of already-redeemed RAVs.

### Solution

  Changed `sender_account.rs:994` to use `config.tap_mode.require_subgraph_service_address()` instead of `config.indexer_address`, making it consistent
  with:
  - RAV storage logic (`tap/context/rav.rs:176`)
  - Receipt/RAV database lookups (`sender_accounts_manager.rs:874, 950`)
  - Receipt validation (`service/tap/checks/data_service_check.rs`)

### Impact
  - Reconciliation now correctly queries on-chain RAV records
  - Prevents potential double-redemption attempts
  - Maintains data consistency across the entire V2/Horizon flow
