### PR TITLE
feat: log proposal rejection reasons on the indexer side

### DIFF
--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -350,6 +350,17 @@ fn bytes32_to_ipfs_hash(bytes: &[u8; 32]) -> String {
     bs58::encode(&multihash).into_string()
 }
 
+/// Try to extract the deployment ID from raw signed RCA bytes.
+///
+/// Best-effort: returns `None` if any decoding step fails.
+pub(crate) fn try_extract_deployment_id(rca_bytes: &[u8]) -> Option<String> {
+    let signed_rca = SignedRecurringCollectionAgreement::abi_decode(rca_bytes).ok()?;
+    let metadata =
+        AcceptIndexingAgreementMetadata::abi_decode(signed_rca.agreement.metadata.as_ref())
+            .ok()?;
+    Some(bytes32_to_ipfs_hash(&metadata.subgraphDeploymentId.0))
+}
+
 /// Validate and create a RecurringCollectionAgreement.
 ///
 /// Performs validation:

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -356,8 +356,7 @@ fn bytes32_to_ipfs_hash(bytes: &[u8; 32]) -> String {
 pub(crate) fn try_extract_deployment_id(rca_bytes: &[u8]) -> Option<String> {
     let signed_rca = SignedRecurringCollectionAgreement::abi_decode(rca_bytes).ok()?;
     let metadata =
-        AcceptIndexingAgreementMetadata::abi_decode(signed_rca.agreement.metadata.as_ref())
-            .ok()?;
+        AcceptIndexingAgreementMetadata::abi_decode(signed_rca.agreement.metadata.as_ref()).ok()?;
     Some(bytes32_to_ipfs_hash(&metadata.subgraphDeploymentId.0))
 }
 

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -152,6 +152,7 @@ impl IndexerDipsService for DipsServer {
 
         // Validate and store RCA
         let domain = crate::rca_eip712_domain(self.chain_id, self.recurring_collector);
+        let deployment_id = crate::try_extract_deployment_id(&signed_voucher);
         match crate::validate_and_create_rca(
             self.ctx.clone(),
             &domain,
@@ -169,7 +170,12 @@ impl IndexerDipsService for DipsServer {
             }
             Err(e) => {
                 let reject_reason = reject_reason_from_error(&e);
-                tracing::warn!(error = %e, reason = ?reject_reason, "RCA rejected");
+                tracing::info!(
+                    error = %e,
+                    reason = ?reject_reason,
+                    deployment_id = deployment_id.as_deref().unwrap_or("unknown"),
+                    "RCA proposal rejected"
+                );
                 Ok(Response::new(SubmitAgreementProposalResponse {
                     response: ProposalResponse::Reject.into(),
                     reject_reason: reject_reason.into(),


### PR DESCRIPTION
## TL;DR

When the indexer rejects a paid indexing proposal, today nothing about why is recorded on the indexer side — only the consumer sees the reason. This change writes the rejection reason and proposed deployment ID to the indexer's logs at info level. The change is logging-only, with no behaviour or wire format changes.

## Motivation

When a payer submits a paid indexing agreement proposal to the indexer, the indexer's service responds over its proposal API with a reject reason but writes nothing to its own logs. An operator looking at the indexer's logs alone can see that proposals are flowing in and being rejected, but cannot tell which subgraph deployment was being proposed or why each one was turned down. Diagnosing a wave of rejections then requires correlating with the consumer side, which an indexer operator may not have access to.

## Summary

- Add a helper that does best-effort decoding of a proposal to recover the deployment ID
- Record the reject reason, deployment ID, and error text on the rejection log line
- Drop the rejection log level from warn to info, since rejections are normal protocol flow
