### PR TITLE
perf: explicitly cast char(n) types in tap receipts table queries

### DIFF
--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -967,11 +967,11 @@ impl DatabaseInteractions for SenderAllocationState<Horizon> {
             FROM
                 tap_horizon_receipts_invalid
             WHERE
-                collection_id = $1
-                AND service_provider = $2
-                AND payer = $3
-                AND data_service = $4
-                AND signer_address IN (SELECT unnest($5::text[]))
+                collection_id = $1::char(64)
+                AND service_provider = $2::char(40)
+                AND payer = $3::char(40)
+                AND data_service = $4::char(40)
+                AND signer_address IN (SELECT unnest($5::char(40)[]))
             "#,
         )
         // self.allocation_id is already a CollectionId in Horizon state
@@ -1026,12 +1026,12 @@ impl DatabaseInteractions for SenderAllocationState<Horizon> {
             FROM
                 tap_horizon_receipts
             WHERE
-                collection_id = $1
-                AND service_provider = $2
-                AND payer = $3
-                AND data_service = $4
+                collection_id = $1::char(64)
+                AND service_provider = $2::char(40)
+                AND payer = $3::char(40)
+                AND data_service = $4::char(40)
                 AND id <= $5
-                AND signer_address IN (SELECT unnest($6::text[]))
+                AND signer_address IN (SELECT unnest($6::char(40)[]))
                 AND timestamp_ns > $7
             "#,
         )

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -971,7 +971,7 @@ impl DatabaseInteractions for SenderAllocationState<Horizon> {
                 AND service_provider = $2::char(40)
                 AND payer = $3::char(40)
                 AND data_service = $4::char(40)
-                AND signer_address IN (SELECT unnest($5::char(40)[]))
+                AND signer_address = ANY($5::char(40)[])
             "#,
         )
         // self.allocation_id is already a CollectionId in Horizon state
@@ -1031,7 +1031,7 @@ impl DatabaseInteractions for SenderAllocationState<Horizon> {
                 AND payer = $3::char(40)
                 AND data_service = $4::char(40)
                 AND id <= $5
-                AND signer_address IN (SELECT unnest($6::char(40)[]))
+                AND signer_address = ANY($6::char(40)[])
                 AND timestamp_ns > $7
             "#,
         )

--- a/crates/tap-agent/src/tap/context/rav.rs
+++ b/crates/tap-agent/src/tap/context/rav.rs
@@ -36,7 +36,7 @@ impl RavRead<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon
     async fn last_rav(&self) -> Result<Option<tap_graph::v2::SignedRav>, Self::AdapterError> {
         let row = sqlx::query(
             r#"
-                SELECT 
+                SELECT
                     signature,
                     collection_id,
                     payer,
@@ -46,11 +46,11 @@ impl RavRead<tap_graph::v2::ReceiptAggregateVoucher> for TapAgentContext<Horizon
                     value_aggregate,
                     metadata
                 FROM tap_horizon_ravs
-                WHERE 
-                    collection_id = $1 
-                    AND payer = $2
-                    AND data_service = $3
-                    AND service_provider = $4
+                WHERE
+                    collection_id = $1::char(64)
+                    AND payer = $2::char(40)
+                    AND data_service = $3::char(40)
+                    AND service_provider = $4::char(40)
             "#,
         )
         .bind(CollectionId::from(self.allocation_id).encode_hex())

--- a/crates/tap-agent/src/tap/context/receipt.rs
+++ b/crates/tap-agent/src/tap/context/receipt.rs
@@ -123,7 +123,7 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
                     AND payer = $2::char(40)
                     AND data_service = $3::char(40)
                     AND service_provider = $4::char(40)
-                    AND signer_address IN (SELECT unnest($5::char(40)[]))
+                    AND signer_address = ANY($5::char(40)[])
                 AND $6::numrange @> timestamp_ns
                 ORDER BY timestamp_ns ASC
                 LIMIT $7
@@ -292,7 +292,7 @@ impl ReceiptDelete for TapAgentContext<Horizon> {
                 DELETE FROM tap_horizon_receipts
                 WHERE
                     collection_id = $1::char(64)
-                    AND signer_address IN (SELECT unnest($2::char(40)[]))
+                    AND signer_address = ANY($2::char(40)[])
                     AND $3::numrange @> timestamp_ns
                     AND payer = $4::char(40)
                     AND data_service = $5::char(40)

--- a/crates/tap-agent/src/tap/context/receipt.rs
+++ b/crates/tap-agent/src/tap/context/receipt.rs
@@ -107,7 +107,7 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
 
         let records = sqlx::query(
             r#"
-                SELECT 
+                SELECT
                     id,
                     signature,
                     collection_id,
@@ -119,11 +119,11 @@ impl ReceiptRead<TapReceipt> for TapAgentContext<Horizon> {
                     value
                 FROM tap_horizon_receipts
                 WHERE
-                    collection_id = $1
-                    AND payer = $2
-                    AND data_service = $3
-                    AND service_provider = $4
-                    AND signer_address IN (SELECT unnest($5::text[]))
+                    collection_id = $1::char(64)
+                    AND payer = $2::char(40)
+                    AND data_service = $3::char(40)
+                    AND service_provider = $4::char(40)
+                    AND signer_address IN (SELECT unnest($5::char(40)[]))
                 AND $6::numrange @> timestamp_ns
                 ORDER BY timestamp_ns ASC
                 LIMIT $7
@@ -291,12 +291,12 @@ impl ReceiptDelete for TapAgentContext<Horizon> {
             r#"
                 DELETE FROM tap_horizon_receipts
                 WHERE
-                    collection_id = $1
-                    AND signer_address IN (SELECT unnest($2::text[]))
+                    collection_id = $1::char(64)
+                    AND signer_address IN (SELECT unnest($2::char(40)[]))
                     AND $3::numrange @> timestamp_ns
-                    AND payer = $4
-                    AND data_service = $5
-                    AND service_provider = $6
+                    AND payer = $4::char(40)
+                    AND data_service = $5::char(40)
+                    AND service_provider = $6::char(40)
             "#,
         )
         .bind(CollectionId::from(self.allocation_id).encode_hex())


### PR DESCRIPTION
Add explicit `::char(n)` casts to SQL query parameters to match the column types in `tap_horizon_receipts` and `tap_horizon_ravs` tables. This prevents PostgreSQL from performing type coercion when comparing text parameters to `char(n)` columns, allowing proper index usage and reducing query time substantially (observed ~30s to <1ms).
