### PR TITLE
refactor: drop misleading DIPs payer allowlist

### DIFF
--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -175,15 +175,10 @@ max_receipts_per_request = 10000
 0xDD6a6f76eb36B873C1C184e8b9b9e762FE216490 = "https://tap-aggregator-arbitrum-one.graphops.xyz"
 
 # DIPS (Decentralized Indexing Payment System). Requires Horizon mode.
-# Payer auth is verified on-chain at acceptance; the `allowed_payers`
-# list below gates which payers may even propose. GRT prices, not wei.
+# Payer auth is verified on-chain at acceptance. GRT prices, not wei.
 [dips]
 host = "0.0.0.0"
 port = "7601"
-
-# Trusted payers. Omit field = accept any caller (legacy); `[]` = deny
-# all. Production addresses TBD — list real dipper addresses to use it.
-# allowed_payers = ["0x0000000000000000000000000000000000000000"]
 
 # Networks you explicitly support indexing.
 # Proposals from the dipper for you to index networks that are not in the list below are rejected.

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -174,8 +174,8 @@ max_receipts_per_request = 10000
 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 0xDD6a6f76eb36B873C1C184e8b9b9e762FE216490 = "https://tap-aggregator-arbitrum-one.graphops.xyz"
 
-# DIPS (Decentralized Indexing Payment System). Requires Horizon mode.
-# Payer auth is verified on-chain at acceptance. GRT prices, not wei.
+# DIPs (Direct Indexer Payments). Payer authorisation is verified
+# on-chain at acceptance. GRT prices, not wei.
 [dips]
 host = "0.0.0.0"
 port = "7601"

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -679,12 +679,6 @@ pub struct DipsConfig {
     /// Minimum acceptable GRT per billion entities per 30 days.
     pub min_grt_per_billion_entities_per_30_days: GRT,
     pub additional_networks: BTreeMap<String, String>,
-    /// Optional allowlist of payer addresses. When `Some`, only proposals
-    /// whose `payer` field is in this set are accepted; everything else is
-    /// rejected before the IPFS fetch. When `None` (the default), proposals
-    /// from any payer are accepted — the operator should normally list the
-    /// addresses of the dippers they do business with.
-    pub allowed_payers: Option<HashSet<Address>>,
 }
 
 impl Default for DipsConfig {
@@ -696,7 +690,6 @@ impl Default for DipsConfig {
             min_grt_per_30_days: BTreeMap::new(),
             min_grt_per_billion_entities_per_30_days: GRT::ZERO,
             additional_networks: BTreeMap::new(),
-            allowed_payers: None,
         }
     }
 }

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -168,8 +168,6 @@ pub enum DipsError {
     },
     #[error("tokens per entity per second {offered} is below configured minimum {minimum}")]
     TokensPerEntityPerSecondTooLow { minimum: U256, offered: U256 },
-    #[error("payer {0} is not in the configured allowlist")]
-    PayerNotAllowed(Address),
     // misc
     #[error("unknown error: {0}")]
     UnknownError(#[from] anyhow::Error),
@@ -277,22 +275,12 @@ pub async fn validate_and_create_rca(
         price_calculator,
         registry,
         additional_networks,
-        allowed_payers,
         ..
     } = ctx.as_ref();
 
     // Decode SignedRCA
     let signed_rca = SignedRecurringCollectionAgreement::abi_decode(rca_bytes.as_ref())
         .map_err(|e| DipsError::AbiDecoding(e.to_string()))?;
-
-    // Reject proposals whose claimed payer is not in the configured allowlist
-    // before doing any I/O. When the allowlist is `None` every payer is
-    // accepted (legacy default).
-    if let Some(allowed) = allowed_payers {
-        if !allowed.contains(&signed_rca.agreement.payer) {
-            return Err(DipsError::PayerNotAllowed(signed_rca.agreement.payer));
-        }
-    }
 
     // Validate service provider
     signed_rca.validate(expected_service_provider)?;
@@ -461,7 +449,6 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
-            allowed_payers: None,
         })
     }
 
