### PR TITLE
feat(monitor): add number_gte support with tiered backoff to allocation queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4289,6 +4289,7 @@ dependencies = [
  "indexer-attestation",
  "indexer-query",
  "indexer-watcher",
+ "regex",
  "reqwest 0.12.24",
  "rstest",
  "serde",

--- a/crates/monitor/Cargo.toml
+++ b/crates/monitor/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio.workspace = true
 bip39.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/monitor/src/allocations.rs
+++ b/crates/monitor/src/allocations.rs
@@ -56,6 +56,8 @@ pub async fn indexer_allocations(
     tokio::spawn(async move {
         let mut time_interval = time::interval(interval);
         time_interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+        // Consume the immediate first tick to avoid redundant query at startup
+        time_interval.tick().await;
 
         loop {
             time_interval.tick().await;

--- a/crates/monitor/src/allocations.rs
+++ b/crates/monitor/src/allocations.rs
@@ -10,11 +10,15 @@ use std::{
 use indexer_allocation::Allocation;
 use indexer_query::allocations_query::{self, AllocationsQuery};
 use thegraph_core::alloy::primitives::{Address, TxHash};
-use tokio::sync::{watch::Receiver, Mutex};
-use tokio::time::{self, sleep};
+use tokio::{
+    sync::{watch::Receiver, Mutex},
+    time::{self, sleep},
+};
 
-use crate::backoff::{is_block_too_high_error, TieredBlockBackoff};
-use crate::client::SubgraphClient;
+use crate::{
+    backoff::{is_block_too_high_error, TieredBlockBackoff},
+    client::SubgraphClient,
+};
 
 /// Receiver of Map between allocation id and allocation struct
 pub type AllocationWatcher = Receiver<HashMap<Address, Allocation>>;

--- a/crates/monitor/src/allocations.rs
+++ b/crates/monitor/src/allocations.rs
@@ -3,36 +3,133 @@
 
 use std::{
     collections::HashMap,
+    sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use indexer_allocation::Allocation;
 use indexer_query::allocations_query::{self, AllocationsQuery};
-use indexer_watcher::new_watcher;
 use thegraph_core::alloy::primitives::{Address, TxHash};
-use tokio::sync::watch::Receiver;
+use tokio::sync::{watch::Receiver, Mutex};
+use tokio::time::{self, sleep};
 
+use crate::backoff::{is_block_too_high_error, TieredBlockBackoff};
 use crate::client::SubgraphClient;
 
 /// Receiver of Map between allocation id and allocation struct
 pub type AllocationWatcher = Receiver<HashMap<Address, Allocation>>;
 
 /// An always up-to-date list of an indexer's active and recently closed allocations.
+///
+/// Uses tiered backoff to handle Gateway routing to indexers with varying sync states.
+/// When queries fail due to "block too high" errors, the `number_gte` constraint is
+/// progressively relaxed to find an indexer that can serve the request.
 pub async fn indexer_allocations(
     network_subgraph: &'static SubgraphClient,
     indexer_address: Address,
     interval: Duration,
     recently_closed_allocation_buffer: Duration,
 ) -> anyhow::Result<AllocationWatcher> {
-    new_watcher(interval, move || async move {
-        get_allocations(
-            network_subgraph,
-            indexer_address,
-            recently_closed_allocation_buffer,
-        )
-        .await
-    })
-    .await
+    let backoff = Arc::new(Mutex::new(TieredBlockBackoff::new()));
+
+    // Initial query without number_gte constraint
+    let initial_result = get_allocations_with_block_state(
+        network_subgraph,
+        indexer_address,
+        recently_closed_allocation_buffer,
+        None,
+    )
+    .await?;
+
+    // Record the initial block number for subsequent queries
+    if let Some(block_number) = initial_result.block_number {
+        backoff.lock().await.on_success(block_number);
+    }
+
+    let (tx, rx) = tokio::sync::watch::channel(initial_result.allocations);
+
+    let backoff_clone = backoff.clone();
+    tokio::spawn(async move {
+        let mut time_interval = time::interval(interval);
+        time_interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        loop {
+            time_interval.tick().await;
+
+            let number_gte = backoff_clone.lock().await.get_number_gte();
+
+            let result = get_allocations_with_block_state(
+                network_subgraph,
+                indexer_address,
+                recently_closed_allocation_buffer,
+                number_gte,
+            )
+            .await;
+
+            match result {
+                Ok(query_result) => {
+                    // Check if we should update before any async operations
+                    // This prevents overwriting valid data with empty results from stale indexers
+                    let (should_update, current_count) = {
+                        let current = tx.borrow();
+                        let should_update =
+                            !query_result.allocations.is_empty() || current.is_empty();
+                        (should_update, current.len())
+                    };
+
+                    if should_update {
+                        if let Some(block_number) = query_result.block_number {
+                            backoff_clone.lock().await.on_success(block_number);
+                        }
+
+                        if tx.send(query_result.allocations).is_err() {
+                            tracing::debug!(
+                                "Allocation watcher channel closed, stopping watcher task"
+                            );
+                            break;
+                        }
+                    } else {
+                        tracing::warn!(
+                            current_count = current_count,
+                            new_count = query_result.allocations.len(),
+                            "Ignoring empty allocation result to preserve existing data"
+                        );
+                    }
+                }
+                Err(err) => {
+                    let error_str = err.to_string();
+
+                    if is_block_too_high_error(&error_str) {
+                        let mut backoff_guard = backoff_clone.lock().await;
+                        backoff_guard.on_block_too_high_error(&error_str);
+
+                        tracing::warn!(
+                            error = %err,
+                            tier = backoff_guard.current_tier(),
+                            number_gte = ?backoff_guard.get_number_gte(),
+                            "Block too high error, advancing backoff tier"
+                        );
+                    } else {
+                        tracing::warn!(
+                            error = %err,
+                            "Error while updating allocation watcher"
+                        );
+                    }
+
+                    // Sleep before retry
+                    sleep(interval.div_f32(2.0)).await;
+                }
+            }
+        }
+    });
+
+    Ok(rx)
+}
+
+/// Result of an allocation query including block metadata for freshness tracking.
+pub struct AllocationQueryResult {
+    pub allocations: HashMap<Address, Allocation>,
+    pub block_number: Option<i64>,
 }
 
 pub async fn get_allocations(
@@ -40,6 +137,27 @@ pub async fn get_allocations(
     indexer_address: Address,
     recently_closed_allocation_buffer: Duration,
 ) -> Result<HashMap<Address, Allocation>, anyhow::Error> {
+    let result = get_allocations_with_block_state(
+        network_subgraph,
+        indexer_address,
+        recently_closed_allocation_buffer,
+        None,
+    )
+    .await?;
+    Ok(result.allocations)
+}
+
+/// Queries allocations with block freshness tracking.
+///
+/// Accepts an optional `number_gte` constraint to ensure the query is served by an indexer
+/// at least as fresh as the specified block. Returns both the allocations and the block
+/// number from the response for use in subsequent queries.
+pub async fn get_allocations_with_block_state(
+    network_subgraph: &'static SubgraphClient,
+    indexer_address: Address,
+    recently_closed_allocation_buffer: Duration,
+    number_gte: Option<i64>,
+) -> Result<AllocationQueryResult, anyhow::Error> {
     let start = SystemTime::now();
     let since_the_epoch = start
         .duration_since(UNIX_EPOCH)
@@ -47,21 +165,34 @@ pub async fn get_allocations(
     let closed_at_threshold = since_the_epoch - recently_closed_allocation_buffer;
 
     let mut hash: Option<TxHash> = None;
+    let mut block_number: Option<i64> = None;
     let mut last: Option<String> = None;
     let mut responses = vec![];
     let page_size = 200;
+
     loop {
+        // For the first page, use number_gte if provided; for subsequent pages, use hash
+        let block_constraint = if hash.is_some() {
+            Some(allocations_query::Block_height {
+                hash,
+                number: None,
+                number_gte: None,
+            })
+        } else {
+            number_gte.map(|n| allocations_query::Block_height {
+                hash: None,
+                number: None,
+                number_gte: Some(n),
+            })
+        };
+
         let result = network_subgraph
             .query::<AllocationsQuery, _>(allocations_query::Variables {
                 indexer: indexer_address.to_string().to_ascii_lowercase(),
                 closed_at_threshold: closed_at_threshold.as_secs() as i64,
                 first: page_size,
                 last: last.unwrap_or_default(),
-                block: hash.map(|hash| allocations_query::Block_height {
-                    hash: Some(hash),
-                    number: None,
-                    number_gte: None,
-                }),
+                block: block_constraint,
             })
             .await
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
@@ -69,7 +200,11 @@ pub async fn get_allocations(
         let mut data = result?;
         let page_len = data.allocations.len();
 
-        hash = data.meta.and_then(|meta| meta.block.hash);
+        // Extract block metadata from response
+        if let Some(ref meta) = data.meta {
+            hash = meta.block.hash;
+            block_number = Some(meta.block.number);
+        }
         last = data.allocations.last().map(|entry| entry.id.to_string());
 
         responses.append(&mut data.allocations);
@@ -77,23 +212,28 @@ pub async fn get_allocations(
             break;
         }
     }
+
     let responses = responses
         .into_iter()
         .map(|allocation| allocation.try_into())
         .collect::<Result<Vec<Allocation>, _>>()?;
 
-    let result: HashMap<Address, Allocation> = responses
+    let allocations: HashMap<Address, Allocation> = responses
         .into_iter()
         .map(|allocation| (allocation.id, allocation))
         .collect();
 
     tracing::info!(
-        allocations = result.len(),
+        allocations = allocations.len(),
+        block_number = ?block_number,
         indexer_address = ?indexer_address,
         "Network subgraph query returned allocations for indexer"
     );
 
-    Ok(result)
+    Ok(AllocationQueryResult {
+        allocations,
+        block_number,
+    })
 }
 
 #[cfg(test)]

--- a/crates/monitor/src/backoff.rs
+++ b/crates/monitor/src/backoff.rs
@@ -1,0 +1,247 @@
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tiered block backoff strategy for handling Gateway routing to indexers with varying sync states.
+//!
+//! When querying subgraphs through the Gateway, different indexers may be at different block heights.
+//! This module provides a backoff strategy that progressively relaxes the `number_gte` constraint
+//! when queries fail due to indexers being behind.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Backoff tiers representing how many blocks to subtract from the last successful block.
+/// Each tier represents a progressively more lenient constraint:
+/// - Tier 0: Exact block (no backoff)
+/// - Tier 1: 100 blocks back (~25 sec on Arbitrum)
+/// - Tier 2: 1,000 blocks back (~4 min on Arbitrum)
+/// - Tier 3: 10,000 blocks back (~40 min on Arbitrum)
+const BACKOFF_TIERS: [i64; 4] = [0, 100, 1_000, 10_000];
+
+/// Regex to extract `latest: \d+` values from Gateway error messages.
+/// Gateway errors look like:
+/// ```text
+/// bad indexers: {0x123...: Unavailable(missing block: 900000000, latest: 425638278), ...}
+/// ```
+static LATEST_BLOCK_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"latest:\s*(\d+)").expect("Invalid regex pattern"));
+
+/// Tiered backoff strategy for block-constrained queries.
+///
+/// Tracks the last successful block number and progressively relaxes the `number_gte`
+/// constraint when queries fail due to indexers being behind the requested block.
+#[derive(Debug, Clone, Default)]
+pub struct TieredBlockBackoff {
+    /// The block number from the last successful query
+    last_successful_block: Option<i64>,
+    /// Current backoff tier (0 = no backoff, higher = more lenient)
+    tier: usize,
+    /// Maximum "latest" block extracted from Gateway error messages
+    max_latest_from_error: Option<i64>,
+}
+
+impl TieredBlockBackoff {
+    /// Creates a new backoff state with no prior block information.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the `number_gte` value to use for the next query.
+    ///
+    /// - If no successful block is recorded, returns `None` (no constraint)
+    /// - If within normal tiers, returns `last_block - BACKOFF_TIERS[tier]`
+    /// - If all tiers exhausted, falls back to `max_latest_from_error`
+    pub fn get_number_gte(&self) -> Option<i64> {
+        let base = self.last_successful_block?;
+
+        if self.tier < BACKOFF_TIERS.len() {
+            Some((base - BACKOFF_TIERS[self.tier]).max(0))
+        } else {
+            // All tiers exhausted, use the max latest from error if available
+            self.max_latest_from_error
+        }
+    }
+
+    /// Called when a query succeeds. Records the block number and resets the tier.
+    pub fn on_success(&mut self, block_number: i64) {
+        self.last_successful_block = Some(block_number);
+        self.tier = 0;
+        self.max_latest_from_error = None;
+    }
+
+    /// Called when a query fails due to a "block too high" error.
+    ///
+    /// Parses the error message to extract the maximum available block number
+    /// and advances to the next backoff tier.
+    pub fn on_block_too_high_error(&mut self, error: &str) {
+        if let Some(max_latest) = parse_max_latest(error) {
+            self.max_latest_from_error = Some(
+                self.max_latest_from_error
+                    .map_or(max_latest, |current| current.max(max_latest)),
+            );
+        }
+        self.tier = self.tier.saturating_add(1);
+    }
+
+    /// Returns the current backoff tier (0 = no backoff).
+    pub fn current_tier(&self) -> usize {
+        self.tier
+    }
+
+    /// Returns the last successful block number, if any.
+    pub fn last_successful_block(&self) -> Option<i64> {
+        self.last_successful_block
+    }
+
+    /// Returns true if all normal tiers have been exhausted.
+    pub fn is_exhausted(&self) -> bool {
+        self.tier >= BACKOFF_TIERS.len()
+    }
+}
+
+/// Parses a Gateway error message to extract the maximum "latest" block number.
+///
+/// Gateway errors contain entries like `latest: 425638278` for each indexer that
+/// couldn't serve the requested block. This function extracts all such values
+/// and returns the maximum.
+pub fn parse_max_latest(error: &str) -> Option<i64> {
+    LATEST_BLOCK_REGEX
+        .captures_iter(error)
+        .filter_map(|cap| cap.get(1)?.as_str().parse::<i64>().ok())
+        .max()
+}
+
+/// Checks if an error message indicates a "block too high" / "missing block" error
+/// from the Gateway.
+pub fn is_block_too_high_error(error: &str) -> bool {
+    error.contains("missing block") || error.contains("block not found")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_backoff_returns_none() {
+        let backoff = TieredBlockBackoff::new();
+        assert_eq!(backoff.get_number_gte(), None);
+        assert_eq!(backoff.current_tier(), 0);
+    }
+
+    #[test]
+    fn test_success_sets_block_and_resets_tier() {
+        let mut backoff = TieredBlockBackoff::new();
+        backoff.tier = 3;
+        backoff.on_success(1000);
+
+        assert_eq!(backoff.last_successful_block(), Some(1000));
+        assert_eq!(backoff.current_tier(), 0);
+        assert_eq!(backoff.get_number_gte(), Some(1000));
+    }
+
+    #[test]
+    fn test_tier_progression() {
+        let mut backoff = TieredBlockBackoff::new();
+        backoff.on_success(10000);
+
+        // Tier 0: exact block
+        assert_eq!(backoff.get_number_gte(), Some(10000));
+
+        // Tier 1: -100
+        backoff.on_block_too_high_error("some error");
+        assert_eq!(backoff.current_tier(), 1);
+        assert_eq!(backoff.get_number_gte(), Some(9900));
+
+        // Tier 2: -1000
+        backoff.on_block_too_high_error("some error");
+        assert_eq!(backoff.current_tier(), 2);
+        assert_eq!(backoff.get_number_gte(), Some(9000));
+
+        // Tier 3: -10000
+        backoff.on_block_too_high_error("some error");
+        assert_eq!(backoff.current_tier(), 3);
+        assert_eq!(backoff.get_number_gte(), Some(0));
+    }
+
+    #[test]
+    fn test_exhausted_tiers_uses_max_latest() {
+        let mut backoff = TieredBlockBackoff::new();
+        backoff.on_success(1_000_000);
+
+        // Exhaust all tiers
+        for _ in 0..5 {
+            backoff.on_block_too_high_error("latest: 500000");
+        }
+
+        assert!(backoff.is_exhausted());
+        assert_eq!(backoff.get_number_gte(), Some(500000));
+    }
+
+    #[test]
+    fn test_parse_max_latest_single_value() {
+        let error = "bad indexers: {0x123: Unavailable(missing block: 900000000, latest: 425638278)}";
+        assert_eq!(parse_max_latest(error), Some(425638278));
+    }
+
+    #[test]
+    fn test_parse_max_latest_multiple_values() {
+        let error = "bad indexers: {0x123: Unavailable(missing block: 900000000, latest: 425638278), 0x456: Unavailable(missing block: 900000000, latest: 425638300)}";
+        assert_eq!(parse_max_latest(error), Some(425638300));
+    }
+
+    #[test]
+    fn test_parse_max_latest_no_match() {
+        let error = "some other error message";
+        assert_eq!(parse_max_latest(error), None);
+    }
+
+    #[test]
+    fn test_parse_max_latest_with_spaces() {
+        let error = "latest:  425638278, latest: 100";
+        assert_eq!(parse_max_latest(error), Some(425638278));
+    }
+
+    #[test]
+    fn test_is_block_too_high_error() {
+        assert!(is_block_too_high_error("Unavailable(missing block: 900000000)"));
+        assert!(is_block_too_high_error("block not found"));
+        assert!(!is_block_too_high_error("connection timeout"));
+    }
+
+    #[test]
+    fn test_saturating_sub_prevents_negative() {
+        let mut backoff = TieredBlockBackoff::new();
+        backoff.on_success(50); // Small block number
+
+        // Tier 3 would subtract 10000, but should saturate to 0
+        backoff.tier = 3;
+        assert_eq!(backoff.get_number_gte(), Some(0));
+    }
+
+    #[test]
+    fn test_max_latest_accumulates_highest() {
+        let mut backoff = TieredBlockBackoff::new();
+        backoff.on_success(1_000_000);
+
+        backoff.on_block_too_high_error("latest: 100");
+        assert_eq!(backoff.max_latest_from_error, Some(100));
+
+        backoff.on_block_too_high_error("latest: 500");
+        assert_eq!(backoff.max_latest_from_error, Some(500));
+
+        backoff.on_block_too_high_error("latest: 200");
+        assert_eq!(backoff.max_latest_from_error, Some(500)); // Should keep 500
+    }
+
+    #[test]
+    fn test_success_clears_max_latest() {
+        let mut backoff = TieredBlockBackoff::new();
+        backoff.on_success(1000);
+        backoff.on_block_too_high_error("latest: 500");
+
+        assert_eq!(backoff.max_latest_from_error, Some(500));
+
+        backoff.on_success(2000);
+        assert_eq!(backoff.max_latest_from_error, None);
+    }
+}

--- a/crates/monitor/src/backoff.rs
+++ b/crates/monitor/src/backoff.rs
@@ -7,8 +7,9 @@
 //! This module provides a backoff strategy that progressively relaxes the `number_gte` constraint
 //! when queries fail due to indexers being behind.
 
-use regex::Regex;
 use std::sync::LazyLock;
+
+use regex::Regex;
 
 /// Backoff tiers representing how many blocks to subtract from the last successful block.
 /// Each tier represents a progressively more lenient constraint:
@@ -179,7 +180,8 @@ mod tests {
 
     #[test]
     fn test_parse_max_latest_single_value() {
-        let error = "bad indexers: {0x123: Unavailable(missing block: 900000000, latest: 425638278)}";
+        let error =
+            "bad indexers: {0x123: Unavailable(missing block: 900000000, latest: 425638278)}";
         assert_eq!(parse_max_latest(error), Some(425638278));
     }
 
@@ -203,7 +205,9 @@ mod tests {
 
     #[test]
     fn test_is_block_too_high_error() {
-        assert!(is_block_too_high_error("Unavailable(missing block: 900000000)"));
+        assert!(is_block_too_high_error(
+            "Unavailable(missing block: 900000000)"
+        ));
         assert!(is_block_too_high_error("block not found"));
         assert!(!is_block_too_high_error("connection timeout"));
     }

--- a/crates/monitor/src/lib.rs
+++ b/crates/monitor/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod allocations;
 mod attestation;
+pub mod backoff;
 mod client;
 mod deployment_to_allocation;
 mod dispute_manager;

--- a/crates/monitor/src/lib.rs
+++ b/crates/monitor/src/lib.rs
@@ -11,7 +11,7 @@ mod escrow_accounts;
 mod horizon_detection;
 
 pub use crate::{
-    allocations::{indexer_allocations, AllocationWatcher},
+    allocations::{indexer_allocations, AllocationQueryResult, AllocationWatcher},
     attestation::{attestation_signers, AttestationWatcher},
     client::{DeploymentDetails, SubgraphClient},
     deployment_to_allocation::{deployment_to_allocation, DeploymentToAllocationWatcher},

--- a/crates/watcher/src/lib.rs
+++ b/crates/watcher/src/lib.rs
@@ -33,6 +33,8 @@ where
     tokio::spawn(async move {
         let mut time_interval = time::interval(interval);
         time_interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+        // Consume the immediate first tick to avoid redundant query at startup
+        time_interval.tick().await;
         loop {
             time_interval.tick().await;
             let result = function().await;


### PR DESCRIPTION
## Summary

- Adds `number_gte` parameter to allocation queries to ensure responses come from indexers synced to at least the last successful block - meaning the block height of the last respond we got from the gateway.
- Implements tiered backoff strategy when Gateway returns "block too high" errors (when indexers have not synced to at least the block height of the previous response)
- This RP effectively protects against overwriting valid allocation data with empty results from stale indexers that are serving old data.

## Problem

The Graph Gateway routes queries to different indexers with varying sync states. Without block freshness constraints, a query might be served by a stale indexer that returns 0 allocations (because it hasn't indexed them yet), overwriting valid cached data.

## Solution

Track the block number from successful responses and use `number_gte` to constrain subsequent queries. When queries fail due to indexers being behind, progressively relax the constraint through tiers:

| Tier | Relax the block height constraint by | Equilavalent time on Arbitrum |
|------|---------|---------------|
| 0 | 0 blocks | immediate |
| 1 | 100 blocks | ~25 sec |
| 2 | 1,000 blocks | ~4 min |
| 3 | 10,000 blocks | ~40 min |
| 4+ | Just use block height from error message | last resort |

🤖 Generated with [Claude Code](https://claude.com/claude-code)