### PR TITLE
refactor: use thegraph-core AllocationId instead of custom Allocation wrapper   

### DIFF
--- a/crates/service/src/middleware.rs
+++ b/crates/service/src/middleware.rs
@@ -12,7 +12,7 @@ mod sender;
 mod tap_context;
 mod tap_receipt;
 
-pub use allocation::{allocation_middleware, Allocation, AllocationState};
+pub use allocation::{allocation_middleware, AllocationState};
 pub use attestation::{attestation_middleware, AttestationInput};
 pub use attestation_signer::{signer_middleware, AttestationState};
 pub use deployment::deployment_middleware;

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -224,7 +224,9 @@ impl AllocationId {
     pub fn address(&self) -> Address {
         match self {
             AllocationId::Legacy(allocation_id) => **allocation_id,
-            AllocationId::Horizon(collection_id) => collection_id.as_address(),
+            AllocationId::Horizon(collection_id) => {
+                AllocationIdCore::from(*collection_id).into_inner()
+            }
         }
     }
 
@@ -233,7 +235,7 @@ impl AllocationId {
     /// Behavior:
     /// - Legacy (V1): returns the allocation address as hex.
     /// - Horizon (V2): derives the 20-byte address from the 32-byte `CollectionId`
-    ///   using `collection_id.as_address()` (last 20 bytes) and encodes as hex.
+    ///   via `thegraph_core::AllocationId::from(collection_id)` (last 20 bytes) and encodes as hex.
     ///
     /// Use for:
     /// - Actor names and routing (consistent identity across versions)

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -146,7 +146,7 @@ impl NetworkVersion for Horizon {
         tap_aggregator::grpc::v2::tap_aggregator_client::TapAggregatorClient<Channel>;
 
     fn allocation_id_to_address(id: &Self::AllocationId) -> Address {
-        id.as_address()
+        AllocationIdCore::from(*id).into_inner()
     }
 
     fn to_allocation_id_enum(

--- a/crates/tap-agent/src/test.rs
+++ b/crates/tap-agent/src/test.rs
@@ -564,10 +564,11 @@ pub async fn store_batch_receipts(
                 values.push(BigDecimal::from(receipt.message.value));
             }
             TapReceipt::V2(receipt) => {
-                use thegraph_core::CollectionId;
+                use thegraph_core::{AllocationId, CollectionId};
                 // For V2, store collection_id in the allocation_id field (as per the database reuse strategy)
                 let collection_id_as_allocation =
-                    CollectionId::from(receipt.message.collection_id).as_address();
+                    AllocationId::from(CollectionId::from(receipt.message.collection_id))
+                        .into_inner();
                 signers.push(
                     receipt
                         .recover_signer(&TAP_EIP712_DOMAIN_SEPARATOR)
@@ -658,12 +659,12 @@ pub async fn store_invalid_receipt_v2(
     pgpool: &PgPool,
     signed_receipt: &tap_graph::v2::SignedReceipt,
 ) -> anyhow::Result<u64> {
-    use thegraph_core::CollectionId;
+    use thegraph_core::{AllocationId, CollectionId};
     let encoded_signature = signed_receipt.signature.as_bytes().to_vec();
 
     // Store collection_id in allocation_id field (database reuse strategy)
     let collection_id_as_allocation =
-        CollectionId::from(signed_receipt.message.collection_id).as_address();
+        AllocationId::from(CollectionId::from(signed_receipt.message.collection_id)).into_inner();
 
     let record = sqlx::query!(
         r#"


### PR DESCRIPTION
# Summary                                                                 
                                                                          
Replace the internal Allocation(Address) newtype with thegraph_core::AllocationId for consistent allocation ID handling across the codebase.                                                          
                                                                        
## Changes                                                                 
                                                                        
- Remove custom `Allocation` wrapper from service middleware in favor of `AllocationId` from `thegraph-core`                                         
- Update allocation address derivation to use `AllocationId::from(CollectionId).into_inner()` instead of `CollectionId::as_address()`                                              
- Fix flaky test race conditions in tap-agent allocation reconciliation tests                                                                   
- Add tests verifying byte-level correctness of `CollectionId` → `AllocationId` conversion                                                 
                                                                        
## Why                                                                     
                                                                        
Using the canonical `AllocationId` type from `thegraph-core` ensures type safety and alignment with the core library's allocation representation, reducing the maintenance burden of a custom wrapper.  

---
Signed off by Joseph Livesey <joseph@semiotic.ai>
