### PR TITLE
feat: verify the signature on indexing agreement proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4343,6 +4343,7 @@ dependencies = [
  "prost 0.14.3",
  "rand 0.8.5",
  "serde",
+ "serde_json",
  "serde_yaml",
  "sqlx",
  "test-assets",
@@ -4356,6 +4357,7 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -194,6 +194,10 @@ supported_networks = []
 # Your own observations may differ - adjust pricing accordingly.
 min_grt_per_billion_entities_per_30_days = "200"  # entity-based component (global)
 
+# RecurringCollector contract address. The EIP-712 verifying contract used to
+# recover the signer of incoming agreement proposals. Required when DIPs is enabled.
+recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
+
 [dips.min_grt_per_30_days]  # base rate component (per-network)
 # arbitrum-one = "450"
 # matic = "300"

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -198,6 +198,11 @@ min_grt_per_billion_entities_per_30_days = "200"  # entity-based component (glob
 # recover the signer of incoming agreement proposals. Required when DIPs is enabled.
 recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
 
+# Ethereum JSON-RPC endpoint used to fetch the EIP-712 domain from the
+# RecurringCollector at startup (EIP-5267), so verification tracks the deployed
+# contract. When unset, built-in domain constants are used instead.
+rpc_url = "https://example.com/rpc"
+
 [dips.min_grt_per_30_days]  # base rate component (per-network)
 # arbitrum-one = "450"
 # matic = "300"

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -198,10 +198,9 @@ min_grt_per_billion_entities_per_30_days = "200"  # entity-based component (glob
 # recover the signer of incoming agreement proposals. Required when DIPs is enabled.
 recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
 
-# Ethereum JSON-RPC endpoint used to fetch the EIP-712 domain from the
-# RecurringCollector at startup (EIP-5267), so verification tracks the deployed
-# contract. When unset, built-in domain constants are used instead.
-rpc_url = "https://example.com/rpc"
+# Ethereum JSON-RPC endpoint for fetching the RecurringCollector's EIP-712
+# domain at startup (EIP-5267). When unset, built-in domain constants are used.
+# rpc_url = "https://arb1.arbitrum.io/rpc"
 
 [dips.min_grt_per_30_days]  # base rate component (per-network)
 # arbitrum-one = "450"

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -775,7 +775,6 @@ mod tests {
         max_config.dips = Some(crate::DipsConfig {
             min_grt_per_billion_entities_per_30_days: crate::GRT::from_grt("200"),
             recurring_collector: Some(address!("cccccccccccccccccccccccccccccccccccccccc")),
-            rpc_url: Some(url::Url::parse("https://example.com/rpc").unwrap()),
             ..Default::default()
         });
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -682,6 +682,9 @@ pub struct DipsConfig {
     /// RecurringCollector address: the EIP-712 verifying contract used to recover
     /// the signer of incoming RCA proposals. Required when DIPs is enabled.
     pub recurring_collector: Option<Address>,
+    /// Ethereum JSON-RPC endpoint used to fetch the EIP-712 domain from the
+    /// RecurringCollector at startup (EIP-5267). Unset: built-in domain constants.
+    pub rpc_url: Option<Url>,
 }
 
 impl Default for DipsConfig {
@@ -694,6 +697,7 @@ impl Default for DipsConfig {
             min_grt_per_billion_entities_per_30_days: GRT::ZERO,
             additional_networks: BTreeMap::new(),
             recurring_collector: None,
+            rpc_url: None,
         }
     }
 }
@@ -771,6 +775,7 @@ mod tests {
         max_config.dips = Some(crate::DipsConfig {
             min_grt_per_billion_entities_per_30_days: crate::GRT::from_grt("200"),
             recurring_collector: Some(address!("cccccccccccccccccccccccccccccccccccccccc")),
+            rpc_url: Some(url::Url::parse("https://example.com/rpc").unwrap()),
             ..Default::default()
         });
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -679,6 +679,9 @@ pub struct DipsConfig {
     /// Minimum acceptable GRT per billion entities per 30 days.
     pub min_grt_per_billion_entities_per_30_days: GRT,
     pub additional_networks: BTreeMap<String, String>,
+    /// RecurringCollector address: the EIP-712 verifying contract used to recover
+    /// the signer of incoming RCA proposals. Required when DIPs is enabled.
+    pub recurring_collector: Option<Address>,
 }
 
 impl Default for DipsConfig {
@@ -690,6 +693,7 @@ impl Default for DipsConfig {
             min_grt_per_30_days: BTreeMap::new(),
             min_grt_per_billion_entities_per_30_days: GRT::ZERO,
             additional_networks: BTreeMap::new(),
+            recurring_collector: None,
         }
     }
 }
@@ -766,6 +770,7 @@ mod tests {
             HashSet::from([address!("deadbeefcafebabedeadbeefcafebabedeadbeef")]);
         max_config.dips = Some(crate::DipsConfig {
             min_grt_per_billion_entities_per_30_days: crate::GRT::from_grt("200"),
+            recurring_collector: Some(address!("cccccccccccccccccccccccccccccccccccccccc")),
             ..Default::default()
         });
 

--- a/crates/dips/Cargo.toml
+++ b/crates/dips/Cargo.toml
@@ -58,6 +58,8 @@ indexer-monitor = { path = "../monitor" }
 graph-networks-registry.workspace = true
 build-info.workspace = true
 rand = "0.8"
+serde_json.workspace = true
+wiremock.workspace = true
 
 [build-dependencies]
 tonic-build = { workspace = true, optional = true }

--- a/crates/dips/src/eip5267.rs
+++ b/crates/dips/src/eip5267.rs
@@ -1,0 +1,313 @@
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
+// SPDX-License-Identifier: Apache-2.0
+
+//! EIP-5267 domain discovery: derive the RCA verification domain from the
+//! RecurringCollector's own `eip712Domain()` report so it tracks in-place
+//! contract upgrades instead of relying on compile-time constants.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use thegraph_core::alloy::{
+    network::TransactionBuilder,
+    primitives::{Address, Bytes, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
+    sol,
+    sol_types::{Eip712Domain, SolCall},
+};
+
+sol! {
+    /// EIP-5267 introspection: a contract reports its own EIP-712 domain.
+    function eip712Domain() external view returns (
+        bytes1 fields,
+        string name,
+        string version,
+        uint256 chainId,
+        address verifyingContract,
+        bytes32 salt,
+        uint256[] extensions
+    );
+}
+
+/// Attempts before giving up on the RPC fetch.
+const FETCH_ATTEMPTS: u32 = 3;
+/// Delay between fetch attempts.
+const FETCH_RETRY_DELAY: Duration = Duration::from_secs(2);
+/// Upper bound on the reported domain name/version. The real values are short
+/// ("RecurringCollector", "1"); anything huge is a hostile or broken RPC.
+const MAX_DOMAIN_FIELD_LEN: usize = 256;
+
+/// Fetch the RCA EIP-712 domain from the RecurringCollector via `eip712Domain()`.
+/// Only network errors are retried; a response that fails to decode or fails
+/// validation (wrong chain id or contract) errors immediately, retries won't fix it.
+pub async fn fetch_rca_eip712_domain(
+    rpc_url: &str,
+    recurring_collector: Address,
+    expected_chain_id: u64,
+) -> anyhow::Result<Eip712Domain> {
+    let mut attempt = 1;
+    let output = loop {
+        match call_eip712_domain(rpc_url, recurring_collector).await {
+            Ok(output) => break output,
+            Err(err) if attempt < FETCH_ATTEMPTS => {
+                tracing::warn!(
+                    attempt,
+                    error = format!("{err:#}"),
+                    "eip712Domain() fetch failed, retrying"
+                );
+                attempt += 1;
+                tokio::time::sleep(FETCH_RETRY_DELAY).await;
+            }
+            Err(err) => return Err(err),
+        }
+    };
+    let report = eip712DomainCall::abi_decode_returns(&output)
+        .context("decoding the eip712Domain() response")?;
+    let domain = domain_from_report(report, recurring_collector, expected_chain_id)?;
+    tracing::info!(
+        name = domain.name.as_deref().unwrap_or_default(),
+        version = domain.version.as_deref().unwrap_or_default(),
+        chain_id = expected_chain_id,
+        verifying_contract = %recurring_collector,
+        "RCA EIP-712 domain fetched from RecurringCollector"
+    );
+    Ok(domain)
+}
+
+async fn call_eip712_domain(rpc_url: &str, recurring_collector: Address) -> anyhow::Result<Bytes> {
+    let provider = ProviderBuilder::new()
+        .connect(rpc_url)
+        .await
+        .context("connecting to dips.rpc_url")?;
+    let request = TransactionRequest::default()
+        .with_to(recurring_collector)
+        .with_input(eip712DomainCall {}.abi_encode());
+    provider
+        .call(request)
+        .await
+        .context("calling eip712Domain() on the RecurringCollector")
+}
+
+/// Build the verification domain from the contract's report, rejecting
+/// reports that don't match the configured chain id and collector address.
+fn domain_from_report(
+    report: eip712DomainReturn,
+    recurring_collector: Address,
+    expected_chain_id: u64,
+) -> anyhow::Result<Eip712Domain> {
+    anyhow::ensure!(
+        report.fields.0 == [0x0f],
+        "eip712Domain() fields bitmap {:#04x} unsupported: expected 0x0f \
+         (name, version, chainId, verifyingContract)",
+        report.fields.0[0]
+    );
+    anyhow::ensure!(
+        report.extensions.is_empty(),
+        "eip712Domain() reports {} extensions, which are not supported",
+        report.extensions.len()
+    );
+    anyhow::ensure!(
+        !report.name.is_empty() && report.name.len() <= MAX_DOMAIN_FIELD_LEN,
+        "eip712Domain() reports a domain name of {} bytes; expected 1-{MAX_DOMAIN_FIELD_LEN}",
+        report.name.len()
+    );
+    anyhow::ensure!(
+        !report.version.is_empty() && report.version.len() <= MAX_DOMAIN_FIELD_LEN,
+        "eip712Domain() reports a domain version of {} bytes; expected 1-{MAX_DOMAIN_FIELD_LEN}",
+        report.version.len()
+    );
+    anyhow::ensure!(
+        report.chainId == U256::from(expected_chain_id),
+        "eip712Domain() reports chain id {} but blockchain.chain_id is {expected_chain_id}; \
+         check that dips.rpc_url points at the right network",
+        report.chainId
+    );
+    anyhow::ensure!(
+        report.verifyingContract == recurring_collector,
+        "eip712Domain() reports verifying contract {} but dips.recurring_collector \
+         is {recurring_collector}",
+        report.verifyingContract
+    );
+    Ok(Eip712Domain::new(
+        Some(report.name.into()),
+        Some(report.version.into()),
+        Some(U256::from(expected_chain_id)),
+        Some(recurring_collector),
+        None,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use thegraph_core::alloy::primitives::{hex, Address, FixedBytes, B256, U256};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    use super::*;
+    use crate::rca_eip712_domain;
+
+    const CHAIN_ID: u64 = 1337;
+
+    fn collector() -> Address {
+        Address::repeat_byte(0xCC)
+    }
+
+    fn report(
+        fields: u8,
+        name: &str,
+        version: &str,
+        chain_id: u64,
+        verifying_contract: Address,
+    ) -> eip712DomainReturn {
+        eip712DomainReturn {
+            fields: FixedBytes([fields]),
+            name: name.to_string(),
+            version: version.to_string(),
+            chainId: U256::from(chain_id),
+            verifyingContract: verifying_contract,
+            salt: B256::ZERO,
+            extensions: vec![],
+        }
+    }
+
+    #[test]
+    fn test_domain_from_report_matches_builtin_domain() {
+        // Arrange
+        let report = report(0x0f, "RecurringCollector", "1", CHAIN_ID, collector());
+
+        // Act
+        let domain = domain_from_report(report, collector(), CHAIN_ID).expect("valid report");
+
+        // Assert
+        assert_eq!(domain, rca_eip712_domain(CHAIN_ID, collector()));
+    }
+
+    #[test]
+    fn test_domain_from_report_rejects_chain_id_mismatch() {
+        // Arrange
+        let report = report(0x0f, "RecurringCollector", "1", 42161, collector());
+
+        // Act
+        let err = domain_from_report(report, collector(), CHAIN_ID).unwrap_err();
+
+        // Assert
+        assert!(err.to_string().contains("chain id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_domain_from_report_rejects_contract_mismatch() {
+        // Arrange
+        let report = report(
+            0x0f,
+            "RecurringCollector",
+            "1",
+            CHAIN_ID,
+            Address::repeat_byte(0xDD),
+        );
+
+        // Act
+        let err = domain_from_report(report, collector(), CHAIN_ID).unwrap_err();
+
+        // Assert
+        assert!(err.to_string().contains("verifying contract"), "got: {err}");
+    }
+
+    #[test]
+    fn test_domain_from_report_rejects_nonempty_extensions() {
+        // Arrange
+        let mut report = report(0x0f, "RecurringCollector", "1", CHAIN_ID, collector());
+        report.extensions = vec![U256::ZERO];
+
+        // Act
+        let err = domain_from_report(report, collector(), CHAIN_ID).unwrap_err();
+
+        // Assert
+        assert!(err.to_string().contains("extensions"), "got: {err}");
+    }
+
+    #[test]
+    fn test_domain_from_report_rejects_empty_name() {
+        // Arrange
+        let report = report(0x0f, "", "1", CHAIN_ID, collector());
+
+        // Act
+        let err = domain_from_report(report, collector(), CHAIN_ID).unwrap_err();
+
+        // Assert
+        assert!(err.to_string().contains("domain name"), "got: {err}");
+    }
+
+    #[test]
+    fn test_domain_from_report_rejects_oversized_version() {
+        // Arrange
+        let oversized = "1".repeat(MAX_DOMAIN_FIELD_LEN + 1);
+        let report = report(
+            0x0f,
+            "RecurringCollector",
+            &oversized,
+            CHAIN_ID,
+            collector(),
+        );
+
+        // Act
+        let err = domain_from_report(report, collector(), CHAIN_ID).unwrap_err();
+
+        // Assert
+        assert!(err.to_string().contains("domain version"), "got: {err}");
+    }
+
+    #[test]
+    fn test_domain_from_report_rejects_unknown_fields_bitmap() {
+        // Arrange: 0x1f would mean the domain also uses a salt, which the
+        // built domain would silently omit, so it must be rejected.
+        let report = report(0x1f, "RecurringCollector", "1", CHAIN_ID, collector());
+
+        // Act
+        let err = domain_from_report(report, collector(), CHAIN_ID).unwrap_err();
+
+        // Assert
+        assert!(err.to_string().contains("fields bitmap"), "got: {err}");
+    }
+
+    /// Replies to any JSON-RPC request with the given eth_call result,
+    /// echoing the request id so the client accepts the response.
+    struct EthCallResponder {
+        result: Vec<u8>,
+    }
+
+    impl Respond for EthCallResponder {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": format!("0x{}", hex::encode(&self.result)),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_rca_eip712_domain_round_trip() {
+        // Arrange
+        let encoded = eip712DomainCall::abi_encode_returns(&report(
+            0x0f,
+            "RecurringCollector",
+            "1",
+            CHAIN_ID,
+            collector(),
+        ));
+        let server = MockServer::start().await;
+        Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(EthCallResponder { result: encoded })
+            .mount(&server)
+            .await;
+
+        // Act
+        let domain = fetch_rca_eip712_domain(&server.uri(), collector(), CHAIN_ID)
+            .await
+            .expect("fetch should succeed");
+
+        // Assert
+        assert_eq!(domain, rca_eip712_domain(CHAIN_ID, collector()));
+    }
+}

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -61,6 +61,7 @@ use thegraph_core::alloy::{
 
 #[cfg(feature = "db")]
 pub mod database;
+pub mod eip5267;
 pub mod inflight;
 pub mod ipfs;
 pub mod price;
@@ -74,6 +75,8 @@ pub mod store;
 
 use thiserror::Error;
 use uuid::Uuid;
+
+pub use crate::eip5267::fetch_rca_eip712_domain;
 
 /// Protocol version (seconds-based RCA)
 pub const PROTOCOL_VERSION: u64 = 2;

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -53,10 +53,10 @@ use std::sync::Arc;
 use server::DipsServerContext;
 use thegraph_core::alloy::{
     core::primitives::Address,
-    primitives::{keccak256, ruint::aliases::U256, Uint},
+    primitives::{keccak256, ruint::aliases::U256, Signature, Uint},
     signers::SignerSync,
     sol,
-    sol_types::{Eip712Domain, SolValue},
+    sol_types::{eip712_domain, Eip712Domain, SolStruct, SolValue},
 };
 
 #[cfg(feature = "db")]
@@ -147,9 +147,23 @@ fn derive_agreement_id(rca: &RecurringCollectionAgreement) -> Uuid {
     Uuid::from_bytes(id_bytes)
 }
 
+/// EIP-712 domain for RecurringCollectionAgreement signatures. Must match the
+/// domain dipper signs with and the on-chain RecurringCollector contract; any
+/// drift in name, version, chain id, or address makes every recovered signer wrong.
+pub fn rca_eip712_domain(chain_id: u64, recurring_collector: Address) -> Eip712Domain {
+    eip712_domain! {
+        name: "RecurringCollector",
+        version: "1",
+        chain_id: chain_id,
+        verifying_contract: recurring_collector,
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum DipsError {
     // RCA validation
+    #[error("invalid signature: {0}")]
+    InvalidSignature(String),
     #[error("RCA service provider {actual} does not match the expected address {expected}")]
     UnexpectedServiceProvider { expected: Address, actual: Address },
     #[error("cannot get subgraph manifest for {0}")]
@@ -208,6 +222,20 @@ impl RecurringCollectionAgreement {
 }
 
 impl SignedRecurringCollectionAgreement {
+    /// Recover the EIP-712 signer of the RCA over the RecurringCollector domain.
+    /// An empty, malformed, or non-recovering signature is rejected as
+    /// InvalidSignature. The recovered address is what PR B gates on.
+    pub fn recover_signer(&self, domain: &Eip712Domain) -> Result<Address, DipsError> {
+        if self.signature.is_empty() {
+            return Err(DipsError::InvalidSignature("missing signature".to_string()));
+        }
+        let signature = Signature::try_from(self.signature.as_ref())
+            .map_err(|err| DipsError::InvalidSignature(err.to_string()))?;
+        signature
+            .recover_address_from_prehash(&self.agreement.eip712_signing_hash(domain))
+            .map_err(|err| DipsError::InvalidSignature(err.to_string()))
+    }
+
     /// Validate proposal-time fields.
     ///
     /// Checks that the service provider matches the expected indexer
@@ -275,12 +303,18 @@ pub async fn validate_and_create_rca(
         price_calculator,
         registry,
         additional_networks,
-        ..
+        rca_domain,
     } = ctx.as_ref();
 
     // Decode SignedRCA
     let signed_rca = SignedRecurringCollectionAgreement::abi_decode(rca_bytes.as_ref())
         .map_err(|e| DipsError::AbiDecoding(e.to_string()))?;
+
+    // Authenticate the sender before acting on the proposal: recover the EIP-712
+    // signer. PR B gates this address against the on-chain agreement-manager role
+    // set; for now any cryptographically valid signature passes.
+    let signer = signed_rca.recover_signer(rca_domain)?;
+    tracing::debug!(%signer, "recovered RCA signer");
 
     // Validate service provider
     signed_rca.validate(expected_service_provider)?;
@@ -428,6 +462,7 @@ mod test {
         derive_agreement_id,
         ipfs::{FailingIpfsFetcher, MockIpfsFetcher},
         price::PriceCalculator,
+        rca_eip712_domain,
         server::DipsServerContext,
         store::{FailingRcaStore, InMemoryRcaStore},
         AcceptIndexingAgreementMetadata, DipsError, IndexingAgreementTermsV1,
@@ -435,8 +470,22 @@ mod test {
     };
     use thegraph_core::alloy::{
         primitives::{keccak256, Address, FixedBytes, U256},
-        sol_types::SolValue,
+        signers::local::PrivateKeySigner,
+        sol_types::{Eip712Domain, SolValue},
     };
+
+    // Fixed signer and domain for round-tripping RCA signatures in tests. The
+    // recovered address equals `test_signer().address()`; the domain must match
+    // the one stored in the test context so recovery succeeds.
+    fn test_signer() -> PrivateKeySigner {
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+            .parse()
+            .unwrap()
+    }
+
+    fn test_rca_domain() -> Eip712Domain {
+        rca_eip712_domain(1337, Address::repeat_byte(0xCC))
+    }
 
     fn create_test_context() -> Arc<DipsServerContext> {
         Arc::new(DipsServerContext {
@@ -449,19 +498,17 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         })
     }
 
-    /// Helper: encode an RCA as a `SignedRecurringCollectionAgreement`
-    /// ABI payload. The signature field is no longer consumed by the
-    /// validator; this just produces the wire bytes that
-    /// `validate_and_create_rca` expects to decode.
+    /// Sign an RCA with the fixed test key over the test domain and ABI-encode
+    /// the wrapper, producing the wire bytes `validate_and_create_rca` decodes
+    /// and recovers the signer from.
     fn rca_to_wire_bytes(rca: RecurringCollectionAgreement) -> Vec<u8> {
-        SignedRecurringCollectionAgreement {
-            agreement: rca,
-            signature: Default::default(),
-        }
-        .abi_encode()
+        rca.sign(&test_rca_domain(), test_signer())
+            .expect("signing test RCA")
+            .abi_encode()
     }
 
     fn create_test_rca(
@@ -636,6 +683,85 @@ mod test {
         assert_eq!(data[0].0, agreement_id);
     }
 
+    #[test]
+    fn test_recover_signer_recovers_the_signing_key() {
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            Address::repeat_byte(0x11),
+            U256::from(200),
+            U256::from(100),
+        );
+
+        let signed = rca
+            .sign(&test_rca_domain(), test_signer())
+            .expect("signing test RCA");
+        let recovered = signed
+            .recover_signer(&test_rca_domain())
+            .expect("recovering signer");
+
+        assert_eq!(recovered, test_signer().address());
+    }
+
+    #[test]
+    fn test_recover_signer_rejects_empty_signature() {
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            Address::repeat_byte(0x11),
+            U256::from(200),
+            U256::from(100),
+        );
+        let signed = SignedRecurringCollectionAgreement {
+            agreement: rca,
+            signature: Default::default(),
+        };
+
+        assert!(matches!(
+            signed.recover_signer(&test_rca_domain()),
+            Err(DipsError::InvalidSignature(_))
+        ));
+    }
+
+    #[test]
+    fn test_recover_signer_rejects_malformed_signature() {
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            Address::repeat_byte(0x11),
+            U256::from(200),
+            U256::from(100),
+        );
+        let signed = SignedRecurringCollectionAgreement {
+            agreement: rca,
+            signature: vec![0xAA; 10].into(),
+        };
+
+        assert!(matches!(
+            signed.recover_signer(&test_rca_domain()),
+            Err(DipsError::InvalidSignature(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_validate_and_create_rca_missing_signature_rejected() {
+        let service_provider = Address::repeat_byte(0x11);
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            service_provider,
+            U256::from(200),
+            U256::from(100),
+        );
+        // An unsigned proposal must be rejected before any other validation.
+        let rca_bytes = SignedRecurringCollectionAgreement {
+            agreement: rca,
+            signature: Default::default(),
+        }
+        .abi_encode();
+
+        let ctx = create_test_context();
+        let result = super::validate_and_create_rca(ctx, &service_provider, rca_bytes).await;
+
+        assert!(matches!(result, Err(DipsError::InvalidSignature(_))));
+    }
+
     #[tokio::test]
     async fn test_validate_and_create_rca_wrong_service_provider() {
         let payer = Address::repeat_byte(0x42);
@@ -718,6 +844,7 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -891,6 +1018,7 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -925,6 +1053,7 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -959,6 +1088,7 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -45,7 +45,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
-use thegraph_core::alloy::primitives::Address;
+use thegraph_core::alloy::{primitives::Address, sol_types::Eip712Domain};
 use tonic::{Request, Response, Status};
 
 use crate::{
@@ -79,6 +79,8 @@ pub struct DipsServerContext {
     pub registry: Arc<graph_networks_registry::NetworksRegistry>,
     /// Additional networks beyond the registry
     pub additional_networks: Arc<BTreeMap<String, String>>,
+    /// EIP-712 domain for recovering the RCA signer (RecurringCollector).
+    pub rca_domain: Eip712Domain,
 }
 
 /// DIPS server implementing RCA protocol.
@@ -109,6 +111,7 @@ fn reject_reason_from_error(err: &DipsError) -> RejectReason {
         DipsError::AgreementExpired { .. } => RejectReason::AgreementExpired,
         DipsError::UnsupportedNetwork(_) => RejectReason::UnsupportedNetwork,
         DipsError::SubgraphManifestUnavailable(_) => RejectReason::SubgraphManifestUnavailable,
+        DipsError::InvalidSignature(_) => RejectReason::InvalidSignature,
         DipsError::UnexpectedServiceProvider { .. } => RejectReason::UnexpectedServiceProvider,
         DipsError::UnsupportedMetadataVersion(_) => RejectReason::UnsupportedMetadataVersion,
         // Malformed proposals with no dedicated reason map to the catch-all; the
@@ -231,6 +234,7 @@ mod tests {
                 )),
                 registry: Arc::new(crate::registry::test_registry()),
                 additional_networks: Arc::new(BTreeMap::new()),
+                rca_domain: crate::rca_eip712_domain(1337, Address::repeat_byte(0xCC)),
             })
         }
     }
@@ -392,6 +396,18 @@ mod tests {
 
         // Assert
         assert_eq!(reason, RejectReason::SubgraphManifestUnavailable);
+    }
+
+    #[test]
+    fn test_reject_reason_invalid_signature() {
+        // Arrange
+        let err = DipsError::InvalidSignature("bad signature".to_string());
+
+        // Act
+        let reason = super::reject_reason_from_error(&err);
+
+        // Assert
+        assert_eq!(reason, RejectReason::InvalidSignature);
     }
 
     #[test]

--- a/crates/service/src/metrics.rs
+++ b/crates/service/src/metrics.rs
@@ -5,7 +5,8 @@ use std::{net::SocketAddr, sync::LazyLock};
 
 use axum::{routing::get, serve, Router};
 use prometheus::{
-    register_counter_vec, register_histogram_vec, CounterVec, HistogramVec, TextEncoder,
+    register_counter_vec, register_histogram_vec, register_int_gauge, CounterVec, HistogramVec,
+    IntGauge, TextEncoder,
 };
 use reqwest::StatusCode;
 use tokio::net::TcpListener;
@@ -32,6 +33,17 @@ pub static FAILED_RECEIPT: LazyLock<CounterVec> = LazyLock::new(|| {
         "indexer_receipt_failed_total",
         "Failed receipt checks",
         &["deployment", "allocation", "sender"]
+    )
+    .unwrap()
+});
+
+/// Set to 1 when the DIPs gRPC server started, 0 when DIPs was configured but
+/// failed to initialize (the service then runs without DIPs). Not exported
+/// when DIPs is not configured, so alerting on 0 is safe for DIPs operators.
+pub static DIPS_ENABLED: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(
+        "indexer_dips_enabled",
+        "1 if the DIPs gRPC server is running; 0 if DIPs is configured but failed to initialize"
     )
     .unwrap()
 });

--- a/crates/service/src/routes/dips_info.rs
+++ b/crates/service/src/routes/dips_info.rs
@@ -1,15 +1,25 @@
 // Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use axum::{extract::State, Json};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
 use serde::Serialize;
 use std::collections::BTreeMap;
 
-/// State for the /dips/info endpoint, derived from DipsConfig at startup.
+/// State for the /dips/info endpoint. `Failed` deliberately carries no error
+/// detail: init errors can reference the operator's RPC endpoint (which may
+/// embed credentials), so the cause stays in logs and metrics only.
 #[derive(Clone, Debug)]
-pub struct DipsInfoState {
-    pub min_grt_per_30_days: BTreeMap<String, String>,
-    pub min_grt_per_billion_entities_per_30_days: String,
+pub enum DipsInfoState {
+    Available {
+        min_grt_per_30_days: BTreeMap<String, String>,
+        min_grt_per_billion_entities_per_30_days: String,
+    },
+    Failed,
 }
 
 #[derive(Serialize)]
@@ -24,15 +34,68 @@ pub struct DipsInfoResponse {
     pub supported_networks: Vec<String>,
 }
 
-pub async fn dips_info(State(state): State<DipsInfoState>) -> Json<DipsInfoResponse> {
-    let supported_networks: Vec<String> = state.min_grt_per_30_days.keys().cloned().collect();
+#[derive(Serialize)]
+pub struct DipsInfoUnavailable {
+    pub status: &'static str,
+    pub error: &'static str,
+}
 
-    Json(DipsInfoResponse {
-        pricing: DipsInfoPricing {
-            min_grt_per_30_days: state.min_grt_per_30_days,
-            min_grt_per_billion_entities_per_30_days: state
-                .min_grt_per_billion_entities_per_30_days,
-        },
-        supported_networks,
-    })
+pub async fn dips_info(State(state): State<DipsInfoState>) -> Response {
+    match state {
+        DipsInfoState::Available {
+            min_grt_per_30_days,
+            min_grt_per_billion_entities_per_30_days,
+        } => {
+            let supported_networks: Vec<String> = min_grt_per_30_days.keys().cloned().collect();
+
+            Json(DipsInfoResponse {
+                pricing: DipsInfoPricing {
+                    min_grt_per_30_days,
+                    min_grt_per_billion_entities_per_30_days,
+                },
+                supported_networks,
+            })
+            .into_response()
+        }
+        DipsInfoState::Failed => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(DipsInfoUnavailable {
+                status: "unavailable",
+                error: "DIPs initialization failed; check the indexer-service logs",
+            }),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_dips_info_available_returns_pricing() {
+        // Arrange
+        let state = DipsInfoState::Available {
+            min_grt_per_30_days: BTreeMap::from([("mainnet".to_string(), "450".to_string())]),
+            min_grt_per_billion_entities_per_30_days: "200".to_string(),
+        };
+
+        // Act
+        let response = dips_info(State(state)).await;
+
+        // Assert
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_dips_info_failed_returns_service_unavailable() {
+        // Arrange
+        let state = DipsInfoState::Failed;
+
+        // Act
+        let response = dips_info(State(state)).await;
+
+        // Assert
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
 }

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -38,7 +38,10 @@ use tower_http::normalize_path::NormalizePath;
 use tracing::info;
 
 use crate::{
-    cli::Cli, constants::HTTP_CLIENT_TIMEOUT, database, metrics::serve_metrics,
+    cli::Cli,
+    constants::HTTP_CLIENT_TIMEOUT,
+    database,
+    metrics::{serve_metrics, DIPS_ENABLED},
     routes::DipsInfoState,
 };
 
@@ -167,17 +170,48 @@ pub async fn run() -> anyhow::Result<()> {
         }
     };
 
-    // Build DipsInfoState if DIPS is configured
-    let dips_info_state = config.dips.as_ref().map(|dips| DipsInfoState {
-        min_grt_per_30_days: dips
-            .min_grt_per_30_days
-            .iter()
-            .map(|(network, grt)| (network.clone(), format_grt(grt.wei())))
-            .collect(),
-        min_grt_per_billion_entities_per_30_days: format_grt(
-            dips.min_grt_per_billion_entities_per_30_days.wei(),
-        ),
-    });
+    // Create a cancellation token for coordinated graceful shutdown
+    let shutdown_token = CancellationToken::new();
+
+    // DIPS: RecurringCollectionAgreement validation and storage. An init
+    // failure here must not take down query serving: log it loudly and run
+    // without DIPs instead. /dips/info and the metric reflect the outcome.
+    let dips_info_state = match config.dips.as_ref() {
+        Some(dips) => match start_dips(
+            dips,
+            blockchain_chain_id,
+            &ipfs_url,
+            database.clone(),
+            indexer_address,
+            &shutdown_token,
+        )
+        .await
+        {
+            Ok(()) => {
+                DIPS_ENABLED.set(1);
+                Some(DipsInfoState::Available {
+                    min_grt_per_30_days: dips
+                        .min_grt_per_30_days
+                        .iter()
+                        .map(|(network, grt)| (network.clone(), format_grt(grt.wei())))
+                        .collect(),
+                    min_grt_per_billion_entities_per_30_days: format_grt(
+                        dips.min_grt_per_billion_entities_per_30_days.wei(),
+                    ),
+                })
+            }
+            Err(err) => {
+                DIPS_ENABLED.set(0);
+                tracing::error!(
+                    error = format!("{err:#}"),
+                    "DIPs initialization failed; the service is running WITHOUT DIPs \
+                     and will not receive indexing agreement proposals until restarted"
+                );
+                Some(DipsInfoState::Failed)
+            }
+        },
+        None => None,
+    };
 
     let router = ServiceRouter::builder()
         .database(database.clone())
@@ -196,34 +230,10 @@ pub async fn run() -> anyhow::Result<()> {
 
     serve_metrics(config.metrics.get_socket_addr());
 
-    // Create a cancellation token for coordinated graceful shutdown
-    let shutdown_token = CancellationToken::new();
-
     tracing::info!(
         address = %host_and_port,
         "Serving requests",
     );
-    // DIPS: RecurringCollectionAgreement validation and storage. An init
-    // failure here must not take down query serving: log it loudly and run
-    // without DIPs instead of exiting.
-    if let Some(dips) = config.dips.as_ref() {
-        if let Err(err) = start_dips(
-            dips,
-            blockchain_chain_id,
-            &ipfs_url,
-            database.clone(),
-            indexer_address,
-            &shutdown_token,
-        )
-        .await
-        {
-            tracing::error!(
-                error = format!("{err:#}"),
-                "DIPs initialization failed; the service is running WITHOUT DIPs \
-                 and will not receive indexing agreement proposals until restarted"
-            );
-        }
-    }
 
     let listener = TcpListener::bind(&host_and_port)
         .await

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -132,6 +132,9 @@ pub async fn run() -> anyhow::Result<()> {
     );
     let host_and_port = config.service.host_and_port;
     let indexer_address = config.indexer.indexer_address;
+    // Captured before `config.blockchain` is moved into the router state below;
+    // used to build the RCA EIP-712 domain for DIPs signer recovery.
+    let blockchain_chain_id = config.blockchain.chain_id as u64;
     let ipfs_url = config.service.ipfs_url.clone();
 
     // V2 escrow accounts (used by DIPs) live in the network subgraph; no
@@ -209,8 +212,15 @@ pub async fn run() -> anyhow::Result<()> {
             min_grt_per_30_days,
             min_grt_per_billion_entities_per_30_days,
             additional_networks,
-            ..
+            recurring_collector,
         } = dips;
+
+        // The RecurringCollector address is the EIP-712 verifying contract used to
+        // recover RCA signers; without it DIPs cannot authenticate proposals.
+        let recurring_collector = (*recurring_collector).ok_or_else(|| {
+            anyhow::anyhow!("dips.recurring_collector must be set when DIPs is enabled")
+        })?;
+        let rca_domain = indexer_dips::rca_eip712_domain(blockchain_chain_id, recurring_collector);
 
         if supported_networks.is_empty() {
             tracing::warn!(
@@ -288,6 +298,7 @@ pub async fn run() -> anyhow::Result<()> {
             )),
             registry,
             additional_networks: Arc::new(additional_networks.clone()),
+            rca_domain,
         });
 
         // Create DIPS server

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -25,7 +25,7 @@ use indexer_monitor::{DeploymentDetails, SubgraphClient};
 use release::IndexerServiceRelease;
 use reqwest::Url;
 use tap_core::tap_eip712_domain;
-use thegraph_core::alloy::primitives::U256;
+use thegraph_core::alloy::primitives::{Address, U256};
 use tokio::{net::TcpListener, signal};
 use tokio_util::sync::CancellationToken;
 use tonic::transport::server::TcpConnectInfo;
@@ -203,120 +203,26 @@ pub async fn run() -> anyhow::Result<()> {
         address = %host_and_port,
         "Serving requests",
     );
-    // DIPS: RecurringCollectionAgreement validation and storage
+    // DIPS: RecurringCollectionAgreement validation and storage. An init
+    // failure here must not take down query serving: log it loudly and run
+    // without DIPs instead of exiting.
     if let Some(dips) = config.dips.as_ref() {
-        let DipsConfig {
-            host,
-            port,
-            supported_networks,
-            min_grt_per_30_days,
-            min_grt_per_billion_entities_per_30_days,
-            additional_networks,
-            recurring_collector,
-        } = dips;
-
-        // The RecurringCollector address is the EIP-712 verifying contract used to
-        // recover RCA signers; without it DIPs cannot authenticate proposals.
-        let recurring_collector = (*recurring_collector).ok_or_else(|| {
-            anyhow::anyhow!("dips.recurring_collector must be set when DIPs is enabled")
-        })?;
-        let rca_domain = indexer_dips::rca_eip712_domain(blockchain_chain_id, recurring_collector);
-
-        if supported_networks.is_empty() {
-            tracing::warn!(
-                "DIPS enabled but no networks in dips.supported_networks. \
-                 All proposals will be rejected."
+        if let Err(err) = start_dips(
+            dips,
+            blockchain_chain_id,
+            &ipfs_url,
+            database.clone(),
+            indexer_address,
+            &shutdown_token,
+        )
+        .await
+        {
+            tracing::error!(
+                error = format!("{err:#}"),
+                "DIPs initialization failed; the service is running WITHOUT DIPs \
+                 and will not receive indexing agreement proposals until restarted"
             );
         }
-
-        tracing::info!(
-            supported_networks = ?supported_networks,
-            ipfs_url = %ipfs_url,
-            "DIPs configuration loaded"
-        );
-        for (network, grt) in min_grt_per_30_days.iter() {
-            tracing::info!(
-                network = %network,
-                min_grt_per_30_days_wei = %grt.wei(),
-                "DIPs network pricing"
-            );
-        }
-        tracing::info!(
-            min_grt_per_billion_entities_per_30_days_wei = %min_grt_per_billion_entities_per_30_days.wei(),
-            "DIPs entity pricing"
-        );
-
-        let addr: SocketAddr = format!("{host}:{port}")
-            .parse()
-            .with_context(|| format!("Invalid DIPS host:port '{host}:{port}'"))?;
-
-        // Shared counter of in-flight gRPC requests. The IPFS client reads
-        // it to decide whether to use the full retry budget or fall back to
-        // a single attempt when the service is under load.
-        let inflight = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-
-        // Initialize validation dependencies
-        let ipfs_fetcher = Arc::new(IpfsClient::new(ipfs_url.as_str(), inflight.clone())?);
-        let registry = Arc::new(
-            NetworksRegistry::from_latest_version()
-                .await
-                .context("Failed to fetch NetworksRegistry for DIPS")?,
-        );
-
-        // Convert GRT/30days to wei/second for protocol compatibility.
-        // Use ceiling division to protect indexers: configured minimums round UP,
-        // ensuring indexers never accept less than their stated minimum.
-        // 30 days = 2,592,000 seconds
-        const SECONDS_PER_30_DAYS: u128 = 30 * 24 * 60 * 60;
-        let tokens_per_second = min_grt_per_30_days
-            .iter()
-            .map(|(network, grt)| {
-                let wei_per_second = grt.wei().div_ceil(SECONDS_PER_30_DAYS);
-                (network.clone(), U256::from(wei_per_second))
-            })
-            .collect();
-
-        // Entity pricing: config is per-billion-entities, convert to per-entity.
-        // Ceiling division protects indexer from precision loss.
-        let entity_divisor = SECONDS_PER_30_DAYS * 1_000_000_000;
-        let tokens_per_entity_per_second = U256::from(
-            min_grt_per_billion_entities_per_30_days
-                .wei()
-                .div_ceil(entity_divisor),
-        );
-
-        // Build server context
-        let ctx = Arc::new(DipsServerContext {
-            rca_store: Arc::new(PsqlRcaStore {
-                pool: database.clone(),
-            }),
-            ipfs_fetcher,
-            price_calculator: Arc::new(PriceCalculator::new(
-                supported_networks.clone(),
-                tokens_per_second,
-                tokens_per_entity_per_second,
-            )),
-            registry,
-            additional_networks: Arc::new(additional_networks.clone()),
-            rca_domain,
-        });
-
-        // Create DIPS server
-        let server = DipsServer {
-            ctx,
-            expected_payee: indexer_address,
-            inflight,
-        };
-
-        info!(
-            address = %addr,
-            "Starting DIPS gRPC server (RecurringCollectionAgreement validation)"
-        );
-
-        let dips_shutdown_token = shutdown_token.clone();
-        tokio::spawn(async move {
-            start_dips_server(addr, server, dips_shutdown_token.cancelled()).await;
-        });
     }
 
     let listener = TcpListener::bind(&host_and_port)
@@ -330,6 +236,146 @@ pub async fn run() -> anyhow::Result<()> {
     Ok(serve(listener, service)
         .with_graceful_shutdown(shutdown_handler(shutdown_token))
         .await?)
+}
+
+/// Initialize and start the DIPS gRPC server. Errors return to the caller,
+/// which runs the service without DIPs rather than letting an optional
+/// subsystem take down query serving.
+async fn start_dips(
+    dips: &DipsConfig,
+    blockchain_chain_id: u64,
+    ipfs_url: &Url,
+    database: sqlx::PgPool,
+    indexer_address: Address,
+    shutdown_token: &CancellationToken,
+) -> anyhow::Result<()> {
+    let DipsConfig {
+        host,
+        port,
+        supported_networks,
+        min_grt_per_30_days,
+        min_grt_per_billion_entities_per_30_days,
+        additional_networks,
+        recurring_collector,
+        rpc_url,
+    } = dips;
+
+    // The RecurringCollector address is the EIP-712 verifying contract used to
+    // recover RCA signers; without it DIPs cannot authenticate proposals.
+    let recurring_collector = (*recurring_collector).ok_or_else(|| {
+        anyhow::anyhow!("dips.recurring_collector must be set when DIPs is enabled")
+    })?;
+
+    // Prefer the domain the deployed contract reports (EIP-5267) so it tracks
+    // upgrades; without an RPC endpoint, fall back to built-in constants.
+    let rca_domain = match rpc_url {
+        Some(url) => {
+            indexer_dips::fetch_rca_eip712_domain(
+                url.as_str(),
+                recurring_collector,
+                blockchain_chain_id,
+            )
+            .await?
+        }
+        None => {
+            tracing::info!("dips.rpc_url not set; using built-in RCA EIP-712 domain constants");
+            indexer_dips::rca_eip712_domain(blockchain_chain_id, recurring_collector)
+        }
+    };
+
+    if supported_networks.is_empty() {
+        tracing::warn!(
+            "DIPS enabled but no networks in dips.supported_networks. \
+             All proposals will be rejected."
+        );
+    }
+
+    tracing::info!(
+        supported_networks = ?supported_networks,
+        ipfs_url = %ipfs_url,
+        "DIPs configuration loaded"
+    );
+    for (network, grt) in min_grt_per_30_days.iter() {
+        tracing::info!(
+            network = %network,
+            min_grt_per_30_days_wei = %grt.wei(),
+            "DIPs network pricing"
+        );
+    }
+    tracing::info!(
+        min_grt_per_billion_entities_per_30_days_wei = %min_grt_per_billion_entities_per_30_days.wei(),
+        "DIPs entity pricing"
+    );
+
+    let addr: SocketAddr = format!("{host}:{port}")
+        .parse()
+        .with_context(|| format!("Invalid DIPS host:port '{host}:{port}'"))?;
+
+    // Shared counter of in-flight gRPC requests. The IPFS client reads
+    // it to decide whether to use the full retry budget or fall back to
+    // a single attempt when the service is under load.
+    let inflight = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    // Initialize validation dependencies
+    let ipfs_fetcher = Arc::new(IpfsClient::new(ipfs_url.as_str(), inflight.clone())?);
+    let registry = Arc::new(
+        NetworksRegistry::from_latest_version()
+            .await
+            .context("Failed to fetch NetworksRegistry for DIPS")?,
+    );
+
+    // Convert GRT/30days to wei/second for protocol compatibility.
+    // Use ceiling division to protect indexers: configured minimums round UP,
+    // ensuring indexers never accept less than their stated minimum.
+    const SECONDS_PER_30_DAYS: u128 = 30 * 24 * 60 * 60;
+    let tokens_per_second = min_grt_per_30_days
+        .iter()
+        .map(|(network, grt)| {
+            let wei_per_second = grt.wei().div_ceil(SECONDS_PER_30_DAYS);
+            (network.clone(), U256::from(wei_per_second))
+        })
+        .collect();
+
+    // Entity pricing: config is per-billion-entities, convert to per-entity.
+    // Ceiling division protects indexer from precision loss.
+    let entity_divisor = SECONDS_PER_30_DAYS * 1_000_000_000;
+    let tokens_per_entity_per_second = U256::from(
+        min_grt_per_billion_entities_per_30_days
+            .wei()
+            .div_ceil(entity_divisor),
+    );
+
+    // Build server context
+    let ctx = Arc::new(DipsServerContext {
+        rca_store: Arc::new(PsqlRcaStore { pool: database }),
+        ipfs_fetcher,
+        price_calculator: Arc::new(PriceCalculator::new(
+            supported_networks.clone(),
+            tokens_per_second,
+            tokens_per_entity_per_second,
+        )),
+        registry,
+        additional_networks: Arc::new(additional_networks.clone()),
+        rca_domain,
+    });
+
+    // Create DIPS server
+    let server = DipsServer {
+        ctx,
+        expected_payee: indexer_address,
+        inflight,
+    };
+
+    info!(
+        address = %addr,
+        "Starting DIPS gRPC server (RecurringCollectionAgreement validation)"
+    );
+
+    let dips_shutdown_token = shutdown_token.clone();
+    tokio::spawn(async move {
+        start_dips_server(addr, server, dips_shutdown_token.cancelled()).await;
+    });
+    Ok(())
 }
 
 /// Per-request timeout across the whole gRPC handler. Long enough to cover


### PR DESCRIPTION
## TL;DR

The indexer stopped checking the signature on incoming indexing-agreement proposals when authorization moved to a later on-chain step. This recovers the proposal's signer from its signature and turns away anything unsigned or tampered before the indexer acts on it. The recovered signer is the handle a following change will use to check the sender is one the indexer trusts.

## Motivation

When the dipper sends an indexing-agreement proposal to an indexer over gRPC, the indexer used to verify a signature on it; that check was dropped when authorization moved to a later on-chain step. As a result the indexer now fetches the subgraph manifest, prices it, and stores the proposal before it has any assurance the message wasn't forged or altered in flight, and without knowing who actually sent it.

This recovers the signer's address from the proposal's signature the moment it arrives and rejects anything missing or malformed, so a tampered or spoofed proposal is turned away before any work is done. On its own it authenticates the message; a following change will check that the recovered signer is one the indexer trusts to send proposals.

## Summary

- Recover the proposal signer from its signature over the recurring-collector signing domain.
- Reject proposals with a missing or malformed signature before any other validation.
- Add a recurring-collector address setting, required only when direct indexer payments are on.
- Fail startup if that address is missing while payments are enabled, instead of misverifying.
- Cover signer recovery, empty and malformed signatures, and the sign/recover round-trip with tests.