### PR TITLE
fix: stop losing invalid payment receipts on a failed write

### DIFF
--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -122,12 +122,9 @@ type TapManager<T> = tap_core::manager::Manager<TapAgentContext<T>, TapReceipt>;
 
 const TAP_VERSION: &str = "v2";
 
-/// Manages unaggregated fees and the TAP lifecyle for a specific (allocation, sender) pair.
+/// Manages unaggregated fees and the TAP lifecycle for a specific (allocation, sender) pair.
 ///
-/// We use PhantomData to be able to add bounds to T while implementing the Actor trait
-///
-/// T is used in SenderAllocationState<T> and SenderAllocationArgs<T> to store the
-/// correct Rav type and the correct aggregator client
+/// `PhantomData<T>` carries the network version so the `Actor` impl can pin the Rav type.
 pub struct SenderAllocation<T>(PhantomData<T>);
 impl<T: NetworkVersion> Default for SenderAllocation<T> {
     fn default() -> Self {
@@ -141,10 +138,7 @@ pub struct SenderAllocationState<T: NetworkVersion> {
     unaggregated_fees: UnaggregatedReceipts,
     /// Sum of all invalid receipts for the current allocation
     invalid_receipts_fees: UnaggregatedReceipts,
-    /// Last sent RAV
-    ///
-    /// This is used to together with a list of receipts to aggregate
-    /// into a new RAV
+    /// Last sent RAV, aggregated together with new receipts into the next RAV
     latest_rav: Option<Eip712SignedMessage<T::Rav>>,
     /// Database connection
     pgpool: PgPool,
@@ -253,10 +247,8 @@ pub enum SenderAllocationMessage {
     ),
 }
 
-/// Actor implementation for [SenderAllocation]
-///
-/// We use some bounds so [TapAgentContext] implements all parts needed for the given
-/// [crate::tap::context::NetworkVersion]
+/// Actor implementation for [SenderAllocation]. The bounds make [TapAgentContext] satisfy
+/// every part needed for the given [crate::tap::context::NetworkVersion].
 #[async_trait::async_trait]
 impl<T> Actor for SenderAllocation<T>
 where
@@ -313,11 +305,8 @@ where
         Ok(state)
     }
 
-    /// This method only runs on graceful stop (real close allocation)
-    /// if the actor crashes, this is not ran
-    ///
-    /// It's used to flush all remaining receipts while creating Ravs
-    /// and marking it as last to be redeemed by indexer-agent
+    /// Runs only on graceful stop (real close allocation), not on crash. Flushes the remaining
+    /// receipts into RAVs and marks the last one for indexer-agent to redeem.
     async fn post_stop(
         &self,
         _myself: ActorRef<Self::Msg>,
@@ -574,10 +563,8 @@ where
         }
     }
 
