### PR TITLE
chore: add audit scope tags for Horizon security review

### DIFF
--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -23,7 +23,7 @@ pub fn derive_key_pair(
     deployment: &DeploymentId,
     index: u64,
 ) -> Result<PrivateKeySigner, anyhow::Error> {
-    // Try the original method first for backward compatibility
+    // V1_LEGACY: Out of scope for Horizon security audit - Try the original method first for backward compatibility
     match derive_key_pair_v1(indexer_mnemonic, epoch, deployment, index) {
         Ok(wallet) => Ok(wallet),
         Err(e) => {
@@ -40,6 +40,7 @@ pub fn derive_key_pair(
     }
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit
 /// Original derivation method - kept for backward compatibility
 fn derive_key_pair_v1(
     indexer_mnemonic: &str,
@@ -306,6 +307,7 @@ fn wallet_for_allocation_multi(
     ))
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit - Tests for V1 derivation and backward compatibility
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -325,6 +327,7 @@ mod tests {
 
     const INDEXER_OPERATOR_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
+    // V1_LEGACY: Test for V1 derivation path analysis
     #[test]
     fn test_deployment_bytes_analysis() {
         let deployment = DeploymentId::from_str(
@@ -460,6 +463,7 @@ mod tests {
         );
     }
 
+    // V1_LEGACY: Test for V1 to V2 fallback behavior
     #[test]
     fn test_v2_fallback_for_long_paths() {
         // Test the problematic deployment from the original error logs
@@ -532,6 +536,7 @@ mod tests {
         }
     }
 
+    // V1_LEGACY: Test for debugging V1 allocation failures
     #[test]
     fn test_specific_failing_allocation() {
         // Test the specific allocation that's failing in the logs
@@ -594,6 +599,7 @@ mod tests {
         println!("This suggests the allocation was created with different parameters or mnemonic");
     }
 
+    // V1_LEGACY: Test for debugging V1 allocation derivation
     #[test]
     fn test_debug_allocation_derivation() {
         let mnemonic = "test test test test test test test test test test test zero";

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -716,6 +716,7 @@ pub struct RavRequestConfig {
 /// [blockchain]
 /// subgraph_service_address = "0x..."
 /// ```
+// SHARED: V1 + V2 common code
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum TapMode {

--- a/crates/indexer-receipt/src/lib.rs
+++ b/crates/indexer-receipt/src/lib.rs
@@ -15,12 +15,14 @@ use thegraph_core::alloy::{
     signers::Signature,
 };
 
+// SHARED: V1 + V2 common code
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TapReceipt {
     V1(tap_graph::SignedReceipt),
     V2(tap_graph::v2::SignedReceipt),
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit
 impl Aggregate<TapReceipt> for tap_graph::ReceiptAggregateVoucher {
     fn aggregate_receipts(
         receipts: &[tap_core::receipt::ReceiptWithState<

--- a/crates/monitor/src/escrow_accounts.rs
+++ b/crates/monitor/src/escrow_accounts.rs
@@ -118,6 +118,7 @@ pub fn empty_escrow_accounts_watcher() -> EscrowAccountsWatcher {
     receiver
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit
 pub async fn escrow_accounts_v1(
     escrow_subgraph: &'static SubgraphClient,
     indexer_address: Address,
@@ -225,6 +226,7 @@ async fn get_escrow_accounts_v2(
     Ok(escrow_accounts)
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit
 async fn get_escrow_accounts_v1(
     escrow_subgraph: &'static SubgraphClient,
     indexer_address: Address,

--- a/crates/service/src/middleware/sender.rs
+++ b/crates/service/src/middleware/sender.rs
@@ -20,6 +20,7 @@ pub struct SenderState {
     /// Used to recoer the signer addres for V2 receipts(Horizon)
     pub domain_separator_v2: Eip712Domain,
     /// Used to get the sender address given the signer address if v1 receipt
+    /// V1_LEGACY: Escrow watcher for legacy TAP
     pub escrow_accounts_v1: Option<watch::Receiver<EscrowAccounts>>,
     /// Used to get the sender address given the signer address if v2 receipt
     pub escrow_accounts_v2: Option<watch::Receiver<EscrowAccounts>>,

--- a/crates/service/src/service/router.rs
+++ b/crates/service/src/service/router.rs
@@ -77,6 +77,7 @@ pub struct ServiceRouter {
         config: EscrowSubgraphConfig|
         (subgraph, config))]
     escrow_subgraph: Option<(&'static SubgraphClient, EscrowSubgraphConfig)>,
+    // V1_LEGACY: Legacy escrow watcher (used in legacy/hybrid mode)
     escrow_accounts_v1: Option<EscrowAccountsWatcher>,
 
     escrow_accounts_v2: Option<EscrowAccountsWatcher>,
@@ -147,7 +148,7 @@ impl ServiceRouter {
             (None, None) => panic!("No allocations or network subgraph was provided"),
         };
 
-        // Monitor escrow accounts v1
+        // V1_LEGACY: Monitor escrow accounts v1 (legacy/hybrid)
         // if not provided, create monitor from subgraph
         let escrow_accounts_v1 = match (self.escrow_accounts_v1, self.escrow_subgraph.as_ref()) {
             (Some(escrow_account), _) => Some(escrow_account),

--- a/crates/service/src/service/tap_receipt_header.rs
+++ b/crates/service/src/service/tap_receipt_header.rs
@@ -55,6 +55,7 @@ impl Header for TapHeader {
                 }
                 Err(e) => {
                     tracing::debug!(error = %e, "Could not base64 decode v2 receipt, trying v1");
+                    // V1_LEGACY: JSON decode path for legacy V1 receipts
                     let parsed_receipt: SignedReceipt =
                         serde_json::from_slice(raw_receipt.as_ref()).map_err(|e| {
                             tracing::debug!(error = %e, "Failed to JSON decode v1 receipt");

--- a/crates/service/src/tap/checks/deny_list_check.rs
+++ b/crates/service/src/tap/checks/deny_list_check.rs
@@ -16,12 +16,14 @@ use crate::{
     tap::{CheckingReceipt, TapReceipt},
 };
 
+// SHARED: V1 + V2 common code
 #[derive(Debug)]
 enum DenyListVersion {
     V1,
     V2,
 }
 
+// SHARED: V1 + V2 common code
 pub struct DenyListCheck {
     sender_denylist_v1: Arc<RwLock<HashSet<Address>>>,
     sender_denylist_v2: Arc<RwLock<HashSet<Address>>>,
@@ -35,6 +37,7 @@ impl DenyListCheck {
     pub async fn new(pgpool: PgPool) -> Self {
         // Listen to pg_notify events. We start it before updating the sender_denylist so that we
         // don't miss any updates. PG will buffer the notifications until we start consuming them.
+        // V1_LEGACY: Out of scope for Horizon security audit
         let mut pglistener_v1 = PgListener::connect_with(&pgpool.clone()).await.unwrap();
         let mut pglistener_v2 = PgListener::connect_with(&pgpool.clone()).await.unwrap();
         pglistener_v1
@@ -64,6 +67,7 @@ impl DenyListCheck {
         let notify = std::sync::Arc::new(tokio::sync::Notify::new());
 
         let sender_denylist_watcher_cancel_token = tokio_util::sync::CancellationToken::new();
+        // V1_LEGACY: Out of scope for Horizon security audit
         tokio::spawn(Self::sender_denylist_watcher(
             pgpool.clone(),
             pglistener_v1,
@@ -93,6 +97,7 @@ impl DenyListCheck {
         }
     }
 
+    // V1_LEGACY: Out of scope for Horizon security audit
     async fn sender_denylist_reload_v1(
         pgpool: PgPool,
         denylist_rwlock: Arc<RwLock<HashSet<Address>>>,
@@ -249,6 +254,7 @@ impl Drop for DenyListCheck {
     }
 }
 
+// V1_LEGACY: Tests for V1 denylist functionality
 #[cfg(test)]
 mod tests {
     use sqlx::PgPool;
@@ -263,6 +269,7 @@ mod tests {
         DenyListCheck::new(pgpool).await
     }
 
+    // V1_LEGACY: Test V1 sender denylist check
     #[tokio::test]
     async fn test_sender_denylist() {
         let test_db = test_assets::setup_shared_test_db().await;
@@ -295,6 +302,7 @@ mod tests {
             .is_err());
     }
 
+    // V1_LEGACY: Test V1 denylist dynamic updates via pg_notify
     #[tokio::test]
     async fn test_sender_denylist_updates() {
         let test_db = test_assets::setup_shared_test_db().await;

--- a/crates/service/src/tap/checks/sender_balance_check.rs
+++ b/crates/service/src/tap/checks/sender_balance_check.rs
@@ -12,6 +12,7 @@ use crate::{
     tap::{CheckingReceipt, TapReceipt},
 };
 
+// SHARED: V1 + V2 common code
 pub struct SenderBalanceCheck {
     escrow_accounts_v1: Option<Receiver<EscrowAccounts>>,
     escrow_accounts_v2: Option<Receiver<EscrowAccounts>>,

--- a/crates/service/src/tap/receipt_store.rs
+++ b/crates/service/src/tap/receipt_store.rs
@@ -101,6 +101,7 @@ impl InnerContext {
         }
     }
 
+    // V1_LEGACY: Out of scope for Horizon security audit
     async fn store_receipts_v1(
         &self,
         receipts: Vec<DbReceiptV1>,
@@ -279,6 +280,7 @@ impl ReceiptStore<TapReceipt> for IndexerTapContext {
     }
 }
 
+// SHARED: V1 + V2 common code
 pub enum DatabaseReceipt {
     V1(DbReceiptV1),
     V2(DbReceiptV2),
@@ -293,6 +295,7 @@ impl DatabaseReceipt {
     }
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit
 pub struct DbReceiptV1 {
     signer_address: String,
     signature: Vec<u8>,
@@ -302,6 +305,7 @@ pub struct DbReceiptV1 {
     value: BigDecimal,
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit
 impl DbReceiptV1 {
     fn from_receipt(
         receipt: &tap_graph::SignedReceipt,
@@ -462,6 +466,7 @@ mod tests {
         }
     }
 
+    // V1_LEGACY: Tests for V1-only processing (when Horizon migrations are excluded)
     mod when_horizon_migrations_are_ignored {
         use super::*;
 
@@ -478,6 +483,7 @@ mod tests {
             assert_eq!(res, ProcessedReceipt::None);
         }
 
+        // V1_LEGACY: Test V1 receipt processing only
         #[tokio::test]
         async fn test_v1_receipts_are_processed_successfully() {
             let migrator = create_migrator();
@@ -496,6 +502,7 @@ mod tests {
             assert_eq!(res, ProcessedReceipt::V1);
         }
 
+        // V1_LEGACY: Test V2 receipts failing when Horizon migrations excluded
         #[rstest::rstest]
         #[case(async { vec![create_v2().await] })]
         #[case(async { vec![create_v2().await, create_v1().await] })]

--- a/crates/tap-agent/src/agent.rs
+++ b/crates/tap-agent/src/agent.rs
@@ -173,6 +173,7 @@ pub async fn start_agent(
         "Initializing V1 escrow accounts watcher with indexer {}",
         indexer_address
     );
+    // V1_LEGACY: Out of scope for Horizon security audit
     let escrow_accounts_v1 = escrow_accounts_v1(
         escrow_subgraph,
         *indexer_address,
@@ -257,7 +258,7 @@ pub async fn start_agent(
         // Use the TapMode from config since horizon is actually enabled and active
         SenderAccountConfig::from_config(&CONFIG)
     } else {
-        // Override to Legacy mode since horizon is not active in the network
+        // V1_LEGACY: Out of scope for Horizon security audit - Override to Legacy mode
         let mut config = SenderAccountConfig::from_config(&CONFIG);
         config.tap_mode = indexer_config::TapMode::Legacy;
         config

--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -661,7 +661,6 @@ impl State {
             ])
             .set(unaggregated_fees.value as f64);
 
-        // Keep legacy metric for V1 only, to preserve existing dashboards
         if matches!(self.sender_type, SenderType::Legacy) {
             UNAGGREGATED_FEES
                 .with_label_values(&[&self.sender.to_string(), &allocation_id.to_string()])
@@ -1888,6 +1887,7 @@ pub fn init_metrics() {
     let _ = &*ALLOCATION_RECONCILIATION_RUNS;
 }
 
+// SHARED: Tests for sender account (V1 + V2 behavior, uses V1 fixtures)
 #[cfg(test)]
 pub mod tests {
     #![allow(missing_docs)]

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -1103,6 +1103,7 @@ pub trait DatabaseInteractions {
     fn mark_rav_last(&self) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit
 impl DatabaseInteractions for SenderAllocationState<Legacy> {
     async fn delete_receipts_between(
         &self,
@@ -1476,6 +1477,7 @@ pub fn init_metrics() {
     let _ = &*RAV_RESPONSE_TIME_BY_VERSION;
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit - Tests for Legacy (V1) sender allocation
 #[cfg(test)]
 pub mod tests {
     #![allow(missing_docs)]

--- a/crates/tap-agent/src/lib.rs
+++ b/crates/tap-agent/src/lib.rs
@@ -21,6 +21,7 @@ use thegraph_core::alloy::sol_types::Eip712Domain;
 pub static CONFIG: LazyLock<Config> =
     LazyLock::new(|| cli::get_config().expect("Failed to load configuration"));
 
+/// V1_LEGACY: Domain separator for legacy TAP
 /// Static EIP_712_DOMAIN used with config values for V1
 pub static EIP_712_DOMAIN: LazyLock<Eip712Domain> = LazyLock::new(|| {
     tap_eip712_domain(

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -29,6 +29,7 @@ mod receipt;
 pub use error::AdapterError;
 use tonic::{transport::Channel, Code, Status};
 
+// SHARED: V1 + V2 common code
 /// This trait represents a version of the network for TapAgentContext
 ///
 /// It's used to define what Rav struct is used and how it handles
@@ -77,6 +78,7 @@ pub trait NetworkVersion: Send + Sync + 'static {
     ) -> impl Future<Output = anyhow::Result<Eip712SignedMessage<Self::Rav>>> + Send;
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit
 /// 0-sized marker for legacy network
 ///
 /// By using an enum with no variants, we prevent any instantiation
@@ -98,6 +100,7 @@ pub enum Legacy {}
 #[derive(Debug)]
 pub enum Horizon {}
 
+// V1_LEGACY: Out of scope for Horizon security audit
 impl NetworkVersion for Legacy {
     type AllocationId = AllocationIdCore;
     type Rav = tap_graph::ReceiptAggregateVoucher;
@@ -180,6 +183,7 @@ impl NetworkVersion for Horizon {
     }
 }
 
+// SHARED: V1 + V2 common code
 /// Context used by [tap_core::manager::Manager] that enables certain helper methods
 ///
 /// This context is implemented for PostgresSQL

--- a/crates/tap-agent/src/tap/context/receipt.rs
+++ b/crates/tap-agent/src/tap/context/receipt.rs
@@ -81,6 +81,7 @@ fn rangebounds_to_pgrange<R: RangeBounds<u64>>(range: R) -> PgRange<BigDecimal> 
 ///
 /// This is important because receipts for each network version
 /// are stored in a different database table
+/// V1_LEGACY: Reads from `scalar_tap_receipts` (legacy table)
 #[async_trait::async_trait]
 impl ReceiptRead<TapReceipt> for TapAgentContext<Legacy> {
     type AdapterError = AdapterError;
@@ -172,6 +173,7 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Legacy> {
 ///
 /// This is important because receipts for each network version
 /// are stored in a different database table
+/// V1_LEGACY: Deletes from `scalar_tap_receipts` (legacy table)
 #[async_trait::async_trait]
 impl ReceiptDelete for TapAgentContext<Legacy> {
     type AdapterError = AdapterError;
@@ -398,6 +400,7 @@ impl ReceiptDelete for TapAgentContext<Horizon> {
     }
 }
 
+// V1_LEGACY: Out of scope for Horizon security audit - Tests for Legacy (V1) receipt operations
 #[cfg(test)]
 mod test {
     use std::{


### PR DESCRIPTION
  Add V1_LEGACY and SHARED tags throughout the codebase to clearly
  delineate code scope for the Horizon (V2) security audit. These tags
  help auditors identify which code is out of scope (legacy V1) versus
  in scope (V2 and shared infrastructure).