### PR TITLE
fix(tap-agent): use unique sender ID in metrics cleanup test

### DIFF
--- a/crates/tap-agent/tests/sender_account_test.rs
+++ b/crates/tap-agent/tests/sender_account_test.rs
@@ -40,7 +40,7 @@ async fn sender_account_layer_test() {
         .await
         .unwrap();
 
-    let (sender_account, mut msg_receiver, _, _, _) = create_sender_account()
+    let (sender_account, mut msg_receiver, _, _, _, _) = create_sender_account()
         .pgpool(pgpool.clone())
         .max_amount_willing_to_lose_grt(TRIGGER_VALUE + 1000)
         .escrow_subgraph_endpoint(&mock_escrow_subgraph_server.uri())


### PR DESCRIPTION
## Summary

Fixes flaky test `test_sender_level_gauges_cleanup_on_post_stop` by using a unique sender ID for test isolation.

## Problem

The test was non-deterministic because:
- It used a shared sender ID (`SENDER.1`) for Prometheus metrics
- Tests run in parallel
- Parallel tests using the same sender label interfered with each other's metric values

```
Test A                          Test B (parallel)
------                          ----------------
1. Set ESCROW_BALANCE = 1000    
2. Stop sender account          1. Create sender account
3. Expect ESCROW_BALANCE = 0    2. Set MAX_FEE_PER_SENDER = 600
   ^                               ^
   FAILS: sees 600 from Test B
```

## Solution

- Add optional `sender_id` parameter to `create_sender_account` test helper
- Return `sender_id` from `create_sender_account` for tests to use
- Update the flaky test to use `Address::random()` for test isolation
- Update all call sites to handle the new 6-element return tuple

🤖 Generated with [Claude Code](https://claude.com/claude-code)