-    /// Request a RAV from the sender's TAP aggregator. Only one RAV request will be running at a
-    /// time because actors run one message at a time.
-    ///
-    /// Yet, multiple different [SenderAllocation] can run a request in parallel.
+    /// Request a RAV from the sender's TAP aggregator. One actor handles one message at a time, so
+    /// an allocation runs a single request at once, though different allocations run in parallel.
     async fn rav_requester_single(&mut self) -> Result<Eip712SignedMessage<T::Rav>, RavError> {
         tracing::trace!("rav_requester_single()");
         let RavRequest {
@@ -1196,10 +1183,8 @@ impl DatabaseInteractions for SenderAllocationState<Horizon> {
     }
 }
 
-/// Force initialization of all LazyLock metrics in this module.
-///
-/// This ensures metrics are registered with Prometheus at startup,
-/// even if no SenderAllocation actors have been created yet.
+/// Force initialization of all LazyLock metrics in this module, so they register with
+/// Prometheus at startup even before any SenderAllocation actor exists.
 pub fn init_metrics() {
     // Dereference each LazyLock to force initialization
     let _ = &*CLOSED_SENDER_ALLOCATIONS;

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -605,6 +605,10 @@ where
                     .max()
                     .expect("invalid receipts should not be empty");
 
+                // Resolve the sender's signers before opening the transaction, so it isn't
+                // held open across that await.
+                let signers = signers_trimmed(self.escrow_accounts.clone(), self.sender).await?;
+
                 // Record the invalid receipts and delete them from the live table in one
                 // transaction, so a crash or delete failure can't leave them in both tables
                 // or delete them without a record.
@@ -613,7 +617,6 @@ where
                 let fees = self
                     .store_invalid_receipts(invalid_receipts, &mut tx)
                     .await?;
-                let signers = signers_trimmed(self.escrow_accounts.clone(), self.sender).await?;
                 self.delete_receipts_between(&signers, min_timestamp, max_timestamp, &mut tx)
                     .await?;
                 tx.commit().await?;

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -608,10 +608,19 @@ where
                     .max()
                     .expect("invalid receipts should not be empty");
 
-                self.store_invalid_receipts(invalid_receipts).await?;
-                let signers = signers_trimmed(self.escrow_accounts.clone(), self.sender).await?;
-                self.delete_receipts_between(&signers, min_timestamp, max_timestamp)
+                // Record the invalid receipts and delete them from the live table in one
+                // transaction, so a crash or delete failure can't leave them in both tables
+                // or delete them without a record.
+                let pool = self.pgpool.clone();
+                let mut tx = pool.begin().await?;
+                let fees = self
+                    .store_invalid_receipts(invalid_receipts, &mut tx)
                     .await?;
+                let signers = signers_trimmed(self.escrow_accounts.clone(), self.sender).await?;
+                self.delete_receipts_between(&signers, min_timestamp, max_timestamp, &mut tx)
+                    .await?;
+                tx.commit().await?;
+                self.account_invalid_receipts_fees(fees)?;
                 Err(RavError::AllReceiptsInvalid)
             }
             // When it receives both valid and invalid receipts or just valid
@@ -658,7 +667,13 @@ where
 
                     // Save invalid receipts to the database for logs.
                     // TODO: consider doing that in a spawned task?
-                    self.store_invalid_receipts(invalid_receipts).await?;
+                    let pool = self.pgpool.clone();
+                    let mut tx = pool.begin().await?;
+                    let fees = self
+                        .store_invalid_receipts(invalid_receipts, &mut tx)
+                        .await?;
+                    tx.commit().await?;
+                    self.account_invalid_receipts_fees(fees)?;
                 }
 
                 match self
@@ -723,10 +738,14 @@ where
         }
     }
 
+    /// Store invalid receipts on the caller's transaction and return their total value.
+    /// The caller commits, then records that value via [`Self::account_invalid_receipts_fees`],
+    /// so the in-memory accounting only advances once the database write is durable.
     async fn store_invalid_receipts(
         &mut self,
         receipts: Vec<ReceiptWithState<Failed, TapReceipt>>,
-    ) -> anyhow::Result<()> {
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    ) -> anyhow::Result<u128> {
         let fees = receipts
             .iter()
             .map(|receipt| receipt.signed_receipt().value())
@@ -739,10 +758,15 @@ where
             receipts_v2.push((receipt, error));
         }
 
-        if let Err(err) = self.store_v2_invalid_receipts(receipts_v2).await {
-            tracing::error!(%err, "There was an error while storing invalid v2 receipts.");
-        }
+        self.store_v2_invalid_receipts(receipts_v2, tx).await?;
 
