### PR TITLE
fix(config): several configuration optimizations

### DIFF
--- a/crates/config/default_values.toml
+++ b/crates/config/default_values.toml
@@ -48,8 +48,6 @@ chain_id = 1337
 receipts_verifier_address_v2 = "0x3333333333333333333333333333333333333333"
 # SubgraphService contract (required).
 subgraph_service_address = "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9"
-# GraphTallyCollector contract (required for V2 escrow filtering).
-graph_tally_collector_address = "0x4444444444444444444444444444444444444444"
 
 [horizon]
 # Enable Horizon support and detection

--- a/crates/config/default_values.toml
+++ b/crates/config/default_values.toml
@@ -48,12 +48,3 @@ chain_id = 1337
 receipts_verifier_address_v2 = "0x3333333333333333333333333333333333333333"
 # SubgraphService contract (required).
 subgraph_service_address = "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9"
-
-[horizon]
-# Enable Horizon support and detection
-# When enabled: checks that Horizon contracts are active via the network subgraph
-# When enabled, set `blockchain.subgraph_service_address` and
-# `blockchain.receipts_verifier_address_v2`
-#
-# Horizon is required in production.
-enabled = true

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -193,7 +193,6 @@ max_receipts_per_request = 10000
 0xDD6a6f76eb36B873C1C184e8b9b9e762FE216490 = "https://tap-aggregator-arbitrum-one.graphops.xyz"
 
 # DIPS (Decentralized Indexing Payment System)
-# NOTE: DIPS requires Horizon mode ([horizon].enabled = true)
 [dips]
 host = "0.0.0.0"
 port = "7601"

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -110,7 +110,7 @@ syncing_interval_secs = 60
 [blockchain]
 # The chain ID of the network that the graph network is running on
 chain_id = 1337
-# Horizon addresses; required when [horizon].enabled = true
+# Horizon addresses (required)
 receipts_verifier_address_v2 = "0x3333333333333333333333333333333333333333"
 subgraph_service_address = "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9"
 
@@ -207,12 +207,3 @@ hardhat = "100"
 
 [dips.additional_networks]
 "eip155:1337" = "hardhat"
-
-[horizon]
-# Enable Horizon support and detection
-# When enabled: checks that Horizon contracts are active via the network subgraph
-# When enabled, set `blockchain.subgraph_service_address` and
-# `blockchain.receipts_verifier_address_v2`
-#
-# Horizon is required in production.
-enabled = true

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -113,7 +113,6 @@ chain_id = 1337
 # Horizon addresses; required when [horizon].enabled = true
 receipts_verifier_address_v2 = "0x3333333333333333333333333333333333333333"
 subgraph_service_address = "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9"
-graph_tally_collector_address = "0x4444444444444444444444444444444444444444"
 
 ##############################################
 # Specific configurations to indexer-service #

--- a/crates/config/minimal-config-example.toml
+++ b/crates/config/minimal-config-example.toml
@@ -61,7 +61,6 @@ chain_id = 1337
 # Horizon addresses; required when [horizon].enabled = true
 receipts_verifier_address_v2 = "0x3333333333333333333333333333333333333333"
 subgraph_service_address = "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9"
-graph_tally_collector_address = "0x4444444444444444444444444444444444444444"
 
 ########################################
 # Specific configurations to tap-agent #

--- a/crates/config/minimal-config-example.toml
+++ b/crates/config/minimal-config-example.toml
@@ -58,7 +58,7 @@ deployment_id = "Qmaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 [blockchain]
 # The chain ID of the network that the graph network is running on
 chain_id = 1337
-# Horizon addresses; required when [horizon].enabled = true
+# Horizon addresses (required)
 receipts_verifier_address_v2 = "0x3333333333333333333333333333333333333333"
 subgraph_service_address = "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9"
 
@@ -70,12 +70,3 @@ subgraph_service_address = "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9"
 # Key-Value of all senders and their aggregator endpoints
 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 0xDD6a6f76eb36B873C1C184e8b9b9e762FE216490 = "https://tap-aggregator-arbitrum-one.graphops.xyz"
