### PR TITLE
ci: add workflow_dispatch trigger to containers.yml

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,6 +1,7 @@
 name: Build and upload Docker image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Allows on-demand image builds from any branch via gh workflow run, producing :sha-<short> tags for downstream integration testing without widening the push-trigger branches list.