+        Ok(fees)
+    }
+
+    /// Add `fees` (the rejected receipts' total value) to the running invalid-receipt
+    /// total and report it to the sender account. Call only after the store commits, so
+    /// the total never runs ahead of what was durably written.
+    fn account_invalid_receipts_fees(&mut self, fees: u128) -> anyhow::Result<()> {
         self.invalid_receipts_fees.value = self
             .invalid_receipts_fees
             .value
@@ -772,6 +796,7 @@ where
     async fn store_v2_invalid_receipts(
         &self,
         receipts: Vec<(tap_graph::v2::SignedReceipt, String)>,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> anyhow::Result<()> {
         let receipts_len = receipts.len();
         let mut reciepts_signers = Vec::with_capacity(receipts_len);
@@ -849,7 +874,7 @@ where
         .bind(&nonces)
         .bind(&values)
         .bind(&error_logs)
-        .execute(&self.pgpool)
+        .execute(&mut **tx)
         .await
         .map_err(|e: sqlx::Error| {
             tracing::error!(error = %e, "Failed to store invalid receipt");
@@ -901,6 +926,7 @@ pub trait DatabaseInteractions {
         signers: &[String],
         min_timestamp: u64,
         max_timestamp: u64,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
     /// Calculates fees for invalid receipts
     fn calculate_invalid_receipts_fee(
@@ -925,6 +951,7 @@ impl DatabaseInteractions for SenderAllocationState<Horizon> {
         signers: &[String],
         min_timestamp: u64,
         max_timestamp: u64,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> anyhow::Result<()> {
         sqlx::query(
             r#"
@@ -949,7 +976,7 @@ impl DatabaseInteractions for SenderAllocationState<Horizon> {
                 .encode_hex(),
         )
         .bind(signers)
-        .execute(&self.pgpool)
+        .execute(&mut **tx)
         .await?;
         Ok(())
     }
@@ -1450,10 +1477,13 @@ mod tests {
             .collect::<Vec<_>>();
         let failing_receipts = join_all(failing_receipts).await;
 
+        let pool = test_db.pool.clone();
+        let mut tx = pool.begin().await.unwrap();
         state
-            .store_invalid_receipts(failing_receipts)
+            .store_invalid_receipts(failing_receipts, &mut tx)
             .await
             .unwrap();
+        tx.commit().await.unwrap();
         let total_invalid_receipts = state.calculate_invalid_receipts_fee().await.unwrap();
         assert_eq!(total_invalid_receipts.value, 3u128);
     }
@@ -1564,8 +1594,78 @@ mod tests {
             .collect::<Vec<_>>();
         let failing_receipts = join_all(failing_receipts).await;
 
-        let result = state.store_invalid_receipts(failing_receipts).await;
+        let pool = test_db.pool.clone();
+        let mut tx = pool.begin().await.unwrap();
+        let result = state
+            .store_invalid_receipts(failing_receipts, &mut tx)
+            .await;
         assert!(result.is_ok());
+        tx.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_store_invalid_receipts_rolls_back_with_transaction() {
+        let test_db = test_assets::setup_shared_test_db().await;
+        let network_mock = setup_network_subgraph(false).await;
+        let network_subgraph = Box::leak(Box::new(
+            SubgraphClient::new(
+                reqwest::Client::new(),
+                None,
+                DeploymentDetails::for_query_url(&network_mock.uri()).unwrap(),
+            )
+            .await,
+        ));
+        let mut state = build_state(test_db.pool.clone(), network_subgraph).await;
+
+        struct FailingCheck;
+        #[async_trait::async_trait]
+        impl Check<TapReceipt> for FailingCheck {
+            async fn check(
+                &self,
+                _: &tap_core::receipt::Context,
+                _receipt: &CheckingReceipt,
+            ) -> tap_core::receipt::checks::CheckResult {
+                Err(tap_core::receipt::checks::CheckError::Failed(anyhow!(
+                    "Failing check"
+                )))
+            }
+        }
+
+        let checks = CheckList::new(vec![Arc::new(FailingCheck)]);
+        let checking_receipts = vec![
+            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 1, 1, 1u128),
+            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 2, 2, 2u128),
+        ];
+        let failing_receipts = checking_receipts
+            .into_iter()
+            .map(|receipt| async {
+                receipt
+                    .finalize_receipt_checks(&Context::new(), &checks)
+                    .await
+                    .unwrap()
+                    .unwrap_err()
+            })
+            .collect::<Vec<_>>();
+        let failing_receipts = join_all(failing_receipts).await;
+
+        // Store the invalid receipts inside a transaction, then roll it back. Because the
+        // store now runs on the caller's transaction instead of autocommitting, the rows
+        // must not survive the rollback.
+        let pool = test_db.pool.clone();
+        let mut tx = pool.begin().await.unwrap();
+        state
+            .store_invalid_receipts(failing_receipts, &mut tx)
+            .await
+            .unwrap();
+        tx.rollback().await.unwrap();
+
+        let count: i64 = sqlx::query("SELECT COUNT(*) AS count FROM tap_horizon_receipts_invalid")
+            .fetch_one(&test_db.pool)
+            .await
+            .unwrap()
+            .try_get("count")
+            .unwrap();
+        assert_eq!(count, 0);
     }
 
     #[tokio::test]

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -1312,6 +1312,38 @@ mod tests {
         (sender_allocation, receiver)
     }
 
+    /// Two receipts forced into the `Failed` state by a check that always fails, for
+    /// exercising invalid-receipt storage. Their values (1 and 2) sum to 3.
+    async fn make_failing_receipts() -> Vec<ReceiptWithState<Failed, TapReceipt>> {
+        struct FailingCheck;
+        #[async_trait::async_trait]
+        impl Check<TapReceipt> for FailingCheck {
+            async fn check(
+                &self,
+                _: &tap_core::receipt::Context,
+                _receipt: &CheckingReceipt,
+            ) -> tap_core::receipt::checks::CheckResult {
+                Err(tap_core::receipt::checks::CheckError::Failed(anyhow!(
+                    "Failing check"
+                )))
+            }
+        }
+
+        let checks = CheckList::new(vec![Arc::new(FailingCheck)]);
+        let checking_receipts = vec![
+            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 1, 1, 1u128),
+            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 2, 2, 2u128),
+        ];
+        join_all(checking_receipts.into_iter().map(|receipt| async {
+            receipt
+                .finalize_receipt_checks(&Context::new(), &checks)
+                .await
+                .unwrap()
+                .unwrap_err()
+        }))
+        .await
+    }
+
     #[tokio::test]
     async fn test_several_receipts_rav_request() {
         let test_db = test_assets::setup_shared_test_db().await;
@@ -1485,36 +1517,7 @@ mod tests {
         ));
         let mut state = build_state(test_db.pool.clone(), network_subgraph).await;
 
-        struct FailingCheck;
-        #[async_trait::async_trait]
-        impl Check<TapReceipt> for FailingCheck {
-            async fn check(
-                &self,
-                _: &tap_core::receipt::Context,
-                _receipt: &CheckingReceipt,
-            ) -> tap_core::receipt::checks::CheckResult {
-                Err(tap_core::receipt::checks::CheckError::Failed(anyhow!(
-                    "Failing check"
-                )))
-            }
-        }
-
-        let checks = CheckList::new(vec![Arc::new(FailingCheck)]);
-        let checking_receipts = vec![
-            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 1, 1, 1u128),
-            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 2, 2, 2u128),
-        ];
-        let failing_receipts = checking_receipts
-            .into_iter()
-            .map(|receipt| async {
-                receipt
-                    .finalize_receipt_checks(&Context::new(), &checks)
-                    .await
-                    .unwrap()
-                    .unwrap_err()
-            })
-            .collect::<Vec<_>>();
-        let failing_receipts = join_all(failing_receipts).await;
+        let failing_receipts = make_failing_receipts().await;
 
         let pool = test_db.pool.clone();
         let mut tx = pool.begin().await.unwrap();
@@ -1602,36 +1605,7 @@ mod tests {
         ));
         let mut state = build_state(test_db.pool.clone(), network_subgraph).await;
 
-        struct FailingCheck;
-        #[async_trait::async_trait]
-        impl Check<TapReceipt> for FailingCheck {
-            async fn check(
-                &self,
-                _: &tap_core::receipt::Context,
-                _receipt: &CheckingReceipt,
-            ) -> tap_core::receipt::checks::CheckResult {
-                Err(tap_core::receipt::checks::CheckError::Failed(anyhow!(
-                    "Failing check"
-                )))
-            }
-        }
-
-        let checks = CheckList::new(vec![Arc::new(FailingCheck)]);
-        let checking_receipts = vec![
-            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 1, 1, 1u128),
-            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 2, 2, 2u128),
-        ];
-        let failing_receipts = checking_receipts
-            .into_iter()
-            .map(|receipt| async {
-                receipt
-                    .finalize_receipt_checks(&Context::new(), &checks)
-                    .await
-                    .unwrap()
-                    .unwrap_err()
-            })
-            .collect::<Vec<_>>();
-        let failing_receipts = join_all(failing_receipts).await;
+        let failing_receipts = make_failing_receipts().await;
 
         let pool = test_db.pool.clone();
         let mut tx = pool.begin().await.unwrap();
@@ -1656,36 +1630,7 @@ mod tests {
         ));
         let mut state = build_state(test_db.pool.clone(), network_subgraph).await;
 
