### PR TITLE
build: add docker-compose.yml and build-image just target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ indexer.toml
 .vscode/
 # migrations/
 .helix
+.claude/
 
 # Node.js related files
 crates/dips/node_modules/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  indexer-service-rs:
+    image: ghcr.io/graphprotocol/indexer-service-rs:${TAG:-local}
+    build:
+      context: .
+      dockerfile: Dockerfile.indexer-service-rs
+
+  indexer-tap-agent:
+    image: ghcr.io/graphprotocol/indexer-tap-agent:${TAG:-local}
+    build:
+      context: .
+      dockerfile: Dockerfile.indexer-tap-agent

--- a/justfile
+++ b/justfile
@@ -24,6 +24,11 @@ fmt:
     cargo fmt
 sqlx-prepare:
     cargo sqlx prepare --workspace  -- --all-targets --all-features
+
+# Build images ghcr.io/graphprotocol/indexer-service-rs and ghcr.io/graphprotocol/indexer-tap-agent (defaults to :local; set TAG=... to override)
+build-image:
+    docker compose build
+
 psql-up: 
     @docker run -d --name indexer-rs-psql -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
     @sleep 5


### PR DESCRIPTION
Enables local image builds via `just build-image`, producing ghcr.io/graphprotocol/indexer-service-rs:local and ghcr.io/graphprotocol/indexer-tap-agent:local from the existing per-crate Dockerfiles. Lets downstream consumers (local-network) consume this repo as image tags instead of source clones.