### PR TITLE
fix: stop a flaky payments-agent test from failing CI

### DIFF
--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -1670,6 +1670,15 @@ mod tests {
 
         let _ = receiver.recv().await;
 
+        // The actor handles one message at a time, so this round-trip can't return
+        // until TriggerRavRequest finished moving the receipts (insert-invalid then
+        // delete-from-main). Without it, recv() can wake mid-move and the counts race.
+        let _ = call!(
+            sender_allocation,
+            SenderAllocationMessage::GetUnaggregatedReceipts
+        )
+        .unwrap();
+
         let invalid_receipts =
             sqlx::query("SELECT COUNT(*) AS count FROM tap_horizon_receipts_invalid")
                 .fetch_one(&test_db.pool)


### PR DESCRIPTION
## TL;DR

A test in the payments agent has been failing CI at random, unrelated to the code it covers. It checked the database right after a wakeup signal that did not guarantee the work it was testing had finished, so it occasionally read half-applied state and failed. This change makes the test wait for that work to actually complete before it checks.

## Motivation

When the payments agent processes a batch of invalid receipts, it records them in one table and removes them from another as two separate steps. A test exercises this by triggering the work and then counting the rows in each table. The trouble is that the test only waited on a single internal notification before counting, and that notification can arrive before both database steps have finished, so the count occasionally ran against a half-updated database and failed.

Because this test runs on every change, that random failure has been turning pull requests red across the repository for reasons unrelated to the change under review, costing contributors reruns and eroding trust in the CI signal. The flake is not a data-isolation problem between tests, since each test already runs against its own database, so the fix is to make the test wait for the work to genuinely finish rather than to isolate anything.

## Summary

- Wait for the invalid-receipt processing to finish before the test counts table rows.
- Use the same actor round-trip the neighbouring receipt tests already rely on.
- Keep the change to the test only, with no edits to production code.