-        struct FailingCheck;
-        #[async_trait::async_trait]
-        impl Check<TapReceipt> for FailingCheck {
-            async fn check(
-                &self,
-                _: &tap_core::receipt::Context,
-                _receipt: &CheckingReceipt,
-            ) -> tap_core::receipt::checks::CheckResult {
-                Err(tap_core::receipt::checks::CheckError::Failed(anyhow!(
-                    "Failing check"
-                )))
-            }
-        }
-
-        let checks = CheckList::new(vec![Arc::new(FailingCheck)]);
-        let checking_receipts = vec![
-            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 1, 1, 1u128),
-            create_received_receipt_v2(&ALLOCATION_ID_0, &SIGNER.0, 2, 2, 2u128),
-        ];
-        let failing_receipts = checking_receipts
-            .into_iter()
-            .map(|receipt| async {
-                receipt
-                    .finalize_receipt_checks(&Context::new(), &checks)
-                    .await
-                    .unwrap()
-                    .unwrap_err()
-            })
-            .collect::<Vec<_>>();
-        let failing_receipts = join_all(failing_receipts).await;
+        let failing_receipts = make_failing_receipts().await;
 
         // Store the invalid receipts inside a transaction, then roll it back. Because the
         // store now runs on the caller's transaction instead of autocommitting, the rows

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -617,7 +617,7 @@ where
                 self.delete_receipts_between(&signers, min_timestamp, max_timestamp, &mut tx)
                     .await?;
                 tx.commit().await?;