-
-[horizon]
-# Enable Horizon support and detection
-# When enabled: checks that Horizon contracts are active via the network subgraph
-# When enabled, set `blockchain.subgraph_service_address` and
-# `blockchain.receipts_verifier_address_v2`
-#
-# Horizon is required in production.
-enabled = true

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -566,8 +566,6 @@ pub struct BlockchainConfig {
     pub receipts_verifier_address_v2: Address,
     /// Address of the SubgraphService contract used for Horizon operations
     pub subgraph_service_address: Option<Address>,
-    /// Address of the GraphTallyCollector contract used to filter V2 escrow account queries.
-    pub graph_tally_collector_address: Address,
 }
 
 impl BlockchainConfig {

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -312,14 +312,6 @@ impl Config {
             "subgraphs.escrow",
         );
 
-        // Horizon configuration validation.
-        if self.blockchain.subgraph_service_address.is_none() {
-            return Err(
-                "Horizon is required; set `blockchain.subgraph_service_address`".to_string(),
-            );
-        }
-        // receipts_verifier_address_v2 is required by config schema.
-
         Ok(())
     }
 
@@ -346,24 +338,6 @@ impl Config {
                     );
                 }
             }
-        }
-    }
-
-    /// Derive TAP operation mode from horizon configuration.
-    ///
-    /// This method translates the `[horizon]` configuration section into a
-    /// [`TapMode`] enum for use throughout the indexer codebase.
-    ///
-    /// # Returns
-    ///
-    /// - [`TapMode::Horizon`] when `horizon.enabled = true` with the configured
-    ///   `blockchain.subgraph_service_address`
-    pub fn tap_mode(&self) -> TapMode {
-        TapMode::Horizon {
-            subgraph_service_address: self
-                .blockchain
-                .subgraph_service_address
-                .expect("subgraph_service_address should be validated during Config::validate()"),
         }
     }
 }
