### PR TITLE
Add PayerCheck to validate V2 receipt payer field

### DIFF
--- a/crates/service/src/tap.rs
+++ b/crates/service/src/tap.rs
@@ -17,9 +17,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::tap::checks::{
     allocation_eligible::AllocationEligible, data_service_check::DataServiceCheck,
-    deny_list_check::DenyListCheck, receipt_max_val_check::ReceiptMaxValueCheck,
-    sender_balance_check::SenderBalanceCheck, timestamp_check::TimestampCheck,
-    value_check::MinimumValue,
+    deny_list_check::DenyListCheck, payer_check::PayerCheck,
+    receipt_max_val_check::ReceiptMaxValueCheck, sender_balance_check::SenderBalanceCheck,
+    timestamp_check::TimestampCheck, value_check::MinimumValue,
 };
 
 mod checks;
@@ -76,6 +76,7 @@ impl IndexerTapContext {
             Arc::new(ReceiptMaxValueCheck::new(config.receipt_max_value)),
             Arc::new(MinimumValue::new(config.pgpool, Duration::from_secs(GRACE_PERIOD)).await),
             Arc::new(ServiceProviderCheck::new(config.service_provider)),
+            Arc::new(PayerCheck::new()),
         ];
 
         if let Some(addrs) = config.allowed_data_services {

--- a/crates/service/src/tap/checks.rs
+++ b/crates/service/src/tap/checks.rs
@@ -4,6 +4,7 @@
 pub mod allocation_eligible;
 pub mod data_service_check;
 pub mod deny_list_check;
+pub mod payer_check;
 pub mod receipt_max_val_check;
 pub mod sender_balance_check;
 pub mod service_provider;

--- a/crates/service/src/tap/checks/payer_check.rs
+++ b/crates/service/src/tap/checks/payer_check.rs
@@ -1,0 +1,199 @@
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
+// SPDX-License-Identifier: Apache-2.0
+
+use tap_core::receipt::checks::{Check, CheckError, CheckResult};
+
+use crate::{
+    middleware::Sender,
+    tap::{CheckingReceipt, TapReceipt},
+};
+
+/// Validates that the V2 receipt's `payer` field matches the on-chain
+/// recovered sender (from signer → payer escrow mapping).
+///
+/// - V1 receipts are ignored by this check (always Ok).
+/// - On mismatch, returns a CheckFailure with a descriptive message.
+///
+/// This prevents attackers from submitting receipts with mismatched payer
+/// fields that would be stored but never aggregated by tap-agent.
+pub struct PayerCheck;
+
+impl PayerCheck {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for PayerCheck {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl Check<TapReceipt> for PayerCheck {
+    async fn check(
+        &self,
+        ctx: &tap_core::receipt::Context,
+        receipt: &CheckingReceipt,
+    ) -> CheckResult {
+        match receipt.signed_receipt() {
+            // Not applicable for V1 (no payer field in V1 receipts)
+            TapReceipt::V1(_) => Ok(()),
+
+            // Validate payer for V2
+            TapReceipt::V2(r) => {
+                // Get the recovered sender from context (injected by sender middleware)
+                let Sender(recovered_sender) = ctx.get::<Sender>().ok_or_else(|| {
+                    CheckError::Failed(anyhow::anyhow!(
+                        "Could not find recovered sender in context"
+                    ))
+                })?;
+
+                // Compare claimed payer against on-chain recovered sender
+                if r.message.payer == *recovered_sender {
+                    Ok(())
+                } else {
+                    Err(CheckError::Failed(anyhow::anyhow!(
+                        "Invalid payer: receipt claims payer {} but signer is authorized for {}",
+                        r.message.payer,
+                        recovered_sender
+                    )))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use indexer_monitor::EscrowAccounts;
+    use tap_core::{
+        receipt::Context, signed_message::Eip712SignedMessage, tap_eip712_domain, TapVersion,
+    };
+    use tap_graph::Receipt;
+    use test_assets::{TAP_SENDER, TAP_SIGNER};
+    use thegraph_core::alloy::{
+        primitives::{Address, FixedBytes, U256},
+        signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner},
+    };
+    use tokio::sync::watch;
+
+    use super::*;
+
+    fn create_escrow_accounts() -> watch::Receiver<EscrowAccounts> {
+        watch::channel(EscrowAccounts::new(
+            HashMap::from([(TAP_SENDER.1, U256::from(1000))]),
+            HashMap::from([(TAP_SENDER.1, vec![TAP_SIGNER.1])]),
+        ))
+        .1
+    }
+
+    fn create_wallet() -> PrivateKeySigner {
+        MnemonicBuilder::<English>::default()
+            .phrase("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
+            .index(0)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    fn create_v2_receipt(payer: Address) -> CheckingReceipt {
+        let wallet = create_wallet();
+        let eip712_domain = tap_eip712_domain(1, Address::from([0x11u8; 20]), TapVersion::V2);
+
+        let receipt = tap_graph::v2::Receipt {
+            payer,
+            data_service: Address::ZERO,
+            service_provider: Address::ZERO,
+            collection_id: FixedBytes::ZERO,
+            timestamp_ns: 1000,
+            nonce: 1,
+            value: 100,
+        };
+
+        let signed = Eip712SignedMessage::new(&eip712_domain, receipt, &wallet).unwrap();
+        CheckingReceipt::new(TapReceipt::V2(signed))
+    }
+
+    fn create_v1_receipt() -> CheckingReceipt {
+        let wallet = create_wallet();
+        let eip712_domain = tap_eip712_domain(1, Address::from([0x11u8; 20]), TapVersion::V1);
+
+        let receipt = Receipt {
+            allocation_id: Address::ZERO,
+            timestamp_ns: 1000,
+            nonce: 1,
+            value: 100,
+        };
+
+        let signed = Eip712SignedMessage::new(&eip712_domain, receipt, &wallet).unwrap();
+        CheckingReceipt::new(TapReceipt::V1(signed))
+    }
+
+    #[tokio::test]
+    async fn test_payer_check_passes_when_payer_matches() {
+        let _escrow = create_escrow_accounts();
+        let check = PayerCheck::new();
+
+        // Create context with recovered sender
+        let mut ctx = Context::new();
+        ctx.insert(Sender(TAP_SENDER.1));
+
+        // Create receipt with matching payer
+        let receipt = create_v2_receipt(TAP_SENDER.1);
+
+        let result = check.check(&ctx, &receipt).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_payer_check_fails_when_payer_mismatches() {
+        let _escrow = create_escrow_accounts();
+        let check = PayerCheck::new();
+
+        // Create context with recovered sender
+        let mut ctx = Context::new();
+        ctx.insert(Sender(TAP_SENDER.1));
+
+        // Create receipt with different payer (attacker scenario)
+        let fake_payer = Address::repeat_byte(0x42);
+        let receipt = create_v2_receipt(fake_payer);
+
+        let result = check.check(&ctx, &receipt).await;
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("Invalid payer"));
+    }
+
+    #[tokio::test]
+    async fn test_payer_check_fails_when_no_sender_in_context() {
+        let check = PayerCheck::new();
+
+        // Empty context (no Sender)
+        let ctx = Context::new();
+        let receipt = create_v2_receipt(TAP_SENDER.1);
+
+        let result = check.check(&ctx, &receipt).await;
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("Could not find recovered sender"));
+    }
+
+    #[tokio::test]
+    async fn test_payer_check_ignores_v1_receipts() {
+        let check = PayerCheck::new();
+        let ctx = Context::new(); // No sender needed for V1
+
+        let checking = create_v1_receipt();
+
+        let result = check.check(&ctx, &checking).await;
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
Adds a new `PayerCheck` to validate that V2 receipts have a `payer` field matching the on-chain recovered sender before storage. This closes a security gap similar to TRST-H-1.

## Problem

V2 receipts contain a `payer` field in the message that was **not validated** against the on-chain recovered sender. An attacker could:

1. Use a signer authorized by `PayerA` (legitimate on-chain mapping)
2. Set `receipt.message.payer = PayerB` (arbitrary address)
3. Receipt passes `SenderBalanceCheck` because signer → `PayerA` has escrow balance
4. Receipt is stored with `payer = PayerB` (claimed, not validated)
5. `tap-agent` queries `WHERE payer = PayerA` → **never finds the receipt**
6. Receipts remain orphaned, causing DB bloat and potential DoS

## Solution

Add `PayerCheck` that compares `receipt.message.payer` against the recovered sender (injected by `sender_middleware` via `get_sender_for_signer()`). Mismatched receipts are rejected before storage.