-                self.account_invalid_receipts_fees(fees)?;
+                self.account_invalid_receipts_fees(fees);
                 Err(RavError::AllReceiptsInvalid)
             }
             // When it receives both valid and invalid receipts or just valid
@@ -670,7 +670,7 @@ where
                         .store_and_commit_invalid_receipts(invalid_receipts)
                         .await
                     {
-                        Ok(fees) => self.account_invalid_receipts_fees(fees)?,
+                        Ok(fees) => self.account_invalid_receipts_fees(fees),
                         Err(err) => {
                             tracing::error!(
                                 %err,
@@ -791,10 +791,10 @@ where
         Ok(fees)
     }
 
-    /// Add `fees` (the rejected receipts' total value) to the running invalid-receipt
-    /// total and report it to the sender account. Call only after the store commits, so
-    /// the total never runs ahead of what was durably written.
-    fn account_invalid_receipts_fees(&mut self, fees: u128) -> anyhow::Result<()> {
+    /// Add `fees` (the rejected receipts' total value) to the running invalid-receipt total
+    /// and report it to the sender account. Call only after the store commits, so the total
+    /// never runs ahead of what was durably written.
+    fn account_invalid_receipts_fees(&mut self, fees: u128) {
         self.invalid_receipts_fees.value = self
             .invalid_receipts_fees
             .value
@@ -812,13 +812,22 @@ where
                 );
                 u128::MAX
             });
-        self.sender_account_ref
-            .cast(SenderAccountMessage::UpdateInvalidReceiptFees(
-                T::to_allocation_id_enum(&self.allocation_id),
-                self.invalid_receipts_fees,
-            ))?;
-
-        Ok(())
+        // Notifying the sender account is best-effort: a failed cast means that actor is
+        // already gone, so log it rather than masking the caller's actual outcome.
+        if let Err(err) =
+            self.sender_account_ref
+                .cast(SenderAccountMessage::UpdateInvalidReceiptFees(
+                    T::to_allocation_id_enum(&self.allocation_id),
+                    self.invalid_receipts_fees,
+                ))
+        {
+            tracing::error!(
+                %err,
+                sender = %self.sender,
+                allocation_id = %self.allocation_id,
+                "Failed to notify sender account of invalid receipt fees",
+            );
+        }
     }
 
     async fn store_v2_invalid_receipts(

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -69,6 +69,16 @@ pub(crate) static RAVS_FAILED_BY_VERSION: LazyLock<CounterVec> = LazyLock::new(|
     )
     .unwrap()
 });
