### PR TITLE
fix: use abi_decode_params for RCA metadata to match Solidity encoding

### DIFF
--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -356,7 +356,8 @@ fn bytes32_to_ipfs_hash(bytes: &[u8; 32]) -> String {
 pub(crate) fn try_extract_deployment_id(rca_bytes: &[u8]) -> Option<String> {
     let signed_rca = SignedRecurringCollectionAgreement::abi_decode(rca_bytes).ok()?;
     let metadata =
-        AcceptIndexingAgreementMetadata::abi_decode_params(signed_rca.agreement.metadata.as_ref()).ok()?;
+        AcceptIndexingAgreementMetadata::abi_decode_params(signed_rca.agreement.metadata.as_ref())
+            .ok()?;
     Some(bytes32_to_ipfs_hash(&metadata.subgraphDeploymentId.0))
 }
 

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -356,7 +356,7 @@ fn bytes32_to_ipfs_hash(bytes: &[u8; 32]) -> String {
 pub(crate) fn try_extract_deployment_id(rca_bytes: &[u8]) -> Option<String> {
     let signed_rca = SignedRecurringCollectionAgreement::abi_decode(rca_bytes).ok()?;
     let metadata =
-        AcceptIndexingAgreementMetadata::abi_decode(signed_rca.agreement.metadata.as_ref()).ok()?;
+        AcceptIndexingAgreementMetadata::abi_decode_params(signed_rca.agreement.metadata.as_ref()).ok()?;
     Some(bytes32_to_ipfs_hash(&metadata.subgraphDeploymentId.0))
 }
 
@@ -413,7 +413,7 @@ pub async fn validate_and_create_rca(
 
     // Decode metadata
     let metadata =
-        AcceptIndexingAgreementMetadata::abi_decode(signed_rca.agreement.metadata.as_ref())
+        AcceptIndexingAgreementMetadata::abi_decode_params(signed_rca.agreement.metadata.as_ref())
             .map_err(|e| {
                 DipsError::AbiDecoding(format!(
                     "Failed to decode AcceptIndexingAgreementMetadata: {e}"
@@ -584,7 +584,7 @@ mod test {
             minSecondsPerCollection: 60,
             maxSecondsPerCollection: 3600,
             nonce: U256::from(1),
-            metadata: metadata.abi_encode().into(),
+            metadata: metadata.abi_encode_params().into(),
         }
     }
 
@@ -793,7 +793,7 @@ mod test {
             minSecondsPerCollection: 60,
             maxSecondsPerCollection: 3600,
             nonce: U256::from(1),
-            metadata: metadata.abi_encode().into(),
+            metadata: metadata.abi_encode_params().into(),
         };
 
         let domain = rca_eip712_domain(CHAIN_ID, recurring_collector);
@@ -840,7 +840,7 @@ mod test {
             minSecondsPerCollection: 60,
             maxSecondsPerCollection: 3600,
             nonce: U256::from(1),
-            metadata: metadata.abi_encode().into(),
+            metadata: metadata.abi_encode_params().into(),
         };
 
         let domain = rca_eip712_domain(CHAIN_ID, recurring_collector);
@@ -884,7 +884,7 @@ mod test {
             minSecondsPerCollection: 60,
             maxSecondsPerCollection: 3600,
             nonce: U256::from(1),
-            metadata: metadata.abi_encode().into(),
+            metadata: metadata.abi_encode_params().into(),
         };
 
         let domain = rca_eip712_domain(CHAIN_ID, recurring_collector);


### PR DESCRIPTION
## Motivation

During local DIPs end-to-end testing, the indexer-service was rejecting every proposal with `ABI decoding error: Failed to decode AcceptIndexingAgreementMetadata`. The root cause is an encoding mismatch between alloy and Solidity for structs containing dynamic fields.

## Summary

Companion to edgeandnode/dipper#582. Alloy's `SolValue::abi_encode()` wraps structs with dynamic fields (`bytes`) with a 32-byte outer tuple offset (`0x20` prefix). Solidity's `abi.encode()` does not include this prefix. Both sides need to use the `_params` variants (`abi_encode_params` / `abi_decode_params`) to produce and consume the same wire format that the SubgraphService contract expects.

Changes `abi_decode` to `abi_decode_params` at the two decode sites, and `abi_encode` to `abi_encode_params` at the four test encode sites. All 58 tests pass.

Generated with [Claude Code](https://claude.com/claude-code)