@@ -674,66 +661,6 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_validate_and_create_rca_rejects_payer_not_in_allowlist() {
-        let payer = Address::repeat_byte(0x42);
-        let allowed_payer = Address::repeat_byte(0x99);
-        let service_provider = Address::repeat_byte(0x11);
-
-        let rca = create_test_rca(payer, service_provider, U256::from(200), U256::from(100));
-
-        let ctx = Arc::new(DipsServerContext {
-            rca_store: Arc::new(InMemoryRcaStore::default()),
-            ipfs_fetcher: Arc::new(MockIpfsFetcher::default()),
-            price_calculator: Arc::new(PriceCalculator::new(
-                HashSet::from(["mainnet".to_string()]),
-                BTreeMap::from([("mainnet".to_string(), U256::from(100))]),
-                U256::from(50),
-            )),
-            registry: Arc::new(crate::registry::test_registry()),
-            additional_networks: Arc::new(BTreeMap::new()),
-            allowed_payers: Some(HashSet::from([allowed_payer])),
-        });
-        let rca_bytes = rca_to_wire_bytes(rca);
-
-        let result = super::validate_and_create_rca(ctx, &service_provider, rca_bytes).await;
-
-        assert!(
-            matches!(result, Err(DipsError::PayerNotAllowed(addr)) if addr == payer),
-            "Expected PayerNotAllowed({:?}), got {:?}",
-            payer,
-            result
-        );
-    }
-
-    #[tokio::test]
-    async fn test_validate_and_create_rca_accepts_payer_in_allowlist() {
-        let payer = Address::repeat_byte(0x42);
-        let service_provider = Address::repeat_byte(0x11);
-
-        let rca = create_test_rca(payer, service_provider, U256::from(200), U256::from(100));
-        let agreement_id = derive_agreement_id(&rca);
-
-        let ctx = Arc::new(DipsServerContext {
-            rca_store: Arc::new(InMemoryRcaStore::default()),
-            ipfs_fetcher: Arc::new(MockIpfsFetcher::default()),
-            price_calculator: Arc::new(PriceCalculator::new(
-                HashSet::from(["mainnet".to_string()]),
-                BTreeMap::from([("mainnet".to_string(), U256::from(100))]),
-                U256::from(50),
-            )),
-            registry: Arc::new(crate::registry::test_registry()),
-            additional_networks: Arc::new(BTreeMap::new()),
-            allowed_payers: Some(HashSet::from([payer])),
-        });
-        let rca_bytes = rca_to_wire_bytes(rca);
-
-        let result = super::validate_and_create_rca(ctx, &service_provider, rca_bytes).await;
-
-        assert!(result.is_ok(), "expected Ok, got {:?}", result);
-        assert_eq!(result.unwrap(), agreement_id);
-    }
-
-    #[tokio::test]
     async fn test_validate_and_create_rca_tokens_per_second_too_low() {
         let payer = Address::repeat_byte(0x42);
         let service_provider = Address::repeat_byte(0x11);
@@ -791,7 +718,6 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
-            allowed_payers: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -965,7 +891,6 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
-            allowed_payers: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1000,7 +925,6 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
-            allowed_payers: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1035,7 +959,6 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
-            allowed_payers: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -42,10 +42,7 @@
 //! directly and indexer-agents observe `IndexingAgreementCanceled` events through
 //! the indexing-payments subgraph.
 
-use std::{
-    collections::{BTreeMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
 use thegraph_core::alloy::primitives::Address;
@@ -81,10 +78,6 @@ pub struct DipsServerContext {
     pub registry: Arc<graph_networks_registry::NetworksRegistry>,
     /// Additional networks beyond the registry
     pub additional_networks: Arc<BTreeMap<String, String>>,
-    /// Optional allowlist of payer addresses. When `Some`, proposals whose
-    /// `payer` field is not in this set are rejected before any I/O. When
-    /// `None`, every payer is accepted (legacy default).
-    pub allowed_payers: Option<HashSet<Address>>,
 }
 
 /// DIPS server implementing RCA protocol.
@@ -116,10 +109,6 @@ fn reject_reason_from_error(err: &DipsError) -> RejectReason {
         DipsError::SubgraphManifestUnavailable(_) => RejectReason::SubgraphManifestUnavailable,
         DipsError::UnexpectedServiceProvider { .. } => RejectReason::UnexpectedServiceProvider,
         DipsError::UnsupportedMetadataVersion(_) => RejectReason::UnsupportedMetadataVersion,
-        // Deliberately maps to Other so the wire response doesn't disclose
-        // why the rejection happened — a caller probing for who is on the
-        // allowlist would otherwise learn that by trial and error.
-        DipsError::PayerNotAllowed(_) => RejectReason::Other,
         _ => RejectReason::Other,
     }
 }
@@ -223,7 +212,6 @@ mod tests {
                 )),
                 registry: Arc::new(crate::registry::test_registry()),
                 additional_networks: Arc::new(BTreeMap::new()),
-                allowed_payers: None,
             })
         }
     }

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -209,7 +209,6 @@ pub async fn run() -> anyhow::Result<()> {
             min_grt_per_30_days,
             min_grt_per_billion_entities_per_30_days,
             additional_networks,
-            allowed_payers,
             ..
         } = dips;
 
@@ -289,7 +288,6 @@ pub async fn run() -> anyhow::Result<()> {
             )),
             registry,
             additional_networks: Arc::new(additional_networks.clone()),
-            allowed_payers: allowed_payers.clone(),
         });
 
         // Create DIPS server


### PR DESCRIPTION
## TL;DR
Drops the `allowed_payers` config field, which gave operators a false sense of access control, and tidies up two stale comments in the maximal config example. Behaviour change: the field is removed; the field shipped in the just-merged on-chain offer PR and no production deployment has picked it up yet, so the blast radius is local-network only.

## Motivation
The DIPs gRPC server accepts proposals from anyone who can reach the port. The `allowed_payers` allowlist looked like access control but only checked the `payer` field inside the proposal, which is just data the caller writes — an attacker could spoof any address and walk past it. So what looked like a wire-level gate was a name filter on caller-supplied data, not authentication. The actual trust gate sits on-chain: the indexer-agent's acceptance call verifies the payer signature via the contract, and rate limits absorb the cost of doing the lookup for junk requests.

While here, two comments in the maximal config example are also corrected. The DIPs acronym was expanded as "Decentralized Indexing Payment System" (the correct expansion is "Direct Indexer Payments"), and a "Requires Horizon mode" hint was stale since the runtime Horizon check was dropped recently and Horizon is now always-on.

## Summary
- Remove the allowlist config field
- Remove the allowlist check from the proposal validator
- Drop the corresponding error variant
- Remove the allowlist field from the gRPC server context
- Drop the two unit tests that exercised the allowlist
- Remove the `allowed_payers` entry from the maximal config example
- Correct the DIPs acronym expansion and drop the stale Horizon mode comment