+pub(crate) static INVALID_RECEIPTS_STORE_FAILED_BY_VERSION: LazyLock<CounterVec> =
+    LazyLock::new(|| {
+        register_counter_vec!(
+            "tap_invalid_receipts_store_failed_total_by_version",
+            "Best-effort writes of invalid receipts that failed while the RAV for the valid \
+             receipts was still stored, per sender allocation and TAP version",
+            &["sender", "allocation", "version"]
+        )
+        .unwrap()
+    });
 pub(crate) static RAV_RESPONSE_TIME_BY_VERSION: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         "tap_rav_response_time_seconds_by_version",
@@ -658,22 +668,39 @@ where
                 //
                 // store them before we call remove_obsolete_receipts()
                 if !invalid_receipts.is_empty() {
+                    let invalid_count = invalid_receipts.len();
                     tracing::warn!(
-                        invalid_count = invalid_receipts.len(),
+                        invalid_count,
                         allocation_id = %self.allocation_id,
                         sender = %self.sender,
                         "Found invalid receipts",
                     );
 
-                    // Save invalid receipts to the database for logs.
-                    // TODO: consider doing that in a spawned task?
-                    let pool = self.pgpool.clone();
-                    let mut tx = pool.begin().await?;
-                    let fees = self
-                        .store_invalid_receipts(invalid_receipts, &mut tx)
-                        .await?;
-                    tx.commit().await?;
-                    self.account_invalid_receipts_fees(fees)?;
+                    // Recording invalid receipts is best-effort logging; a failed write must
+                    // not drop the RAV the valid receipts earned, so we log and meter it and
+                    // only advance the in-memory total when the write actually committed.
+                    match self
+                        .store_and_commit_invalid_receipts(invalid_receipts)
+                        .await
+                    {
+                        Ok(fees) => self.account_invalid_receipts_fees(fees)?,
+                        Err(err) => {
+                            tracing::error!(
+                                %err,
+                                invalid_count,
+                                allocation_id = %self.allocation_id,
+                                sender = %self.sender,
+                                "Failed to record invalid receipts; storing the RAV anyway",
+                            );
+                            INVALID_RECEIPTS_STORE_FAILED_BY_VERSION
+                                .with_label_values(&[
+                                    &self.sender.to_string(),
+                                    &self.allocation_id.to_string(),
+                                    TAP_VERSION,
+                                ])
+                                .inc();
+                        }
+                    }
                 }
 
                 match self
@@ -736,6 +763,20 @@ where
             }
             (Err(e), ..) => Err(e.into()),
         }
