### PR TITLE
fix: accept v1 indexing agreement proposals during validation

### DIFF
--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -410,8 +410,8 @@ pub async fn validate_and_create_rca(
                 ))
             })?;
 
-    // Only support version 1 terms for now
-    if metadata.version != 1 {
+    // Only support V1 terms (IndexingAgreementVersion.V1 = 0 in Solidity enum)
+    if metadata.version != 0 {
         return Err(DipsError::UnsupportedMetadataVersion(metadata.version));
     }
 
@@ -559,7 +559,7 @@ mod test {
         let metadata = AcceptIndexingAgreementMetadata {
             // Any bytes32 works - MockIpfsFetcher ignores the deployment ID
             subgraphDeploymentId: FixedBytes::ZERO,
-            version: 1,
+            version: 0, // IndexingAgreementVersion.V1 = 0
             terms: terms.abi_encode().into(),
         };
 
@@ -814,7 +814,7 @@ mod test {
 
         let metadata = AcceptIndexingAgreementMetadata {
             subgraphDeploymentId: FixedBytes::ZERO,
-            version: 1,
+            version: 0, // IndexingAgreementVersion.V1 = 0
             terms: terms.abi_encode().into(),
         };
 
@@ -858,7 +858,7 @@ mod test {
 
         let metadata = AcceptIndexingAgreementMetadata {
             subgraphDeploymentId: FixedBytes::ZERO,
-            version: 1,
+            version: 0, // IndexingAgreementVersion.V1 = 0
             terms: terms.abi_encode().into(),
         };
 


### PR DESCRIPTION
## TL;DR

The indexer rejects every legitimate v1 paid indexing proposal because of a mismatch with how the on-chain contract encodes the agreement version. The fix changes the validator to match the contract's encoding. This unblocks the end-to-end paid indexing flow.

## Motivation

When the indexer receives a paid indexing proposal, its proposal validator decodes the agreement metadata and only continues if the metadata's version field equals one. The on-chain contract encodes v1 of the agreement as zero, not one — the smart-contract enum lists v1 as its first variant, which the ABI represents as zero. So every legitimate v1 proposal is rejected as "unsupported metadata version", and the paid indexing runtime flow is fully blocked at the first validation step. This change pairs with the consumer-side fix in edgeandnode/dipper#583.

## Summary

- Match the validator on the contract's encoded value instead of the wrong literal
- Update the test fixtures that asserted the wrong value
- Pairs with the consumer-side fix in edgeandnode/dipper#583