@@ -563,8 +537,8 @@ pub struct BlockchainConfig {
     pub receipts_verifier_address: Option<Address>,
     /// Verifier address for Horizon receipts.
     pub receipts_verifier_address_v2: Address,
-    /// Address of the SubgraphService contract used for Horizon operations
-    pub subgraph_service_address: Option<Address>,
+    /// Address of the SubgraphService contract used for Horizon operations.
+    pub subgraph_service_address: Address,
 }
 
 impl BlockchainConfig {
@@ -710,46 +684,6 @@ pub struct RavRequestConfig {
     pub request_timeout_secs: Duration,
     /// how many receipts are sent in a single rav requests
     pub max_receipts_per_request: u64,
-}
-
-/// TAP protocol operation mode.
-///
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
-pub enum TapMode {
-    /// Horizon TAP mode.
-    Horizon {
-        /// Address of the SubgraphService contract used for Horizon operations.
-        subgraph_service_address: Address,
-    },
-}
-
-impl TapMode {
-    /// Deprecated: Horizon is always enabled; this method always returns true.
-    #[deprecated(note = "Horizon is always enabled; this method always returns true.")]
-    pub fn is_horizon(&self) -> bool {
-        true
-    }
-
-    /// Get the SubgraphService address for Horizon mode.
-    pub fn subgraph_service_address(&self) -> Address {
-        self.require_subgraph_service_address()
-    }
-
-    /// Get the SubgraphService address, panicking if not in Horizon mode.
-    pub fn require_subgraph_service_address(&self) -> Address {
-        match self {
-            TapMode::Horizon {
-                subgraph_service_address,
-            } => *subgraph_service_address,
-        }
-    }
-
-    /// Deprecated: Horizon is always enabled; this method always returns true.
-    #[deprecated(note = "Horizon is always enabled; this method always returns true.")]
-    pub fn supports_v2(&self) -> bool {
-        true
-    }
 }
 
 /// Configuration for Horizon support.

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -41,6 +41,8 @@ pub struct Config {
     pub service: ServiceConfig,
     pub tap: TapConfig,
     pub dips: Option<DipsConfig>,
+    /// Deprecated: Horizon is always enabled. This section is ignored.
+    #[serde(default)]
     pub horizon: HorizonConfig,
 }
 
@@ -310,10 +312,7 @@ impl Config {
             "subgraphs.escrow",
         );
 
-        // Horizon configuration validation (required).
-        if !self.horizon.enabled {
-            return Err("Horizon is required; set [horizon].enabled = true".to_string());
-        }
+        // Horizon configuration validation.
         if self.blockchain.subgraph_service_address.is_none() {
             return Err(
                 "Horizon is required; set `blockchain.subgraph_service_address`".to_string(),
@@ -726,11 +725,10 @@ pub enum TapMode {
 }
 
 impl TapMode {
-    /// Check if the indexer is operating in Horizon mode
-    ///
-    /// Returns `true` when Horizon is enabled, `false` otherwise.
+    /// Deprecated: Horizon is always enabled; this method always returns true.
+    #[deprecated(note = "Horizon is always enabled; this method always returns true.")]
     pub fn is_horizon(&self) -> bool {
-        matches!(self, TapMode::Horizon { .. })
+        true
     }
 
     /// Get the SubgraphService address for Horizon mode.
@@ -747,21 +745,21 @@ impl TapMode {
         }
     }
 
-    /// Check if Horizon receipts are supported.
-    ///
-    /// Alias for [`is_horizon()`](Self::is_horizon) with more explicit naming.
+    /// Deprecated: Horizon is always enabled; this method always returns true.
+    #[deprecated(note = "Horizon is always enabled; this method always returns true.")]
     pub fn supports_v2(&self) -> bool {
-        self.is_horizon()
+        true
     }
 }
 
 /// Configuration for Horizon support.
+///
+/// Note: Horizon is always enabled. The `enabled` field is deprecated and ignored.
 #[derive(Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct HorizonConfig {
-    /// Enable Horizon support and detection.
-    /// When enabled, set `blockchain.subgraph_service_address` and
-    /// `blockchain.receipts_verifier_address_v2`.
+    /// Deprecated: Horizon is now always enabled. This field is ignored.
+    #[deprecated(note = "Horizon is always enabled; this field is ignored.")]
     #[serde(default)]
     pub enabled: bool,
 }
@@ -827,6 +825,40 @@ mod tests {
         .unwrap();
 
         assert_eq!(max_config, max_config_file);
+    }
+
+    /// Test backwards compatibility: configs with deprecated [horizon] section should still work
+    #[sealed_test(files = ["minimal-config-example.toml", "default_values.toml"])]
+    #[allow(deprecated)]
+    fn test_horizon_enabled_backwards_compatibility() {
+        // Test with horizon.enabled = true via environment variable
+        env::set_var("INDEXER_SERVICE_HORIZON__ENABLED", "true");
+        let config_with_horizon_true = Config::parse(
+            ConfigPrefix::Service,
+            Some(PathBuf::from("minimal-config-example.toml")).as_ref(),
+        )
+        .unwrap();
+        assert!(config_with_horizon_true.horizon.enabled);
+        env::remove_var("INDEXER_SERVICE_HORIZON__ENABLED");
+
+        // Test with horizon.enabled = false via environment variable
+        env::set_var("INDEXER_SERVICE_HORIZON__ENABLED", "false");
+        let config_with_horizon_false = Config::parse(
+            ConfigPrefix::Service,
+            Some(PathBuf::from("minimal-config-example.toml")).as_ref(),
+        )
+        .unwrap();
+        assert!(!config_with_horizon_false.horizon.enabled);
+        env::remove_var("INDEXER_SERVICE_HORIZON__ENABLED");
+
+        // Test without horizon section (uses default)
+        let config_without_horizon = Config::parse(
+            ConfigPrefix::Service,
+            Some(PathBuf::from("minimal-config-example.toml")).as_ref(),
+        )
+        .unwrap();
+        // Default is false since #[serde(default)] on bool defaults to false
+        assert!(!config_without_horizon.horizon.enabled);
     }
 
     // Test that we can load config with unknown fields, in particular coming from environment variables

--- a/crates/monitor/src/escrow_accounts.rs
+++ b/crates/monitor/src/escrow_accounts.rs
@@ -128,7 +128,7 @@ pub async fn escrow_accounts_v2(
     indexer_address: Address,
     interval: Duration,
     reject_thawing_signers: bool,
-    graph_tally_collector_address: Address,
+    collector_address: Address,
     min_balance_grt_wei: String,
     max_signers_per_payer: usize,
 ) -> Result<EscrowAccountsWatcher, anyhow::Error> {
@@ -137,7 +137,7 @@ pub async fn escrow_accounts_v2(
             escrow_subgraph,
             indexer_address,
             reject_thawing_signers,
-            graph_tally_collector_address,
+            collector_address,
             min_balance_grt_wei.clone(),
             max_signers_per_payer,
         )
@@ -149,7 +149,7 @@ async fn get_escrow_accounts_v2(
     escrow_subgraph: &'static SubgraphClient,
     indexer_address: Address,
     reject_thawing_signers: bool,
-    graph_tally_collector_address: Address,
+    collector_address: Address,
     min_balance_grt_wei: String,
     max_signers_per_payer: usize,
 ) -> anyhow::Result<EscrowAccounts> {
@@ -181,7 +181,7 @@ async fn get_escrow_accounts_v2(
         let response = escrow_subgraph
             .query::<NetworkEscrowAccountQueryV2, _>(network_escrow_account_v2::Variables {
                 receiver: format!("{indexer_address:x?}"),
-                collector: format!("{graph_tally_collector_address:x?}"),
+                collector: format!("{collector_address:x?}"),
                 thaw_end_timestamp: thaw_end_timestamp.clone(),
                 first: page_size,
                 last: last.unwrap_or_default(),

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -131,7 +131,7 @@ pub async fn run() -> anyhow::Result<()> {
 
     tracing::info!("Horizon contracts detected - using Horizon (V2) mode");
 
-    let graph_tally_collector_address = config.blockchain.graph_tally_collector_address;
+    let collector_address = config.blockchain.receipts_verifier_address_v2;
     let escrow_min_balance_grt_wei = config.subgraphs.network.escrow_min_balance_grt_wei.clone();
     let max_signers_per_payer = config.subgraphs.network.max_signers_per_payer;
 
@@ -140,7 +140,7 @@ pub async fn run() -> anyhow::Result<()> {
         indexer_address,
         config.subgraphs.network.config.syncing_interval_secs,
         true, // Reject thawing signers eagerly
-        graph_tally_collector_address,
+        collector_address,
         escrow_min_balance_grt_wei.clone(),
         max_signers_per_payer,
     )
@@ -232,7 +232,7 @@ pub async fn run() -> anyhow::Result<()> {
             indexer_address,
             Duration::from_secs(500),
             true,
-            graph_tally_collector_address,
+            collector_address,
             escrow_min_balance_grt_wei.clone(),
             max_signers_per_payer,
         )

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -101,15 +101,11 @@ pub async fn run() -> anyhow::Result<()> {
     let indexer_address = config.indexer.indexer_address;
     let ipfs_url = config.service.ipfs_url.clone();
 
-    // Horizon is required; verify contracts are active.
-    if !config.tap_mode().is_horizon() {
-        anyhow::bail!("Horizon mode is required; legacy mode is no longer supported.");
-    }
-
     // V2 escrow accounts (used by DIPS) are in the network subgraph
     let escrow_v2_query_url_for_dips = config.subgraphs.network.config.query_url.clone();
 
-    tracing::info!("Horizon mode configured; checking network subgraph readiness");
+    // Verify Horizon contracts are active in the network subgraph
+    tracing::info!("Checking network subgraph readiness for Horizon mode");
     match indexer_monitor::is_horizon_active(network_subgraph).await {
         Ok(true) => {
             tracing::info!("Horizon contracts detected in network subgraph");

--- a/crates/service/src/service/router.rs
+++ b/crates/service/src/service/router.rs
@@ -271,10 +271,7 @@ impl ServiceRouter {
                 let receipt_max_value = max_receipt_value_grt.get_value();
 
                 // Create checks
-                let allowed_data_services = self
-                    .blockchain
-                    .subgraph_service_address
-                    .map(|addr| vec![addr]);
+                let allowed_data_services = Some(vec![self.blockchain.subgraph_service_address]);
 
                 let checks = IndexerTapContext::get_checks(TapChecksConfig {
                     pgpool: self.database.clone(),

--- a/crates/service/src/service/router.rs
+++ b/crates/service/src/service/router.rs
@@ -157,7 +157,7 @@ impl ServiceRouter {
                     indexer_address,
                     escrow.config.syncing_interval_secs,
                     true, // Reject thawing signers eagerly
-                    self.blockchain.graph_tally_collector_address,
+                    self.blockchain.receipts_verifier_address_v2,
                     min_balance,
                     max_signers,
                 )

--- a/crates/service/tests/router_test.rs
+++ b/crates/service/tests/router_test.rs
@@ -76,7 +76,6 @@ fn build_service_router(inputs: RouterInputs) -> ServiceRouter {
                 receipts_verifier_address: None,
                 receipts_verifier_address_v2: test_assets::VERIFIER_ADDRESS,
                 subgraph_service_address: None,
-                graph_tally_collector_address: Address::ZERO,
             }
         })
         .timestamp_buffer_secs(Duration::from_secs(10))

--- a/crates/service/tests/router_test.rs
+++ b/crates/service/tests/router_test.rs
@@ -75,7 +75,7 @@ fn build_service_router(inputs: RouterInputs) -> ServiceRouter {
                 chain_id: indexer_config::TheGraphChainId::Test,
                 receipts_verifier_address: None,
                 receipts_verifier_address_v2: test_assets::VERIFIER_ADDRESS,
-                subgraph_service_address: None,
+                subgraph_service_address: test_assets::VERIFIER_ADDRESS,
             }
         })
         .timestamp_buffer_secs(Duration::from_secs(10))

--- a/crates/tap-agent/src/agent.rs
+++ b/crates/tap-agent/src/agent.rs
@@ -181,7 +181,7 @@ pub async fn start_agent(
         *indexer_address,
         *network_sync_interval,
         false,
-        CONFIG.blockchain.graph_tally_collector_address,
+        CONFIG.blockchain.receipts_verifier_address_v2,
         escrow_min_balance_grt_wei.clone(),
         *max_signers_per_payer,
     )
@@ -195,7 +195,7 @@ pub async fn start_agent(
         *indexer_address,
         *network_sync_interval,
         true,
-        CONFIG.blockchain.graph_tally_collector_address,
+        CONFIG.blockchain.receipts_verifier_address_v2,
         escrow_min_balance_grt_wei.clone(),
         *max_signers_per_payer,
     )

--- a/crates/tap-agent/src/agent.rs
+++ b/crates/tap-agent/src/agent.rs
@@ -143,12 +143,8 @@ pub async fn start_agent(
     .await
     .with_context(|| "Failed to initialize indexer_allocations watcher")?;
 
-    // Verify Horizon mode is enabled and the network subgraph is ready
-    if !CONFIG.tap_mode().is_horizon() {
-        anyhow::bail!("Legacy TAP mode is no longer supported; enable Horizon mode");
-    }
-
-    tracing::info!("Horizon mode configured; checking network subgraph readiness");
+    // Verify the network subgraph is ready for Horizon mode
+    tracing::info!("Checking network subgraph readiness for Horizon mode");
     match indexer_monitor::is_horizon_active(network_subgraph).await {
         Ok(true) => {
             tracing::info!("Horizon schema available in network subgraph - enabling Horizon mode");

--- a/crates/tap-agent/src/agent/sender_account.rs
+++ b/crates/tap-agent/src/agent/sender_account.rs
@@ -408,8 +408,8 @@ pub struct SenderAccountConfig {
     /// over the escrow balance
     pub trusted_senders: HashSet<Address>,
 
-    /// TAP protocol operation mode (Horizon mode required)
-    pub tap_mode: indexer_config::TapMode,
+    /// SubgraphService contract address
+    pub subgraph_service_address: Address,
 
     /// Interval for periodic allocation reconciliation.
     /// This ensures stale allocations are detected after subgraph connectivity issues.
@@ -430,8 +430,7 @@ impl SenderAccountConfig {
             tap_sender_timeout: config.tap.sender_timeout_secs,
             trusted_senders: config.tap.trusted_senders.clone(),
 
-            // Derive TapMode from horizon configuration
-            tap_mode: config.tap_mode(),
+            subgraph_service_address: config.blockchain.subgraph_service_address,
 
             allocation_reconciliation_interval: config.tap.allocation_reconciliation_interval_secs,
         }
@@ -809,14 +808,8 @@ impl Actor for SenderAccount {
                 "#,
                 )
                 .bind(sender_id.encode_hex())
-                // service_provider is the indexer address; data_service comes from TapMode config
                 .bind(config.indexer_address.encode_hex())
-                .bind(
-                    config
-                        .tap_mode
-                        .require_subgraph_service_address()
-                        .encode_hex(),
-                )
+                .bind(config.subgraph_service_address.encode_hex())
                 .fetch_all(&pgpool)
                 .await
                 .expect("Should not fail to fetch from tap_horizon_ravs")

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -526,12 +526,7 @@ impl State {
                 GROUP BY signer_address
             "#,
         )
-        .bind(
-            self.config
-                .tap_mode
-                .require_subgraph_service_address()
-                .encode_hex(),
-        )
+        .bind(self.config.subgraph_service_address.encode_hex())
         .bind(self.config.indexer_address.encode_hex())
         .fetch_all(&self.pgpool)
         .await
@@ -598,12 +593,7 @@ impl State {
             "#,
         )
         // Constrain to our Horizon bucket to avoid conflating RAVs across services/providers
-        .bind(
-            self.config
-                .tap_mode
-                .require_subgraph_service_address()
-                .encode_hex(),
-        )
+        .bind(self.config.subgraph_service_address.encode_hex())
         .bind(self.config.indexer_address.encode_hex())
         .fetch_all(&self.pgpool)
         .await

--- a/crates/tap-agent/src/agent/sender_accounts_manager.rs
+++ b/crates/tap-agent/src/agent/sender_accounts_manager.rs
@@ -238,10 +238,7 @@ impl Actor for SenderAccountsManager {
     ) -> Result<Self::State, ActorProcessingErr> {
         // Do not pre-map allocations globally. We keep the raw watcher and
         // normalize per SenderAccount.
-        tracing::info!(
-            horizon_active = %config.tap_mode.is_horizon(),
-            "Using raw indexer_allocations watcher; normalization happens per sender"
-        );
+        tracing::info!("Using raw indexer_allocations watcher; normalization happens per sender");
         // We only listen to Horizon notifications.
         let pglistener_v2 = PgListener::connect_with(&pgpool.clone()).await.unwrap();
 

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -177,8 +177,8 @@ pub struct AllocationConfig {
     pub indexer_address: Address,
     /// Polling interval for escrow subgraph
     pub escrow_polling_interval: Duration,
-    /// TAP protocol operation mode (Horizon mode required)
-    pub tap_mode: indexer_config::TapMode,
+    /// SubgraphService contract address
+    pub subgraph_service_address: Address,
 }
 
 impl AllocationConfig {
@@ -189,7 +189,7 @@ impl AllocationConfig {
             rav_request_receipt_limit: config.rav_request_receipt_limit,
             indexer_address: config.indexer_address,
             escrow_polling_interval: config.escrow_polling_interval,
-            tap_mode: config.tap_mode.clone(),
+            subgraph_service_address: config.subgraph_service_address,
         }
     }
 }
@@ -487,7 +487,6 @@ where
                 escrow_accounts.clone(),
             )),
         ];
-        let subgraph_service_address = config.tap_mode.subgraph_service_address();
         let context = TapAgentContext::builder()
             .pgpool(pgpool.clone())
             .allocation_id(T::allocation_id_to_address(&allocation_id))
@@ -495,7 +494,7 @@ where
             .sender(sender)
             .escrow_accounts(escrow_accounts.clone())
             .escrow_accounts_strict(escrow_accounts_strict.clone())
-            .subgraph_service_address(subgraph_service_address)
+            .subgraph_service_address(config.subgraph_service_address)
             .build();
 
         let latest_rav = context.last_rav().await.unwrap_or_default();
@@ -505,7 +504,7 @@ where
             CheckList::new(required_checks),
         );
 
-        let data_service = Some(subgraph_service_address);
+        let data_service = Some(config.subgraph_service_address);
 
         Ok(Self {
             pgpool,

--- a/crates/tap-agent/src/tap/context.rs
+++ b/crates/tap-agent/src/tap/context.rs
@@ -138,8 +138,7 @@ pub struct TapAgentContext<T> {
     #[cfg_attr(test, builder(default = crate::test::INDEXER.1))]
     indexer_address: Address,
     /// SubgraphService address (used by Horizon V2 queries)
-    /// Only present when operating in Horizon mode for V2 operations.
-    subgraph_service_address: Option<Address>,
+    subgraph_service_address: Address,
     escrow_accounts: Receiver<EscrowAccounts>,
     /// Strict escrow accounts watcher that excludes thawing signers.
     /// Used only for RAV signature verification in verify_signer().
@@ -149,27 +148,4 @@ pub struct TapAgentContext<T> {
     /// for each type of network
     #[builder(default = PhantomData)]
     _phantom: PhantomData<T>,
-}
-
-impl<T> TapAgentContext<T> {
-    /// Get the SubgraphService address if available
-    ///
-    /// Returns `Some(Address)` in Horizon mode.
-    pub fn subgraph_service_address(&self) -> Option<Address> {
-        self.subgraph_service_address
-    }
-
-    /// Get the SubgraphService address, panicking if not available
-    ///
-    /// Use this when you know you're in a V2/Horizon context and the address
-    /// should always be available. Panics with a descriptive message if called
-    /// when the address is not set.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `subgraph_service_address` is `None`.
-    pub fn require_subgraph_service_address(&self) -> Address {
-        self.subgraph_service_address
-            .expect("subgraph_service_address not available - check TapMode configuration")
-    }
 }

--- a/crates/tap-agent/src/tap/context/escrow.rs
+++ b/crates/tap-agent/src/tap/context/escrow.rs
@@ -63,6 +63,7 @@ mod tests {
             .sender(sender)
             .escrow_accounts(rx.clone())
             .escrow_accounts_strict(rx)
+            .subgraph_service_address(test_assets::VERIFIER_ADDRESS)
             .build()
     }
 
@@ -102,6 +103,7 @@ mod tests {
             .sender(SENDER)
             .escrow_accounts(rx.clone())
             .escrow_accounts_strict(rx)
+            .subgraph_service_address(test_assets::VERIFIER_ADDRESS)
             .build();
         let result = ctx.verify_signer(ACTIVE_SIGNER).await;
         assert!(

--- a/crates/tap-agent/src/tap/context/rav.rs
+++ b/crates/tap-agent/src/tap/context/rav.rs
@@ -55,15 +55,7 @@ impl RavRead<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon
         )
         .bind(CollectionId::from(self.allocation_id).encode_hex())
         .bind(self.sender.encode_hex())
-        // For Horizon (V2): data_service is the SubgraphService address, service_provider is the indexer
-        .bind(
-            self.subgraph_service_address()
-                .ok_or_else(|| AdapterError::RavRead {
-                    error: "SubgraphService address not available - check TapMode configuration"
-                        .to_string(),
-                })?
-                .encode_hex(),
-        )
+        .bind(self.subgraph_service_address.encode_hex())
         .bind(self.indexer_address.encode_hex())
         .fetch_optional(&self.pgpool)
         .await

--- a/crates/tap-agent/src/tap/context/receipt.rs
+++ b/crates/tap-agent/src/tap/context/receipt.rs
@@ -131,14 +131,7 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
         )
         .bind(CollectionId::from(self.allocation_id).encode_hex())
         .bind(self.sender.encode_hex())
-        .bind(
-            self.subgraph_service_address()
-                .ok_or_else(|| AdapterError::ReceiptRead {
-                    error: "SubgraphService address not available - check TapMode configuration"
-                        .to_string(),
-                })?
-                .encode_hex(),
-        )
+        .bind(self.subgraph_service_address.encode_hex())
         .bind(self.indexer_address.encode_hex())
         .bind(&signers)
         .bind(rangebounds_to_pgrange(timestamp_range_ns))
@@ -310,14 +303,7 @@ impl ReceiptDelete for TapAgentContext<Horizon> {
         .bind(&signers)
         .bind(rangebounds_to_pgrange(timestamp_ns))
         .bind(self.sender.encode_hex())
-        .bind(
-            self.subgraph_service_address()
-                .ok_or_else(|| AdapterError::ReceiptDelete {
-                    error: "SubgraphService address not available - check TapMode configuration"
-                        .to_string(),
-                })?
-                .encode_hex(),
-        )
+        .bind(self.subgraph_service_address.encode_hex())
         .bind(self.indexer_address.encode_hex())
         .execute(&self.pgpool)
         .await?;

--- a/crates/tap-agent/src/test.rs
+++ b/crates/tap-agent/src/test.rs
@@ -11,7 +11,6 @@ use std::{
 
 use actors::TestableActor;
 use bigdecimal::num_bigint::BigInt;
-use indexer_config;
 use indexer_monitor::{DeploymentDetails, EscrowAccounts, SubgraphClient};
 use ractor::{concurrency::JoinHandle, Actor, ActorRef};
 use rand::{distr::Alphanumeric, rng, Rng};
@@ -91,9 +90,7 @@ pub fn get_sender_account_config() -> &'static SenderAccountConfig {
         escrow_polling_interval: ESCROW_POLLING_INTERVAL,
         tap_sender_timeout: Duration::from_secs(63),
         trusted_senders: HashSet::new(),
-        tap_mode: indexer_config::TapMode::Horizon {
-            subgraph_service_address: SUBGRAPH_SERVICE_ADDRESS,
-        },
+        subgraph_service_address: SUBGRAPH_SERVICE_ADDRESS,
         allocation_reconciliation_interval: Duration::from_secs(300),
     }))
 }
@@ -136,9 +133,7 @@ pub async fn create_sender_account(
         escrow_polling_interval: ESCROW_POLLING_INTERVAL,
         tap_sender_timeout: TAP_SENDER_TIMEOUT,
         trusted_senders,
-        tap_mode: indexer_config::TapMode::Horizon {
-            subgraph_service_address: SUBGRAPH_SERVICE_ADDRESS,
-        },
+        subgraph_service_address: SUBGRAPH_SERVICE_ADDRESS,
         allocation_reconciliation_interval,
     }));
 

--- a/crates/tap-agent/tests/tap_agent_test.rs
+++ b/crates/tap-agent/tests/tap_agent_test.rs
@@ -108,9 +108,7 @@ pub async fn start_agent(
         escrow_polling_interval: Duration::from_secs(10),
         tap_sender_timeout: Duration::from_secs(30),
         trusted_senders: HashSet::new(),
-        tap_mode: indexer_config::TapMode::Horizon {
-            subgraph_service_address: SUBGRAPH_SERVICE_ADDRESS,
-        },
+        subgraph_service_address: SUBGRAPH_SERVICE_ADDRESS,
         allocation_reconciliation_interval: Duration::from_secs(300),
     }));
 

--- a/crates/test-assets/src/lib.rs
+++ b/crates/test-assets/src/lib.rs
@@ -405,7 +405,7 @@ pub async fn create_signed_receipt_v2(
         tap_graph::v2::Receipt {
             payer: TAP_SENDER.1,
             service_provider: INDEXER_ADDRESS,
-            data_service: Address::ZERO,
+            data_service: VERIFIER_ADDRESS,
             collection_id: collection_id.into_inner(),
             nonce,
             timestamp_ns,


### PR DESCRIPTION
Addresses #1013 

Horizon mode is now always enabled, making several config fields and abstractions unnecessary. This
PR removes the dead code while maintaining backwards compatibility for existing configs.

## Changes

Remove `graph_tally_collector_address`
- Duplicate of `receipts_verifier_address_v2`; use the latter instead

Deprecate `horizon.enabled`
- Field is now ignored if present (no breaking change for existing configs)
- Removed validation that rejected `enabled = false`

Remove `TapMode` enum
- Only had one variant (Horizon), so replaced with direct `Address` usage
- `SenderAccountConfig.tap_mode` → `SenderAccountConfig.subgraph_service_address`
- Removed `Config.tap_mode()` method

Simplify `subgraph_service_address`
- `BlockchainConfig.subgraph_service_address: Option<Address> → Address`
- `TapAgentContext.subgraph_service_address: Option<Address> → Address`
- Removed unnecessary getter methods that just returned the field