+    }
+
+    /// Store invalid receipts in their own committed transaction and return their total
+    /// value. Used by the mixed valid+invalid path, where recording is best-effort and must
+    /// not share a transaction with the RAV being stored for the valid receipts.
+    async fn store_and_commit_invalid_receipts(
+        &mut self,
+        receipts: Vec<ReceiptWithState<Failed, TapReceipt>>,
+    ) -> anyhow::Result<u128> {
+        let pool = self.pgpool.clone();
+        let mut tx = pool.begin().await?;
+        let fees = self.store_invalid_receipts(receipts, &mut tx).await?;
+        tx.commit().await?;
+        Ok(fees)
     }
 
     /// Store invalid receipts on the caller's transaction and return their total value.
@@ -1164,6 +1205,7 @@ pub fn init_metrics() {
     let _ = &*CLOSED_SENDER_ALLOCATIONS;
     let _ = &*RAVS_CREATED_BY_VERSION;
     let _ = &*RAVS_FAILED_BY_VERSION;
+    let _ = &*INVALID_RECEIPTS_STORE_FAILED_BY_VERSION;
     let _ = &*RAV_RESPONSE_TIME_BY_VERSION;
 }
 

--- a/crates/tap-agent/src/agent/sender_allocation.rs
+++ b/crates/tap-agent/src/agent/sender_allocation.rs
@@ -827,7 +827,7 @@ where
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> anyhow::Result<()> {
         let receipts_len = receipts.len();
-        let mut reciepts_signers = Vec::with_capacity(receipts_len);
+        let mut receipts_signers = Vec::with_capacity(receipts_len);
         let mut encoded_signatures = Vec::with_capacity(receipts_len);
         let mut collection_ids = Vec::with_capacity(receipts_len);
         let mut payers = Vec::with_capacity(receipts_len);
@@ -856,7 +856,7 @@ where
                 reason = %receipt_error,
                 "Invalid receipt stored",
             );
-            reciepts_signers.push(receipt_signer.encode_hex());
+            receipts_signers.push(receipt_signer.encode_hex());
             encoded_signatures.push(encoded_signature);
             collection_ids.push(collection_id.encode_hex());
             payers.push(payer.encode_hex());
@@ -892,7 +892,7 @@ where
                 $10::TEXT[]
             )"#,
         )
-        .bind(&reciepts_signers)
+        .bind(&receipts_signers)
         .bind(&encoded_signatures)
         .bind(&collection_ids)
         .bind(&payers)


### PR DESCRIPTION
## TL;DR

The payments agent records the receipts it rejects as invalid, with the reason, in a separate audit log. When an entire batch is invalid it now records and removes them in one transaction, instead of two unlinked writes where a failed record could delete a receipt without ever logging it. When a batch mixes valid and invalid receipts, recording is best-effort and no longer blocks storing the valid receipts' payment.

## Motivation

When the agent judges receipts invalid, it writes them — each with the reason — to a separate audit log that is the operator's durable account of what the indexer turned away and why, and when none are valid it also removes them from the live set it still works on. Those were two unlinked writes whose record step was logged but ignored on failure, so a receipt could be dropped from the live set without ever being recorded as rejected, leaving a silent gap in exactly the visibility the log exists to provide.

When a batch instead holds both valid and invalid receipts, that same record write sits just before the valid ones are aggregated into a signed payment voucher. Tying the voucher to the record write means one failed record discards the voucher, and because the agent retries the same batch on a capped backoff that never gives up, a persistent failure could keep the valid receipts from ever being paid.

## Summary

- Record and delete invalid receipts in one transaction when a whole batch is invalid.
- In that case, let a failed record stop the delete instead of deleting without a record.
- Make invalid-receipt recording best-effort in mixed batches so it can't block payment.
- Log and count a failed record write, and advance the running invalid total only once it commits.
- Add a test that rolls the transaction back and confirms nothing was written.
