### PR TITLE
ci(containers): multi-arch images + workflow_dispatch for main-dips

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -29,69 +29,157 @@ jobs:
     steps:
       - name: Release please
         id: release-please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  builds-linux:
+  prepare:
     runs-on: ubuntu-latest
-    needs: release-please
-    if: always() && (needs.release-please.result == 'success' || needs.release-please.result == 'skipped')
-    strategy:
-      matrix:
-        target: [indexer-service-rs, indexer-tap-agent]
+    outputs:
+      targets: ${{ steps.set.outputs.targets }}
+    steps:
+      - id: set
+        run: echo 'targets=["indexer-service-rs","indexer-tap-agent"]' >> $GITHUB_OUTPUT
 
+  build:
+    name: Build ${{ matrix.target }} (${{ matrix.platform }})
+    needs: [prepare, release-please]
+    if: always() && needs.prepare.result == 'success' && (needs.release-please.result == 'success' || needs.release-please.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.prepare.outputs.targets) }}
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       packages: write
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Extract version from tag
-        id: extract_version
+      - name: Prepare platform pair
         run: |
-          TAG_NAME="${{ needs.release-please.outputs[matrix.target] }}"
-          # Extract the version part from tags with prefix "${{ matrix.target }}-" using a regex pattern
-          if [[ "$TAG_NAME" =~ ^${{ matrix.target }}-(.*)$ ]]; then
-            VERSION="${BASH_REMATCH[1]}"
-          else
-            VERSION=""
-          fi
-          echo $VERSION
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ${{ env.REGISTRY }}/${{matrix.target}}
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}},value=${{steps.extract_version.outputs.version}}
-            type=semver,pattern={{major}}.{{minor}},value=${{steps.extract_version.outputs.version}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{steps.extract_version.outputs.version}}
-            type=semver,pattern={{major}},value=${{steps.extract_version.outputs.version}}
-            type=semver,pattern=v{{version}},value=${{steps.extract_version.outputs.version}}
-            type=semver,pattern=v{{major}}.{{minor}},value=${{steps.extract_version.outputs.version}}
-            type=semver,pattern=v{{major}}.{{minor}}.{{patch}},value=${{steps.extract_version.outputs.version}}
-            type=semver,pattern=v{{major}},value=${{steps.extract_version.outputs.version}}
-            type=sha
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@3227f5311cb93ffd14d13e65d8cc400d30f4dd8a
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+      - name: Docker labels
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.target }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ./
-          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          tags: ${{ steps.meta.outputs.tags }}
           file: Dockerfile.${{ matrix.target }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.target }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          name: digests-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge ${{ matrix.target }} into multi-arch manifest
+    needs: [prepare, release-please, build]
+    if: |
+      !cancelled()
+      && needs.build.result == 'success'
+      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.prepare.outputs.targets) }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # When release-please is skipped (workflow_dispatch, or no releasable commits) VERSION is empty;
+      # meta.outputs.version then falls back to the branch/sha tag, which is intentional.
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          TAG_NAME="${{ needs.release-please.outputs[matrix.target] }}"
+          if [[ "$TAG_NAME" =~ ^${{ matrix.target }}-(.*)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+          else
+            VERSION=""
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.target }}-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker tags
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.target }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}},value=${{ steps.extract_version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.extract_version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.extract_version.outputs.version }}
+            type=semver,pattern={{major}},value=${{ steps.extract_version.outputs.version }}
+            type=semver,pattern=v{{version}},value=${{ steps.extract_version.outputs.version }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ steps.extract_version.outputs.version }}
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}},value=${{ steps.extract_version.outputs.version }}
+            type=semver,pattern=v{{major}},value=${{ steps.extract_version.outputs.version }}
+            # Forced on so workflow_dispatch from a non-default branch (no `latest`,
+            # no tag ref) still yields a populated meta.outputs.version for Inspect.
+            type=sha,enable=true
+
+      # Glob `*` expands to digest-named files written by the build job's Export digest step.
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ matrix.target }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ matrix.target }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,6 +1,7 @@
 name: Build and upload Docker image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Brings the `main-dips` container build up to a native multi-arch (linux/amd64 + linux/arm64) workflow and adds an on-demand `workflow_dispatch` trigger so any branch can produce `:sha-<short>` tags for downstream integration testing without widening the push-trigger branches list.

## What's in here

- **Multi-arch matrix.** Native runner per platform (`ubuntu-24.04`, `ubuntu-24.04-arm`), push-by-digest, manifest fused in a follow-up `merge` job. Per-platform, per-target buildcache scopes to avoid collisions.
- **`workflow_dispatch` trigger.** Manual builds from any branch via `gh workflow run`.
- **SHA-pinned third-party actions** with `# vX.Y.Z` comments. Tags are mutable and the jobs hold `packages: write`.
- **Merge gate:** `!cancelled() && needs.build.result == 'success'` + fork-PR check, so `workflow_dispatch` from a non-default branch doesn't leave orphan per-platform digest blobs in GHCR.
- **Target list** owned by a small `prepare` job and consumed via `fromJSON` in `build` and `merge` (removes the duplicated matrix between the two).
- **`type=sha,enable=true`** so `meta.outputs.version` is populated for the `Inspect` step on `workflow_dispatch` from a non-default branch (where `latest` and `ref,event=tag` don't fire).