### PR TITLE
feat: log signer validation outcomes with payer context

### DIFF
--- a/crates/dips/src/signers.rs
+++ b/crates/dips/src/signers.rs
@@ -62,10 +62,30 @@ mod escrow_validator {
         fn validate(&self, payer: &Address, signer: &Address) -> Result<(), anyhow::Error> {
             let signers = self.watcher.borrow().get_signers_for_sender(payer);
 
-            if !signers.contains(signer) {
+            if signers.is_empty() {
+                tracing::warn!(
+                    payer = %payer,
+                    signer = %signer,
+                    "no escrow accounts found for payer — signer authorization may not be indexed yet"
+                );
                 return Err(anyhow!("Signer is not a valid signer for the sender"));
             }
 
+            if !signers.contains(signer) {
+                tracing::warn!(
+                    payer = %payer,
+                    signer = %signer,
+                    authorized_count = signers.len(),
+                    "signer not in authorized list for payer"
+                );
+                return Err(anyhow!("Signer is not a valid signer for the sender"));
+            }
+
+            tracing::debug!(
+                payer = %payer,
+                signer = %signer,
+                "signer authorization validated"
+            );
             Ok(())
         }
     }


### PR DESCRIPTION
## TL;DR

When the indexer rejects a paid indexing proposal because the proposer's signing key isn't authorized, the rejection reaches the consumer but the indexer writes nothing to its own logs. This change adds structured logs at warn or debug for each signer-validation outcome. Operators can now tell a transient indexing lag apart from a real authorization mismatch.

## Motivation

When a paid indexing proposal arrives, the indexer looks up the proposer's escrow account in a subgraph and checks whether the signing key is on the authorized list for that payer. If either step fails the proposal is rejected, but with no log line and the same generic outcome on the wire. The two failure modes are very different in operational terms: an escrow account that simply hasn't been indexed yet is a transient subgraph lag the operator can wait out, while a signer genuinely missing from the authorized list is a real authorization problem. Operators triaging a wave of rejections cannot tell these apart and waste time chasing the wrong root cause.

## Summary

- Warn-log when no escrow record exists for the payer, noting it may not be indexed yet
- Warn-log when the signer isn't on the payer's authorized list, with authorized-signer count
- Debug-log on success
- Include the payer and signer addresses as structured fields for filtering
