### PR TITLE
feat: reject proposals from untrusted senders and update docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4342,7 +4342,9 @@ dependencies = [
  "ipfs-api-backend-hyper",
  "prost 0.14.3",
  "rand 0.8.5",
+ "reqwest 0.12.24",
  "serde",
+ "serde_json",
  "serde_yaml",
  "sqlx",
  "test-assets",
@@ -4356,6 +4358,7 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4341,6 +4341,7 @@ dependencies = [
  "indexer-monitor",
  "indexer-query",
  "ipfs-api-backend-hyper",
+ "prometheus 0.13.4",
  "prost 0.14.3",
  "rand 0.8.5",
  "reqwest 0.12.24",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4339,6 +4339,7 @@ dependencies = [
  "futures",
  "graph-networks-registry",
  "indexer-monitor",
+ "indexer-query",
  "ipfs-api-backend-hyper",
  "prost 0.14.3",
  "rand 0.8.5",

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -194,6 +194,10 @@ supported_networks = []
 # Your own observations may differ - adjust pricing accordingly.
 min_grt_per_billion_entities_per_30_days = "200"  # entity-based component (global)
 
+# RecurringCollector contract address. The EIP-712 verifying contract used to
+# recover the signer of incoming agreement proposals. Required when DIPs is enabled.
+recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
+
 [dips.min_grt_per_30_days]  # base rate component (per-network)
 # arbitrum-one = "450"
 # matic = "300"

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -94,9 +94,10 @@ max_signers_per_payer = 0
 # Indexing-payments subgraph, read for the set of accounts allowed to send DIPs
 # agreement proposals (the agreement-manager role). Required when [dips] is set.
 [subgraphs.indexing_payments]
-# Query URL for the indexing-payments subgraph.
+# Query URL for the indexing-payments subgraph -- a SEPARATE deployment from [subgraphs.network].
 query_url = "http://example.com/indexing-payments-subgraph"
-# How often to refresh contract information from this subgraph, in seconds.
+# Required when this section is present (no default). How often to refresh from this subgraph, in
+# seconds. Distinct from dips.role_refresh_interval_secs, which governs the role-set pull.
 syncing_interval_secs = 60
 # Optional, auth token used as "bearer auth".
 # query_auth_token = "super-secret"
@@ -187,41 +188,54 @@ max_receipts_per_request = 10000
 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 0xDD6a6f76eb36B873C1C184e8b9b9e762FE216490 = "https://tap-aggregator-arbitrum-one.graphops.xyz"
 
-# DIPs (Direct Indexer Payments). Payer authorisation is verified
-# on-chain at acceptance. GRT prices, not wei.
+# DIPs (Direct Indexer Payments). Each proposal's recovered EIP-712 signer is checked against
+# the on-chain agreement-manager role set, read off the indexing-payments subgraph at proposal
+# time -- not the payer, not on-chain at acceptance. Prices below are GRT, not wei.
+
+# To enable DIPs you must set: recurring_collector, [subgraphs.indexing_payments] (query_url +
+# syncing_interval_secs), and at least one supported_networks entry with a matching price under
+# [dips.min_grt_per_30_days]. Everything else here has a default.
+
+# Failure modes: an empty role set, or a subgraph outage past role_failopen_grace_secs, rejects
+# all proposals; if DIPs init fails the service keeps serving queries but runs WITHOUT DIPs
+# (check the /dips/info endpoint and the dips_enabled metric). Per-field consequences below.
 [dips]
+# Address/port the DIPs gRPC server binds to, where the dipper sends proposals; needs ingress
+# reachable by the dipper. port is a quoted string. Defaults: "0.0.0.0" / "7601".
 host = "0.0.0.0"
 port = "7601"
 
-# Networks you explicitly support indexing.
-# Proposals from the dipper for you to index networks that are not in the list below are rejected.
-# See https://github.com/graphprotocol/networks-registry/blob/main/docs/networks-table.md
-# e.g. supported_networks = ["mainnet", "arbitrum-one"]
+# Networks you support indexing. REQUIRED to accept anything: list at least one here AND set its
+# price under [dips.min_grt_per_30_days]; empty = ALL proposals rejected (not "accept all").
+# Names: https://github.com/graphprotocol/networks-registry (e.g. ["mainnet", "arbitrum-one"]).
 supported_networks = []
 
-# Minimum payment you are willing to accept in order to accept indexing agreements
-# (base price + entity-based price). Total payment = base price + (entities on sg * entity_rate)
+# Minimum payment you require to accept indexing agreements (base + entity-based). Total =
+# min_grt_per_30_days[network] + (entities_in_billions * min_grt_per_billion_entities_per_30_days)
 #
 # For reference: analysis of subgraphs indexed by the upgrade indexer in Q1 2025 found
 # the average entity size to be ~0.759 KiB. At this size, 1 billion entities ≈ 0.707 TiB.
 # Your own observations may differ - adjust pricing accordingly.
-min_grt_per_billion_entities_per_30_days = "200"  # entity-based component (global)
+min_grt_per_billion_entities_per_30_days = "200"  # illustrative, NOT the default (default 0)
 
-# RecurringCollector contract address. The EIP-712 verifying contract used to
-# recover the signer of incoming agreement proposals. Required when DIPs is enabled.
+# RecurringCollector contract address: the EIP-712 verifying contract used to recover each
+# proposal's signer, which is then checked against the agreement-manager role set. Also the
+# contract rpc_url reads the domain from. Required when DIPs is enabled.
 recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
 
-# How often to re-pull the set of accounts allowed to send proposals (the
-# agreement-manager role) from the indexing-payments subgraph, in seconds.
+# How often to re-pull the agreement-manager role set from the indexing-payments subgraph, in
+# seconds. Must be > 0. Default 86400 (1 day); lower it to honour on-chain revocations sooner.
 role_refresh_interval_secs = 86400
-# Extra seconds past the refresh interval that a cached role set stays trusted
-# while refreshes keep failing, before the gate starts rejecting (fail-open window).
+# Fail-open window: extra seconds past the refresh interval that a KNOWN holder from the last
+# good role set keeps being admitted while refreshes fail (unknown signers are not); after it
+# the gate rejects everyone. Default 3600.
 role_failopen_grace_secs = 3600
-# Largest the subgraph head may lag wall-clock (seconds) before its role data is
-# treated as unreliable. 0 disables the check.
+# Largest the subgraph head may lag wall-clock (seconds) before role data is treated as
+# unreliable: past this the fetch is a failure (role set not updated, proposals rejected as
+# transient) rather than trusting stale grants/revokes. 0 disables. Default 1800.
 role_subgraph_max_lag_secs = 1800
-# Ethereum JSON-RPC endpoint for fetching the RecurringCollector's EIP-712
-# domain at startup (EIP-5267). When unset, built-in domain constants are used.
+# JSON-RPC to read the RecurringCollector's EIP-712 domain at startup (EIP-5267); unset = built-in
+# constants. Set on local/dev/upgraded chains, else signer recovery is wrong and all proposals rejected.
 # rpc_url = "https://arb1.arbitrum.io/rpc"
 
 [dips.min_grt_per_30_days]  # base rate component (per-network)
@@ -323,4 +337,6 @@ role_subgraph_max_lag_secs = 1800
 # boba = "5"
 # sepolia = "5"
 
+# Custom or test networks not in the global networks-registry: maps network name to CAIP-2
+# chain id so proposals for them pass the registry check. Default empty. e.g. hardhat = "eip155:1337"
 [dips.additional_networks]

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -91,6 +91,19 @@ escrow_min_balance_grt_wei = "100000000000000000"
 # signers, orphaning receipts and enabling free queries.
 max_signers_per_payer = 0
 
+# Indexing-payments subgraph, read for the set of accounts allowed to send DIPs
+# agreement proposals (the agreement-manager role). Required when [dips] is set.
+[subgraphs.indexing_payments]
+# Query URL for the indexing-payments subgraph.
+query_url = "http://example.com/indexing-payments-subgraph"
+# How often to refresh contract information from this subgraph, in seconds.
+syncing_interval_secs = 60
+# Optional, auth token used as "bearer auth".
+# query_auth_token = "super-secret"
+# Optional deployment to look for in the local `graph-node`, if locally indexed.
+# NOTE: use `query_url` or `deployment_id` only.
+# deployment_id = "Qmbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
 [blockchain]
 # The chain ID of the network that the graph network is running on
 chain_id = 1337
@@ -197,6 +210,16 @@ min_grt_per_billion_entities_per_30_days = "200"  # entity-based component (glob
 # RecurringCollector contract address. The EIP-712 verifying contract used to
 # recover the signer of incoming agreement proposals. Required when DIPs is enabled.
 recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
+
+# How often to re-pull the set of accounts allowed to send proposals (the
+# agreement-manager role) from the indexing-payments subgraph, in seconds.
+role_refresh_interval_secs = 86400
+# Extra seconds past the refresh interval that a cached role set stays trusted
+# while refreshes keep failing, before the gate starts rejecting (fail-open window).
+role_failopen_grace_secs = 3600
+# Largest the subgraph head may lag wall-clock (seconds) before its role data is
+# treated as unreliable. 0 disables the check.
+role_subgraph_max_lag_secs = 1800
 
 [dips.min_grt_per_30_days]  # base rate component (per-network)
 # arbitrum-one = "450"

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -64,12 +64,13 @@ status_url = "http://graph-node:8000/graphql"
 [subgraphs.network]
 # Query URL for the Graph Network subgraph.
 query_url = "http://example.com/network-subgraph"
-# Optional, Auth token will used a "bearer auth"
+# Bearer token sent with queries to query_url. Set only if that endpoint needs auth (e.g. a
+# hosted/gateway URL); leave unset for an open or self-hosted graph-node. Default unset.
 # query_auth_token = "super-secret"
 
-# Optional, deployment to look for in the local `graph-node`, if locally indexed.
-# Locally indexing the subgraph is recommended.
-# NOTE: Use `query_url` or `deployment_id` only
+# Optional: index this subgraph on your own graph-node and put its deployment id here -- queries
+# then prefer your local node (free) and fall back to query_url only if it is unsynced or errors.
+# query_url stays required as that fallback. Indexing locally is recommended.
 deployment_id = "Qmaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 # Refreshing interval for the Graph contracts information from the Graph Network
 # subgraph.
@@ -99,10 +100,12 @@ query_url = "http://example.com/indexing-payments-subgraph"
 # Required when this section is present (no default). How often to refresh from this subgraph, in
 # seconds. Distinct from dips.role_refresh_interval_secs, which governs the role-set pull.
 syncing_interval_secs = 60
-# Optional, auth token used as "bearer auth".
+# Bearer token sent with queries to query_url. Set only if that endpoint needs auth; leave unset
+# for an open or self-hosted graph-node. Default unset.
 # query_auth_token = "super-secret"
-# Optional deployment to look for in the local `graph-node`, if locally indexed.
-# NOTE: use `query_url` or `deployment_id` only.
+
+# Optional: index this subgraph yourself and set its deployment id -- queries then prefer your
+# local node (free) and fall back to query_url if it is unsynced. query_url stays required.
 # deployment_id = "Qmbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 [blockchain]
@@ -124,9 +127,11 @@ url_prefix = "/"
 # Serve the network subgraph on `common.server.host_and_port`/network
 serve_network_subgraph = false
 #### OPTIONAL VALUES ####
-## use this to add a layer while serving network/escrow subgraph
+
+# Bearer token that gates the served network/escrow subgraph endpoint (serve_network_subgraph).
 # serve_auth_token = "token"
-## allow queries using this token
+
+# Lets anyone presenting this token query for FREE -- no TAP receipt required. Share sparingly.
 # free_query_auth_token = "i-am-authorized-right?"
 ipfs_url = "https://api.thegraph.com/ipfs/"
 # Maximum number of deployments allowed in a single /cost GraphQL batch query.
@@ -158,8 +163,9 @@ max_receipt_value_grt = "0.001" # 0.001 GRT. We use strings to prevent rounding 
 # max_amount_willing_to_lose_grt = "0.1"
 max_amount_willing_to_lose_grt = 20
 
-# List of Senders that are allowed to spend up to `max_amount_willing_to_lose_grt`
-# over the escrow balance
+# Senders allowed to spend up to `max_amount_willing_to_lose_grt` beyond their escrow balance.
+# This is unsecured credit: if such a sender stops aggregating you may never recover those fees,
+# so only list senders you trust to settle. Default empty.
 trusted_senders = ["0xdeadbeefcafebabedeadbeefcafebabedeadbeef"]
 
 
@@ -223,19 +229,20 @@ min_grt_per_billion_entities_per_30_days = "200"  # illustrative, NOT the defaul
 # contract rpc_url reads the domain from. Required when DIPs is enabled.
 recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
 
-# How often to re-pull the agreement-manager role set from the indexing-payments subgraph, in
-# seconds. Must be > 0. Default 86400 (1 day); lower it to honour on-chain revocations sooner.
+# How often (seconds) to re-read the indexing-payments subgraph for which addresses may send you
+# agreements. New senders are picked up within seconds anyway; this mainly sets how fast a REVOKED
+# sender stops being accepted, so lower it to apply revocations sooner. Must be > 0. Default 86400.
 role_refresh_interval_secs = 86400
-# Fail-open window: extra seconds past the refresh interval that a KNOWN holder from the last
-# good role set keeps being admitted while refreshes fail (unknown signers are not); after it
-# the gate rejects everyone. Default 3600.
+# What happens during a subgraph outage. If re-reads keep failing, senders already on the last
+# good list stay accepted for this many extra seconds (brand-new senders never are); once it
+# elapses, every proposal is rejected until the subgraph recovers. Default 3600 (1 hour).
 role_failopen_grace_secs = 3600
-# Largest the subgraph head may lag wall-clock (seconds) before role data is treated as
-# unreliable: past this the fetch is a failure (role set not updated, proposals rejected as
-# transient) rather than trusting stale grants/revokes. 0 disables. Default 1800.
+# Safety check on subgraph freshness: if the subgraph has fallen more than this many seconds
+# behind the chain, its sender list is treated as untrustworthy and proposals are rejected as
+# "try again later" rather than risk stale data. 0 turns the check off. Default 1800 (30 min).
 role_subgraph_max_lag_secs = 1800
-# JSON-RPC to read the RecurringCollector's EIP-712 domain at startup (EIP-5267); unset = built-in
-# constants. Set on local/dev/upgraded chains, else signer recovery is wrong and all proposals rejected.
+# Startup chain RPC for the RecurringCollector's EIP-712 signing domain. Unset uses built-in
+# values (correct on standard networks); set on local/dev or upgraded chains, else every proposal fails.
 # rpc_url = "https://arb1.arbitrum.io/rpc"
 
 [dips.min_grt_per_30_days]  # base rate component (per-network)

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -682,11 +682,9 @@ fn default_allocation_reconciliation_interval_secs() -> Duration {
     Duration::from_secs(300)
 }
 
-/// DIPs configuration.
-///
-/// Validates RCA proposals (signature, IPFS manifest, network, pricing)
-/// before storing. The indexer agent queries pending proposals from the
-/// database and decides on-chain acceptance.
+/// DIPs configuration. Authorises proposal senders -- recovers each agreement's EIP-712 signer
+/// and requires it to hold the on-chain agreement-manager role (from the indexing-payments
+/// subgraph) -- then validates accepted proposals before storing them for the indexer-agent.
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 #[cfg_attr(test, derive(PartialEq))]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -286,11 +286,20 @@ impl Config {
             );
         }
 
-        // A zero DIPs role-refresh interval would panic the refresh task on startup
-        // (tokio's interval timer rejects a zero period), so reject it up front.
+        // Validate DIPs settings up front rather than partway through boot. A zero
+        // refresh interval panics the refresh task (tokio rejects a zero period); the
+        // collector address and indexing-payments subgraph are both needed to authorise.
         if let Some(dips) = &self.dips {
             if dips.role_refresh_interval_secs == 0 {
                 return Err("dips.role_refresh_interval_secs must be greater than 0".to_string());
+            }
+            if dips.recurring_collector.is_none() {
+                return Err("dips.recurring_collector must be set when DIPs is enabled".to_string());
+            }
+            if self.subgraphs.indexing_payments.is_none() {
+                return Err(
+                    "subgraphs.indexing_payments must be set when DIPs is enabled".to_string(),
+                );
             }
         }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -473,6 +473,10 @@ impl MetricsConfig {
 #[allow(deprecated)] // Allow using deprecated EscrowSubgraphConfig type
 pub struct SubgraphsConfig {
     pub network: NetworkSubgraphConfig,
+    /// Indexing-payments subgraph, read for the DIPs agreement-manager role set.
+    /// Required when DIPs is enabled.
+    #[serde(default)]
+    pub indexing_payments: Option<SubgraphConfig>,
     #[deprecated(note = "V2 escrow accounts are in the network subgraph; this field is ignored.")]
     #[serde(default)]
     pub escrow: Option<EscrowSubgraphConfig>,
@@ -682,6 +686,14 @@ pub struct DipsConfig {
     /// RecurringCollector address: the EIP-712 verifying contract used to recover
     /// the signer of incoming RCA proposals. Required when DIPs is enabled.
     pub recurring_collector: Option<Address>,
+    /// How often to re-pull the agreement-manager role set from the subgraph.
+    pub role_refresh_interval_secs: u64,
+    /// Extra time past the refresh interval that a cached role set stays trusted
+    /// while refreshes fail, before the gate fails closed (the fail-open window).
+    pub role_failopen_grace_secs: u64,
+    /// Max seconds the role subgraph head may lag wall-clock before its data is
+    /// treated as unreliable. 0 disables the check.
+    pub role_subgraph_max_lag_secs: u64,
 }
 
 impl Default for DipsConfig {
@@ -694,6 +706,9 @@ impl Default for DipsConfig {
             min_grt_per_billion_entities_per_30_days: GRT::ZERO,
             additional_networks: BTreeMap::new(),
             recurring_collector: None,
+            role_refresh_interval_secs: 86_400,
+            role_failopen_grace_secs: 3_600,
+            role_subgraph_max_lag_secs: 1_800,
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -679,6 +679,9 @@ pub struct DipsConfig {
     /// Minimum acceptable GRT per billion entities per 30 days.
     pub min_grt_per_billion_entities_per_30_days: GRT,
     pub additional_networks: BTreeMap<String, String>,
+    /// RecurringCollector address: the EIP-712 verifying contract used to recover
+    /// the signer of incoming RCA proposals. Required when DIPs is enabled.
+    pub recurring_collector: Option<Address>,
 }
 
 impl Default for DipsConfig {
@@ -690,6 +693,7 @@ impl Default for DipsConfig {
             min_grt_per_30_days: BTreeMap::new(),
             min_grt_per_billion_entities_per_30_days: GRT::ZERO,
             additional_networks: BTreeMap::new(),
+            recurring_collector: None,
         }
     }
 }
@@ -766,6 +770,7 @@ mod tests {
             HashSet::from([address!("deadbeefcafebabedeadbeefcafebabedeadbeef")]);
         max_config.dips = Some(crate::DipsConfig {
             min_grt_per_billion_entities_per_30_days: crate::GRT::from_grt("200"),
+            recurring_collector: Some(address!("cccccccccccccccccccccccccccccccccccccccc")),
             ..Default::default()
         });
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -796,6 +796,14 @@ mod tests {
             recurring_collector: Some(address!("cccccccccccccccccccccccccccccccccccccccc")),
             ..Default::default()
         });
+        max_config.subgraphs.indexing_payments = Some(crate::SubgraphConfig {
+            query_url: "http://example.com/indexing-payments-subgraph"
+                .parse()
+                .unwrap(),
+            query_auth_token: None,
+            deployment_id: None,
+            syncing_interval_secs: std::time::Duration::from_secs(60),
+        });
 
         let max_config_file: Config = toml::from_str(
             fs::read_to_string("maximal-config-example.toml")

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -286,6 +286,14 @@ impl Config {
             );
         }
 
+        // A zero DIPs role-refresh interval would panic the refresh task on startup
+        // (tokio's interval timer rejects a zero period), so reject it up front.
+        if let Some(dips) = &self.dips {
+            if dips.role_refresh_interval_secs == 0 {
+                return Err("dips.role_refresh_interval_secs must be greater than 0".to_string());
+            }
+        }
+
         // Warn about auth tokens over cleartext HTTP (TRST-L-3)
         // This is a security risk as tokens can be intercepted
         Self::warn_if_token_over_http(

--- a/crates/dips/Cargo.toml
+++ b/crates/dips/Cargo.toml
@@ -20,10 +20,10 @@ db = [
     "dep:sqlx",
     "dep:build-info",
     "dep:indexer-monitor",
+    "dep:indexer-query",
     "dep:graph-networks-registry",
     "dep:serde",
     "dep:serde_yaml",
-    "dep:bytes",
 ]
 
 [dependencies]
@@ -36,6 +36,7 @@ tracing.workspace = true
 bs58 = "0.5"
 build-info = { workspace = true, optional = true }
 indexer-monitor = { path = "../monitor", optional = true }
+indexer-query = { path = "../query", optional = true }
 thiserror.workspace = true
 graph-networks-registry = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }

--- a/crates/dips/Cargo.toml
+++ b/crates/dips/Cargo.toml
@@ -65,6 +65,7 @@ build-info.workspace = true
 rand = "0.8"
 reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 wiremock.workspace = true
 
 [build-dependencies]

--- a/crates/dips/Cargo.toml
+++ b/crates/dips/Cargo.toml
@@ -23,6 +23,7 @@ db = [
     "dep:graph-networks-registry",
     "dep:serde",
     "dep:serde_yaml",
+    "dep:bytes",
 ]
 
 [dependencies]
@@ -37,7 +38,7 @@ build-info = { workspace = true, optional = true }
 indexer-monitor = { path = "../monitor", optional = true }
 thiserror.workspace = true
 graph-networks-registry = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
 serde_yaml = { version = "0.9", optional = true }
 
 # IPFS client dependencies
@@ -58,6 +59,9 @@ indexer-monitor = { path = "../monitor" }
 graph-networks-registry.workspace = true
 build-info.workspace = true
 rand = "0.8"
+reqwest = { workspace = true, features = ["json"] }
+serde_json.workspace = true
+wiremock.workspace = true
 
 [build-dependencies]
 tonic-build = { workspace = true, optional = true }

--- a/crates/dips/Cargo.toml
+++ b/crates/dips/Cargo.toml
@@ -15,6 +15,7 @@ rpc = [
     "dep:graph-networks-registry",
     "dep:serde",
     "dep:serde_yaml",
+    "dep:prometheus",
 ]
 db = [
     "dep:sqlx",
@@ -24,6 +25,7 @@ db = [
     "dep:graph-networks-registry",
     "dep:serde",
     "dep:serde_yaml",
+    "dep:prometheus",
 ]
 
 [dependencies]
@@ -41,6 +43,7 @@ thiserror.workspace = true
 graph-networks-registry = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_yaml = { version = "0.9", optional = true }
+prometheus = { workspace = true, optional = true }
 
 # IPFS client dependencies
 derivative = "2.2.0"

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -53,10 +53,10 @@ use std::sync::Arc;
 use server::DipsServerContext;
 use thegraph_core::alloy::{
     core::primitives::Address,
-    primitives::{keccak256, ruint::aliases::U256, Uint},
+    primitives::{keccak256, ruint::aliases::U256, Signature, Uint},
     signers::SignerSync,
     sol,
-    sol_types::{Eip712Domain, SolValue},
+    sol_types::{eip712_domain, Eip712Domain, SolStruct, SolValue},
 };
 
 #[cfg(feature = "db")]
@@ -147,9 +147,23 @@ fn derive_agreement_id(rca: &RecurringCollectionAgreement) -> Uuid {
     Uuid::from_bytes(id_bytes)
 }
 
+/// EIP-712 domain for RecurringCollectionAgreement signatures. Must match the
+/// domain dipper signs with and the on-chain RecurringCollector contract; any
+/// drift in name, version, chain id, or address makes every recovered signer wrong.
+pub fn rca_eip712_domain(chain_id: u64, recurring_collector: Address) -> Eip712Domain {
+    eip712_domain! {
+        name: "RecurringCollector",
+        version: "1",
+        chain_id: chain_id,
+        verifying_contract: recurring_collector,
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum DipsError {
     // RCA validation
+    #[error("invalid signature: {0}")]
+    InvalidSignature(String),
     #[error("RCA service provider {actual} does not match the expected address {expected}")]
     UnexpectedServiceProvider { expected: Address, actual: Address },
     #[error("cannot get subgraph manifest for {0}")]
@@ -208,6 +222,20 @@ impl RecurringCollectionAgreement {
 }
 
 impl SignedRecurringCollectionAgreement {
+    /// Recover the EIP-712 signer of the RCA over the RecurringCollector domain.
+    /// An empty, malformed, or non-recovering signature is rejected as
+    /// InvalidSignature. The recovered address is what PR B gates on.
+    pub fn recover_signer(&self, domain: &Eip712Domain) -> Result<Address, DipsError> {
+        if self.signature.is_empty() {
+            return Err(DipsError::InvalidSignature("missing signature".to_string()));
+        }
+        let signature = Signature::try_from(self.signature.as_ref())
+            .map_err(|err| DipsError::InvalidSignature(err.to_string()))?;
+        signature
+            .recover_address_from_prehash(&self.agreement.eip712_signing_hash(domain))
+            .map_err(|err| DipsError::InvalidSignature(err.to_string()))
+    }
+
     /// Validate proposal-time fields.
     ///
     /// Checks that the service provider matches the expected indexer
@@ -275,12 +303,18 @@ pub async fn validate_and_create_rca(
         price_calculator,
         registry,
         additional_networks,
-        ..
+        rca_domain,
     } = ctx.as_ref();
 
     // Decode SignedRCA
     let signed_rca = SignedRecurringCollectionAgreement::abi_decode(rca_bytes.as_ref())
         .map_err(|e| DipsError::AbiDecoding(e.to_string()))?;
+
+    // Authenticate the sender before acting on the proposal: recover the EIP-712
+    // signer. PR B gates this address against the on-chain agreement-manager role
+    // set; for now any cryptographically valid signature passes.
+    let signer = signed_rca.recover_signer(rca_domain)?;
+    tracing::debug!(%signer, "recovered RCA signer");
 
     // Validate service provider
     signed_rca.validate(expected_service_provider)?;
@@ -428,6 +462,7 @@ mod test {
         derive_agreement_id,
         ipfs::{FailingIpfsFetcher, MockIpfsFetcher},
         price::PriceCalculator,
+        rca_eip712_domain,
         server::DipsServerContext,
         store::{FailingRcaStore, InMemoryRcaStore},
         AcceptIndexingAgreementMetadata, DipsError, IndexingAgreementTermsV1,
@@ -435,8 +470,22 @@ mod test {
     };
     use thegraph_core::alloy::{
         primitives::{keccak256, Address, FixedBytes, U256},
-        sol_types::SolValue,
+        signers::local::PrivateKeySigner,
+        sol_types::{Eip712Domain, SolValue},
     };
+
+    // Fixed signer and domain for round-tripping RCA signatures in tests. The
+    // recovered address equals `test_signer().address()`; the domain must match
+    // the one stored in the test context so recovery succeeds.
+    fn test_signer() -> PrivateKeySigner {
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+            .parse()
+            .unwrap()
+    }
+
+    fn test_rca_domain() -> Eip712Domain {
+        rca_eip712_domain(1337, Address::repeat_byte(0xCC))
+    }
 
     fn create_test_context() -> Arc<DipsServerContext> {
         Arc::new(DipsServerContext {
@@ -449,19 +498,17 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         })
     }
 
-    /// Helper: encode an RCA as a `SignedRecurringCollectionAgreement`
-    /// ABI payload. The signature field is no longer consumed by the
-    /// validator; this just produces the wire bytes that
-    /// `validate_and_create_rca` expects to decode.
+    /// Sign an RCA with the fixed test key over the test domain and ABI-encode
+    /// the wrapper, producing the wire bytes `validate_and_create_rca` decodes
+    /// and recovers the signer from.
     fn rca_to_wire_bytes(rca: RecurringCollectionAgreement) -> Vec<u8> {
-        SignedRecurringCollectionAgreement {
-            agreement: rca,
-            signature: Default::default(),
-        }
-        .abi_encode()
+        rca.sign(&test_rca_domain(), test_signer())
+            .expect("signing test RCA")
+            .abi_encode()
     }
 
     fn create_test_rca(
@@ -636,6 +683,85 @@ mod test {
         assert_eq!(data[0].0, agreement_id);
     }
 
+    #[test]
+    fn test_recover_signer_recovers_the_signing_key() {
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            Address::repeat_byte(0x11),
+            U256::from(200),
+            U256::from(100),
+        );
+
+        let signed = rca
+            .sign(&test_rca_domain(), test_signer())
+            .expect("signing test RCA");
+        let recovered = signed
+            .recover_signer(&test_rca_domain())
+            .expect("recovering signer");
+
+        assert_eq!(recovered, test_signer().address());
+    }
+
+    #[test]
+    fn test_recover_signer_rejects_empty_signature() {
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            Address::repeat_byte(0x11),
+            U256::from(200),
+            U256::from(100),
+        );
+        let signed = SignedRecurringCollectionAgreement {
+            agreement: rca,
+            signature: Default::default(),
+        };
+
+        assert!(matches!(
+            signed.recover_signer(&test_rca_domain()),
+            Err(DipsError::InvalidSignature(_))
+        ));
+    }
+
+    #[test]
+    fn test_recover_signer_rejects_malformed_signature() {
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            Address::repeat_byte(0x11),
+            U256::from(200),
+            U256::from(100),
+        );
+        let signed = SignedRecurringCollectionAgreement {
+            agreement: rca,
+            signature: vec![0xAA; 10].into(),
+        };
+
+        assert!(matches!(
+            signed.recover_signer(&test_rca_domain()),
+            Err(DipsError::InvalidSignature(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_validate_and_create_rca_missing_signature_rejected() {
+        let service_provider = Address::repeat_byte(0x11);
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            service_provider,
+            U256::from(200),
+            U256::from(100),
+        );
+        // An unsigned proposal must be rejected before any other validation.
+        let rca_bytes = SignedRecurringCollectionAgreement {
+            agreement: rca,
+            signature: Default::default(),
+        }
+        .abi_encode();
+
+        let ctx = create_test_context();
+        let result = super::validate_and_create_rca(ctx, &service_provider, rca_bytes).await;
+
+        assert!(matches!(result, Err(DipsError::InvalidSignature(_))));
+    }
+
     #[tokio::test]
     async fn test_validate_and_create_rca_wrong_service_provider() {
         let payer = Address::repeat_byte(0x42);
@@ -718,6 +844,7 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -891,6 +1018,7 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -925,6 +1053,7 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -959,6 +1088,7 @@ mod test {
             )),
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -63,6 +63,8 @@ use thegraph_core::alloy::{
 pub mod database;
 pub mod inflight;
 pub mod ipfs;
+#[cfg(any(feature = "rpc", feature = "db"))]
+pub mod metrics;
 pub mod price;
 #[cfg(feature = "rpc")]
 pub mod proto;

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -71,6 +71,7 @@ mod registry;
 #[cfg(feature = "rpc")]
 pub mod server;
 pub mod store;
+pub mod trusted_signers;
 
 use thiserror::Error;
 use uuid::Uuid;
@@ -195,6 +196,10 @@ pub enum DipsError {
     DeadlineExpired { deadline: u64, now: u64 },
     #[error("agreement end time {ends_at} has already passed (current time: {now})")]
     AgreementExpired { ends_at: u64, now: u64 },
+    #[error("sender {signer} is not authorised to send agreement proposals")]
+    SenderNotTrusted { signer: Address },
+    #[error("could not verify sender authorisation: {0}")]
+    TrustVerificationUnavailable(String),
 }
 
 #[cfg(feature = "rpc")]
@@ -304,17 +309,18 @@ pub async fn validate_and_create_rca(
         registry,
         additional_networks,
         rca_domain,
+        trusted_signers,
     } = ctx.as_ref();
 
     // Decode SignedRCA
     let signed_rca = SignedRecurringCollectionAgreement::abi_decode(rca_bytes.as_ref())
         .map_err(|e| DipsError::AbiDecoding(e.to_string()))?;
 
-    // Authenticate the sender before acting on the proposal: recover the EIP-712
-    // signer. PR B gates this address against the on-chain agreement-manager role
-    // set; for now any cryptographically valid signature passes.
+    // Authenticate then authorize the sender: recover the EIP-712 signer, then
+    // require it to hold the on-chain agreement-manager role before doing any work.
     let signer = signed_rca.recover_signer(rca_domain)?;
     tracing::debug!(%signer, "recovered RCA signer");
+    trusted_signers.verify_trusted(signer).await?;
 
     // Validate service provider
     signed_rca.validate(expected_service_provider)?;
@@ -465,6 +471,7 @@ mod test {
         rca_eip712_domain,
         server::DipsServerContext,
         store::{FailingRcaStore, InMemoryRcaStore},
+        trusted_signers::{StaticTrustedSigners, TrustedSignerSource},
         AcceptIndexingAgreementMetadata, DipsError, IndexingAgreementTermsV1,
         RecurringCollectionAgreement, SignedRecurringCollectionAgreement,
     };
@@ -487,6 +494,12 @@ mod test {
         rca_eip712_domain(1337, Address::repeat_byte(0xCC))
     }
 
+    fn trusted_signers_for_test() -> Arc<dyn TrustedSignerSource> {
+        Arc::new(StaticTrustedSigners(HashSet::from([
+            test_signer().address()
+        ])))
+    }
+
     fn create_test_context() -> Arc<DipsServerContext> {
         Arc::new(DipsServerContext {
             rca_store: Arc::new(InMemoryRcaStore::default()),
@@ -499,7 +512,39 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            trusted_signers: trusted_signers_for_test(),
         })
+    }
+
+    #[tokio::test]
+    async fn test_validate_and_create_rca_untrusted_signer_rejected() {
+        let service_provider = Address::repeat_byte(0x11);
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            service_provider,
+            U256::from(200),
+            U256::from(100),
+        );
+
+        // Trusted set excludes the test signer, so a valid signature is rejected.
+        let ctx = Arc::new(DipsServerContext {
+            rca_store: Arc::new(InMemoryRcaStore::default()),
+            ipfs_fetcher: Arc::new(MockIpfsFetcher::default()),
+            price_calculator: Arc::new(PriceCalculator::new(
+                HashSet::from(["mainnet".to_string()]),
+                BTreeMap::from([("mainnet".to_string(), U256::from(100))]),
+                U256::from(50),
+            )),
+            registry: Arc::new(crate::registry::test_registry()),
+            additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
+            trusted_signers: Arc::new(StaticTrustedSigners::default()),
+        });
+        let rca_bytes = rca_to_wire_bytes(rca);
+
+        let result = super::validate_and_create_rca(ctx, &service_provider, rca_bytes).await;
+
+        assert!(matches!(result, Err(DipsError::SenderNotTrusted { .. })));
     }
 
     /// Sign an RCA with the fixed test key over the test domain and ABI-encode
@@ -845,6 +890,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            trusted_signers: trusted_signers_for_test(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1019,6 +1065,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            trusted_signers: trusted_signers_for_test(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1054,6 +1101,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            trusted_signers: trusted_signers_for_test(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1089,6 +1137,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            trusted_signers: trusted_signers_for_test(),
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);

--- a/crates/dips/src/metrics.rs
+++ b/crates/dips/src/metrics.rs
@@ -1,0 +1,40 @@
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Prometheus metrics for the DIPs proposal path. Registered in the global
+//! registry, so the indexer-service /metrics endpoint exposes them.
+
+use std::sync::LazyLock;
+
+use prometheus::{register_counter_vec, register_int_gauge, CounterVec, IntGauge};
+
+/// Incoming agreement proposals by outcome: `accepted`, `untrusted` (signer is
+/// not a role holder), `transient` (couldn't verify -- sender should retry), or
+/// `rejected` (other validation failure).
+pub static PROPOSAL_OUTCOMES: LazyLock<CounterVec> = LazyLock::new(|| {
+    register_counter_vec!(
+        "dips_proposal_outcomes_total",
+        "Incoming DIPs agreement proposals by outcome",
+        &["outcome"]
+    )
+    .unwrap()
+});
+
+/// Agreement-manager role holders in the last successful subgraph fetch.
+pub static ROLE_SET_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(
+        "dips_agreement_manager_role_holders",
+        "Agreement-manager role holders in the last successful subgraph fetch"
+    )
+    .unwrap()
+});
+
+/// Unix time of the last successful role-set fetch. Alert on `time() - this` to
+/// catch a refresh that has stalled.
+pub static ROLE_LAST_REFRESH_TIMESTAMP: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(
+        "dips_agreement_manager_role_last_refresh_timestamp",
+        "Unix time of the last successful agreement-manager role fetch"
+    )
+    .unwrap()
+});

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -45,7 +45,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
-use thegraph_core::alloy::primitives::Address;
+use thegraph_core::alloy::{primitives::Address, sol_types::Eip712Domain};
 use tonic::{Request, Response, Status};
 
 use crate::{
@@ -79,6 +79,8 @@ pub struct DipsServerContext {
     pub registry: Arc<graph_networks_registry::NetworksRegistry>,
     /// Additional networks beyond the registry
     pub additional_networks: Arc<BTreeMap<String, String>>,
+    /// EIP-712 domain for recovering the RCA signer (RecurringCollector).
+    pub rca_domain: Eip712Domain,
 }
 
 /// DIPS server implementing RCA protocol.
@@ -109,6 +111,7 @@ fn reject_reason_from_error(err: &DipsError) -> RejectReason {
         DipsError::AgreementExpired { .. } => RejectReason::AgreementExpired,
         DipsError::UnsupportedNetwork(_) => RejectReason::UnsupportedNetwork,
         DipsError::SubgraphManifestUnavailable(_) => RejectReason::SubgraphManifestUnavailable,
+        DipsError::InvalidSignature(_) => RejectReason::InvalidSignature,
         DipsError::UnexpectedServiceProvider { .. } => RejectReason::UnexpectedServiceProvider,
         DipsError::UnsupportedMetadataVersion(_) => RejectReason::UnsupportedMetadataVersion,
         // Malformed proposals with no dedicated reason map to the catch-all; the
@@ -231,6 +234,7 @@ mod tests {
                 )),
                 registry: Arc::new(crate::registry::test_registry()),
                 additional_networks: Arc::new(BTreeMap::new()),
+                rca_domain: crate::rca_eip712_domain(1337, Address::repeat_byte(0xCC)),
             })
         }
     }
@@ -392,6 +396,18 @@ mod tests {
 
         // Assert
         assert_eq!(reason, RejectReason::SubgraphManifestUnavailable);
+    }
+
+    #[test]
+    fn test_reject_reason_invalid_signature() {
+        // Arrange
+        let err = DipsError::InvalidSignature("bad signature".to_string());
+
+        // Act
+        let reason = super::reject_reason_from_error(&err);
+
+        // Assert
+        assert_eq!(reason, RejectReason::InvalidSignature);
     }
 
     #[test]

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -58,6 +58,7 @@ use crate::{
         SubmitAgreementProposalRequest, SubmitAgreementProposalResponse,
     },
     store::RcaStore,
+    trusted_signers::TrustedSignerSource,
     DipsError,
 };
 
@@ -81,6 +82,8 @@ pub struct DipsServerContext {
     pub additional_networks: Arc<BTreeMap<String, String>>,
     /// EIP-712 domain for recovering the RCA signer (RecurringCollector).
     pub rca_domain: Eip712Domain,
+    /// Authorises the recovered signer against the on-chain agreement-manager role.
+    pub trusted_signers: Arc<dyn TrustedSignerSource>,
 }
 
 /// DIPS server implementing RCA protocol.
@@ -119,9 +122,12 @@ fn reject_reason_from_error(err: &DipsError) -> RejectReason {
         DipsError::AbiDecoding(_)
         | DipsError::InvalidSubgraphManifest(_)
         | DipsError::InvalidRca(_) => RejectReason::Unspecified,
-        // A store failure means the proposal was valid but the indexer couldn't persist
-        // it -- tell dipper this is transient so it retries rather than giving up.
-        DipsError::UnknownError(_) => RejectReason::IndexerUnavailable,
+        DipsError::SenderNotTrusted { .. } => RejectReason::SenderNotTrusted,
+        // A store failure or an unverifiable role set means a valid proposal the
+        // indexer couldn't act on -- tell dipper it's transient so it retries.
+        DipsError::TrustVerificationUnavailable(_) | DipsError::UnknownError(_) => {
+            RejectReason::IndexerUnavailable
+        }
     }
 }
 
@@ -222,7 +228,10 @@ mod tests {
     impl DipsServerContext {
         pub fn for_testing() -> Arc<Self> {
             use std::collections::{BTreeMap, HashSet};
+
             use thegraph_core::alloy::primitives::U256;
+
+            use crate::trusted_signers::StaticTrustedSigners;
 
             Arc::new(Self {
                 rca_store: Arc::new(InMemoryRcaStore::default()),
@@ -235,6 +244,7 @@ mod tests {
                 registry: Arc::new(crate::registry::test_registry()),
                 additional_networks: Arc::new(BTreeMap::new()),
                 rca_domain: crate::rca_eip712_domain(1337, Address::repeat_byte(0xCC)),
+                trusted_signers: Arc::new(StaticTrustedSigners::default()),
             })
         }
     }
@@ -470,6 +480,28 @@ mod tests {
         // Assert: a valid proposal the indexer can't persist is transient, so the
         // sender should retry rather than treat it as a permanent failure.
         assert_eq!(reason, RejectReason::IndexerUnavailable);
+    }
+
+    #[test]
+    fn test_reject_reason_sender_not_trusted() {
+        let err = DipsError::SenderNotTrusted {
+            signer: Address::repeat_byte(0x55),
+        };
+
+        assert_eq!(
+            super::reject_reason_from_error(&err),
+            RejectReason::SenderNotTrusted
+        );
+    }
+
+    #[test]
+    fn test_reject_reason_trust_unverifiable_is_transient() {
+        let err = DipsError::TrustVerificationUnavailable("role subgraph down".to_string());
+
+        assert_eq!(
+            super::reject_reason_from_error(&err),
+            RejectReason::IndexerUnavailable
+        );
     }
 
     #[test]

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -140,6 +140,16 @@ fn reject_detail_from_error(err: &DipsError) -> String {
     }
 }
 
+/// Coarse `outcome` label for the proposal metric: an untrusted signer, a
+/// transient failure the sender should retry, or some other validation rejection.
+fn outcome_label(err: &DipsError) -> &'static str {
+    match err {
+        DipsError::SenderNotTrusted { .. } => "untrusted",
+        DipsError::TrustVerificationUnavailable(_) | DipsError::UnknownError(_) => "transient",
+        _ => "rejected",
+    }
+}
+
 #[async_trait]
 impl IndexerDipsService for DipsServer {
     /// Submit an RCA proposal.
@@ -190,6 +200,9 @@ impl IndexerDipsService for DipsServer {
             .await
         {
             Ok(agreement_id) => {
+                crate::metrics::PROPOSAL_OUTCOMES
+                    .with_label_values(&["accepted"])
+                    .inc();
                 tracing::info!(%agreement_id, "RCA accepted");
                 Ok(Response::new(SubmitAgreementProposalResponse {
                     outcome: Some(Outcome::Accepted(Accepted {})),
@@ -197,6 +210,9 @@ impl IndexerDipsService for DipsServer {
             }
             Err(e) => {
                 let reject_reason = reject_reason_from_error(&e);
+                crate::metrics::PROPOSAL_OUTCOMES
+                    .with_label_values(&[outcome_label(&e)])
+                    .inc();
                 tracing::info!(
                     error = %e,
                     reason = ?reject_reason,

--- a/crates/dips/src/trusted_signers.rs
+++ b/crates/dips/src/trusted_signers.rs
@@ -64,6 +64,11 @@ mod subgraph {
     /// long, so a burst of unknown signers can't turn into a fetch storm.
     const REFRESH_DEBOUNCE: Duration = Duration::from_secs(5);
 
+    /// Don't refetch the holder set on demand more than once per this interval: a
+    /// recent successful fetch is authoritative, so a burst of distinct unknown
+    /// signers is answered from it instead of triggering one refetch each.
+    const ON_DEMAND_REFRESH_MIN_INTERVAL: Duration = Duration::from_secs(5);
+
     /// How long a "not a role holder" answer is reused from memory before that
     /// signer is re-checked. Caps how often a repeated unknown signer drives a
     /// fetch, and bounds how long a later-granted signer waits to be recognised.
@@ -406,10 +411,20 @@ mod subgraph {
                 }
             }
 
-            // A new (or newly-expired) signer, or a cache gone stale past the
-            // window: try a single-flighted refresh, then decide against the
-            // freshest data.
-            let refreshed = self.refresh().await;
+            // A new or stale-cache signer: refresh on demand to catch a just-granted
+            // manager, but skip the refetch when the last success is recent and still
+            // fresh -- bounds a distinct-unknown-signer flood to one fetch per window.
+            let recently_refreshed = {
+                let cache = self.cache.read().unwrap();
+                cache.last_success.is_some_and(|t| {
+                    t.elapsed() < ON_DEMAND_REFRESH_MIN_INTERVAL && self.is_fresh(Some(t))
+                })
+            };
+            let refreshed = if recently_refreshed {
+                Ok(())
+            } else {
+                self.refresh().await
+            };
 
             let (present, fresh) = {
                 let cache = self.cache.read().unwrap();
@@ -792,6 +807,55 @@ mod subgraph {
                 Duration::from_secs(1800),
             );
             assert!(src.verify_trusted(HOLDER).await.is_ok());
+        }
+
+        #[tokio::test]
+        async fn on_demand_refetch_is_rate_limited() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(holders_body(&[HOLDER], now_secs())),
+                )
+                .mount(&server)
+                .await;
+            let client = leak_client(&server).await;
+            // Window far larger than the 5s min-interval so the freshness gate never
+            // trips here; lag check off.
+            let src =
+                SubgraphTrustedSigners::new(client, Duration::from_secs(3600), Duration::ZERO);
+
+            // Freeze time so the on-demand min-interval is exercised deterministically.
+            tokio::time::pause();
+
+            // First unknown signer: cold cache, one real fetch, then rejected.
+            assert!(matches!(
+                src.verify_trusted(Address::repeat_byte(0xa0)).await,
+                Err(DipsError::SenderNotTrusted { .. })
+            ));
+            // More distinct unknowns inside the window: answered from the recent fetch.
+            for b in [0xa1u8, 0xa2, 0xa3] {
+                assert!(matches!(
+                    src.verify_trusted(Address::repeat_byte(b)).await,
+                    Err(DipsError::SenderNotTrusted { .. })
+                ));
+            }
+            assert_eq!(
+                server.received_requests().await.unwrap().len(),
+                1,
+                "distinct unknown signers within the window must share one fetch"
+            );
+
+            // Past the window, the next unknown signer triggers exactly one more fetch.
+            tokio::time::advance(Duration::from_secs(6)).await;
+            assert!(matches!(
+                src.verify_trusted(Address::repeat_byte(0xa4)).await,
+                Err(DipsError::SenderNotTrusted { .. })
+            ));
+            assert_eq!(
+                server.received_requests().await.unwrap().len(),
+                2,
+                "an unknown signer past the window triggers one more fetch"
+            );
         }
     }
 }

--- a/crates/dips/src/trusted_signers.rs
+++ b/crates/dips/src/trusted_signers.rs
@@ -1,0 +1,519 @@
+// Copyright 2023-, Edge & Node, GraphOps, and Semiotic Labs.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Trust gate for incoming agreement proposals: require the recovered EIP-712
+//! signer to hold the on-chain `AGREEMENT_MANAGER_ROLE` (read from the
+//! indexing-payments-subgraph), gating on the signer, never the spoofable payer.
+
+use async_trait::async_trait;
+use thegraph_core::alloy::primitives::Address;
+
+use crate::DipsError;
+
+/// Source of truth for which signers may send agreement proposals.
+#[async_trait]
+pub trait TrustedSignerSource: std::fmt::Debug + Send + Sync {
+    /// Confirm `signer` may send agreement proposals. `Ok` = trusted;
+    /// `SenderNotTrusted` = definitively not a role holder; any other error means
+    /// the check failed and the caller should treat it as transient and retry.
+    async fn verify_trusted(&self, signer: Address) -> Result<(), DipsError>;
+}
+
+/// A fixed set of trusted signers. Used in tests and as a simple in-memory
+/// source; production uses [`SubgraphTrustedSigners`].
+#[derive(Debug, Clone, Default)]
+pub struct StaticTrustedSigners(pub std::collections::HashSet<Address>);
+
+#[async_trait]
+impl TrustedSignerSource for StaticTrustedSigners {
+    async fn verify_trusted(&self, signer: Address) -> Result<(), DipsError> {
+        if self.0.contains(&signer) {
+            Ok(())
+        } else {
+            Err(DipsError::SenderNotTrusted { signer })
+        }
+    }
+}
+
+#[cfg(feature = "db")]
+pub use subgraph::SubgraphTrustedSigners;
+
+#[cfg(feature = "db")]
+mod subgraph {
+    use std::{
+        collections::HashSet,
+        sync::{Arc, RwLock},
+        time::Duration,
+    };
+
+    use async_trait::async_trait;
+    use indexer_monitor::SubgraphClient;
+    use thegraph_core::alloy::primitives::Address;
+    use tokio::{sync::Mutex, time::Instant};
+
+    use super::TrustedSignerSource;
+    use crate::DipsError;
+
+    /// Fetches every active AGREEMENT_MANAGER_ROLE holder in one query, plus the
+    /// subgraph head time for the staleness guard. The role filter and `active:
+    /// true` are load-bearing: several roles are indexed, and revokes only flag.
+    const ROLE_HOLDERS_QUERY: &str = r#"{"query":"{ roleAssignments(where: {role: \"0xeb1b3455811b30c0dd237887f6349f22cc96ee5963709d7fe356d9b0cefa6d22\", active: true}, first: 1000) { account } _meta { block { timestamp } } }"}"#;
+
+    /// Page size for the holder query. The manager set is tiny in practice; if a
+    /// fetch ever returns a full page we log it rather than silently truncating.
+    const MAX_ROLE_HOLDERS: usize = 1000;
+
+    /// After a failed on-demand fetch, don't re-hit the subgraph again for this
+    /// long, so a burst of unknown signers can't turn into a fetch storm.
+    const REFRESH_DEBOUNCE: Duration = Duration::from_secs(5);
+
+    #[derive(Default)]
+    struct RoleCache {
+        holders: HashSet<Address>,
+        /// When the holder set was last fetched successfully.
+        last_success: Option<Instant>,
+        /// When a fetch most recently failed (for debouncing retries).
+        last_failed_attempt: Option<Instant>,
+    }
+
+    /// Caches the AGREEMENT_MANAGER_ROLE holder set, refreshing on a timer and on
+    /// demand for unknown signers. A cache hit within the bounded window is
+    /// answered from memory (fail-open through outages); past it, fails closed.
+    pub struct SubgraphTrustedSigners {
+        subgraph: &'static SubgraphClient,
+        cache: Arc<RwLock<RoleCache>>,
+        refresh_lock: Arc<Mutex<()>>,
+        /// Oldest a successful fetch may be before a cache hit stops being
+        /// trusted: the bounded fail-open window. Set to the refresh interval
+        /// plus a grace period so a healthy deploy never trips it.
+        max_stale: Duration,
+        /// Largest gap between the subgraph head and wall-clock that is still
+        /// trusted; past it the data is treated as unreliable. 0 disables it.
+        max_chain_lag: Duration,
+    }
+
+    impl std::fmt::Debug for SubgraphTrustedSigners {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("SubgraphTrustedSigners")
+                .field("max_stale", &self.max_stale)
+                .field("max_chain_lag", &self.max_chain_lag)
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl SubgraphTrustedSigners {
+        /// Construct the source without fetching or starting the refresh task.
+        fn new(
+            subgraph: &'static SubgraphClient,
+            max_stale: Duration,
+            max_chain_lag: Duration,
+        ) -> Arc<Self> {
+            Arc::new(Self {
+                subgraph,
+                cache: Arc::new(RwLock::new(RoleCache::default())),
+                refresh_lock: Arc::new(Mutex::new(())),
+                max_stale,
+                max_chain_lag,
+            })
+        }
+
+        /// Build the source, seed it once (best-effort), and start the periodic
+        /// refresh. A failed initial fetch is logged, not fatal: proposals are
+        /// rejected as transient until the first successful fetch.
+        pub async fn spawn(
+            subgraph: &'static SubgraphClient,
+            refresh_interval: Duration,
+            failopen_grace: Duration,
+            max_chain_lag: Duration,
+        ) -> Arc<Self> {
+            let this = Self::new(subgraph, refresh_interval + failopen_grace, max_chain_lag);
+
+            if let Err(e) = this.refresh().await {
+                tracing::warn!(
+                    error = %e,
+                    "initial agreement-manager role fetch failed; DIPs proposals \
+                     will be rejected as transient until it succeeds"
+                );
+            }
+
+            let bg = this.clone();
+            tokio::spawn(async move {
+                let mut tick = tokio::time::interval(refresh_interval);
+                tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                tick.tick().await; // the immediate first tick; already seeded above
+                loop {
+                    tick.tick().await;
+                    if let Err(e) = bg.refresh().await {
+                        tracing::warn!(error = %e, "periodic agreement-manager role refresh failed");
+                    }
+                }
+            });
+
+            this
+        }
+
+        fn is_fresh(&self, last_success: Option<Instant>) -> bool {
+            last_success.is_some_and(|t| t.elapsed() < self.max_stale)
+        }
+
+        /// Fetch the whole holder set and swap it into the cache. Single-flighted
+        /// (concurrent callers coalesce onto one fetch) and debounced after a
+        /// failure so an outage doesn't trigger a fetch per request.
+        async fn refresh(&self) -> Result<(), DipsError> {
+            let started = Instant::now();
+            let _guard = self.refresh_lock.lock().await;
+
+            {
+                let cache = self.cache.read().unwrap();
+                // A concurrent refresh already succeeded after we started waiting.
+                if cache.last_success.is_some_and(|t| t >= started) {
+                    return Ok(());
+                }
+                // We failed very recently; don't hammer the subgraph.
+                if cache
+                    .last_failed_attempt
+                    .is_some_and(|t| t.elapsed() < REFRESH_DEBOUNCE)
+                {
+                    return Err(DipsError::TrustVerificationUnavailable(
+                        "agreement-manager role subgraph was unreachable moments ago".to_string(),
+                    ));
+                }
+            }
+
+            match self.fetch_holders().await {
+                Ok(holders) => {
+                    let mut cache = self.cache.write().unwrap();
+                    cache.holders = holders;
+                    cache.last_success = Some(Instant::now());
+                    cache.last_failed_attempt = None;
+                    Ok(())
+                }
+                Err(e) => {
+                    self.cache.write().unwrap().last_failed_attempt = Some(Instant::now());
+                    Err(DipsError::TrustVerificationUnavailable(e.to_string()))
+                }
+            }
+        }
+
+        async fn fetch_holders(&self) -> anyhow::Result<HashSet<Address>> {
+            let body = bytes::Bytes::from_static(ROLE_HOLDERS_QUERY.as_bytes());
+            let response = self
+                .subgraph
+                .query_raw(body)
+                .await
+                .map_err(|e| anyhow::anyhow!("role-holder query failed: {e}"))?;
+            let parsed: GraphqlResponse = response
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("decoding role-holder response failed: {e}"))?;
+
+            if let Some(errors) = parsed.errors.filter(|e| !e.is_empty()) {
+                let joined = errors
+                    .into_iter()
+                    .map(|e| e.message)
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                return Err(anyhow::anyhow!(
+                    "role-holder query returned errors: {joined}"
+                ));
+            }
+
+            let data = parsed
+                .data
+                .ok_or_else(|| anyhow::anyhow!("role-holder response had no data"))?;
+
+            // A badly-lagging subgraph may be missing recent grants or revokes,
+            // so treat it as unreliable rather than trusting a stale role set.
+            let max_lag = self.max_chain_lag.as_secs() as i64;
+            if max_lag > 0 {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map_err(|e| anyhow::anyhow!("system time before unix epoch: {e}"))?
+                    .as_secs() as i64;
+                let lag = now - data.meta.block.timestamp;
+                if lag > max_lag {
+                    return Err(anyhow::anyhow!(
+                        "indexing-payments subgraph is {lag}s behind wall-clock (max {max_lag}s); \
+                         treating agreement-manager role data as unreliable"
+                    ));
+                }
+            }
+
+            if data.role_assignments.len() >= MAX_ROLE_HOLDERS {
+                tracing::warn!(
+                    returned = data.role_assignments.len(),
+                    "agreement-manager role query hit the page cap; some holders may be missing"
+                );
+            }
+
+            let holders: HashSet<Address> = data
+                .role_assignments
+                .into_iter()
+                .map(|r| r.account)
+                .collect();
+            if holders.is_empty() {
+                tracing::warn!(
+                    "agreement-manager role set is empty; all DIPs proposals will be \
+                     rejected as untrusted"
+                );
+            }
+            Ok(holders)
+        }
+    }
+
+    #[async_trait]
+    impl TrustedSignerSource for SubgraphTrustedSigners {
+        async fn verify_trusted(&self, signer: Address) -> Result<(), DipsError> {
+            // Fast path: a known holder whose cache is still inside the window is
+            // answered from memory, with no subgraph round-trip.
+            {
+                let cache = self.cache.read().unwrap();
+                if cache.holders.contains(&signer) && self.is_fresh(cache.last_success) {
+                    return Ok(());
+                }
+            }
+
+            // Unknown signer, or the cache has gone stale past the window: try a
+            // single-flighted refresh, then decide against the freshest data.
+            let refreshed = self.refresh().await;
+
+            let (present, fresh) = {
+                let cache = self.cache.read().unwrap();
+                (
+                    cache.holders.contains(&signer),
+                    self.is_fresh(cache.last_success),
+                )
+            };
+
+            match refreshed {
+                // Authoritative answer from a fresh fetch.
+                Ok(()) if present => Ok(()),
+                Ok(()) => Err(DipsError::SenderNotTrusted { signer }),
+                // Couldn't refresh: fail open only for a known holder still inside
+                // the window (e.g. a concurrent refresh just succeeded); otherwise
+                // we can't vouch for the signer, so report transient.
+                Err(transient) => {
+                    if present && fresh {
+                        tracing::warn!(
+                            %signer,
+                            "agreement-manager role refresh failed; admitting known \
+                             signer from cached set within fail-open window"
+                        );
+                        Ok(())
+                    } else {
+                        Err(transient)
+                    }
+                }
+            }
+        }
+    }
+
+    #[derive(serde::Deserialize)]
+    struct GraphqlResponse {
+        data: Option<RoleData>,
+        #[serde(default)]
+        errors: Option<Vec<GraphqlError>>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct GraphqlError {
+        message: String,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct RoleData {
+        #[serde(rename = "roleAssignments")]
+        role_assignments: Vec<RoleRow>,
+        #[serde(rename = "_meta")]
+        meta: Meta,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct RoleRow {
+        account: Address,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Meta {
+        block: MetaBlock,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct MetaBlock {
+        timestamp: i64,
+    }
+
+    #[cfg(test)]
+    mod test {
+        use std::time::Duration;
+
+        use indexer_monitor::{DeploymentDetails, SubgraphClient};
+        use serde_json::json;
+        use thegraph_core::alloy::primitives::{address, Address};
+        use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
+
+        use super::*;
+
+        const HOLDER: Address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        const STRANGER: Address = address!("0000000000000000000000000000000000000099");
+
+        fn now_secs() -> i64 {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64
+        }
+
+        fn holders_body(accounts: &[Address], timestamp: i64) -> serde_json::Value {
+            json!({
+                "data": {
+                    "roleAssignments": accounts
+                        .iter()
+                        .map(|a| json!({ "account": a }))
+                        .collect::<Vec<_>>(),
+                    "_meta": { "block": { "timestamp": timestamp } }
+                }
+            })
+        }
+
+        async fn leak_client(server: &MockServer) -> &'static SubgraphClient {
+            Box::leak(Box::new(
+                SubgraphClient::new(
+                    reqwest::Client::new(),
+                    None,
+                    DeploymentDetails::for_query_url(&server.uri()).unwrap(),
+                )
+                .await,
+            ))
+        }
+
+        async fn client_always(
+            template: ResponseTemplate,
+        ) -> (&'static SubgraphClient, MockServer) {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(template)
+                .mount(&server)
+                .await;
+            let client = leak_client(&server).await;
+            (client, server)
+        }
+
+        #[tokio::test]
+        async fn known_signer_passes() {
+            let (client, _server) = client_always(
+                ResponseTemplate::new(200).set_body_json(holders_body(&[HOLDER], now_secs())),
+            )
+            .await;
+            let src = SubgraphTrustedSigners::new(client, Duration::from_secs(60), Duration::ZERO);
+            src.refresh().await.unwrap();
+
+            assert!(src.verify_trusted(HOLDER).await.is_ok());
+        }
+
+        #[tokio::test]
+        async fn unknown_signer_rejected_after_refresh() {
+            let (client, _server) = client_always(
+                ResponseTemplate::new(200).set_body_json(holders_body(&[HOLDER], now_secs())),
+            )
+            .await;
+            // Cold cache: the verify triggers an on-demand refresh, then rejects.
+            let src = SubgraphTrustedSigners::new(client, Duration::from_secs(60), Duration::ZERO);
+
+            assert!(matches!(
+                src.verify_trusted(STRANGER).await,
+                Err(DipsError::SenderNotTrusted { .. })
+            ));
+        }
+
+        #[tokio::test]
+        async fn empty_role_set_rejects() {
+            let (client, _server) = client_always(
+                ResponseTemplate::new(200).set_body_json(holders_body(&[], now_secs())),
+            )
+            .await;
+            let src = SubgraphTrustedSigners::new(client, Duration::from_secs(60), Duration::ZERO);
+
+            assert!(matches!(
+                src.verify_trusted(HOLDER).await,
+                Err(DipsError::SenderNotTrusted { .. })
+            ));
+        }
+
+        #[tokio::test]
+        async fn unreachable_subgraph_is_transient() {
+            let (client, _server) = client_always(ResponseTemplate::new(500)).await;
+            let src = SubgraphTrustedSigners::new(client, Duration::from_secs(60), Duration::ZERO);
+
+            assert!(matches!(
+                src.verify_trusted(HOLDER).await,
+                Err(DipsError::TrustVerificationUnavailable(_))
+            ));
+        }
+
+        #[tokio::test]
+        async fn stale_subgraph_head_is_transient() {
+            // Head far behind wall-clock with a 60s tolerance: treated as unreliable.
+            let (client, _server) =
+                client_always(ResponseTemplate::new(200).set_body_json(holders_body(&[HOLDER], 1)))
+                    .await;
+            let src = SubgraphTrustedSigners::new(
+                client,
+                Duration::from_secs(60),
+                Duration::from_secs(60),
+            );
+
+            assert!(matches!(
+                src.verify_trusted(HOLDER).await,
+                Err(DipsError::TrustVerificationUnavailable(_))
+            ));
+        }
+
+        #[tokio::test]
+        async fn known_signer_fails_closed_past_window() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(holders_body(&[HOLDER], now_secs())),
+                )
+                .mount(&server)
+                .await;
+            let client = leak_client(&server).await;
+
+            // Tiny window so the cache ages out within the test. Chain-lag check off.
+            let src =
+                SubgraphTrustedSigners::new(client, Duration::from_millis(400), Duration::ZERO);
+            src.refresh().await.unwrap();
+            assert!(
+                src.verify_trusted(HOLDER).await.is_ok(),
+                "a known holder passes from cache while the window is fresh"
+            );
+
+            // The subgraph goes down and the cache ages past the window.
+            server.reset().await;
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(500))
+                .mount(&server)
+                .await;
+            tokio::time::sleep(Duration::from_millis(600)).await;
+
+            assert!(
+                matches!(
+                    src.verify_trusted(HOLDER).await,
+                    Err(DipsError::TrustVerificationUnavailable(_))
+                ),
+                "past the window with the subgraph down, even a known holder fails closed"
+            );
+        }
+
+        #[test]
+        fn query_role_hash_matches_keccak() {
+            use thegraph_core::alloy::primitives::keccak256;
+            let expected = format!("0x{:x}", keccak256(b"AGREEMENT_MANAGER_ROLE"));
+            assert!(
+                ROLE_HOLDERS_QUERY.contains(&expected),
+                "query role hash drifted from keccak256(\"AGREEMENT_MANAGER_ROLE\")"
+            );
+        }
+    }
+}

--- a/crates/dips/src/trusted_signers.rs
+++ b/crates/dips/src/trusted_signers.rs
@@ -358,6 +358,28 @@ mod subgraph {
         }
     }
 
+    /// What `verify_trusted` should do once it holds the freshest cache state.
+    /// Pulled out as a pure function so every branch -- including the fail-open
+    /// admit, which otherwise only fires on a rare race -- is unit-testable.
+    enum Decision {
+        Trusted,
+        Untrusted,
+        FailOpen,
+        Transient(DipsError),
+    }
+
+    /// Decide from a refresh result plus the post-refresh cache state: `present`
+    /// is whether the signer is in the holder set, `fresh` whether that set is
+    /// still inside the fail-open window.
+    fn decide(refreshed: Result<(), DipsError>, present: bool, fresh: bool) -> Decision {
+        match refreshed {
+            Ok(()) if present => Decision::Trusted,
+            Ok(()) => Decision::Untrusted,
+            Err(_) if present && fresh => Decision::FailOpen,
+            Err(transient) => Decision::Transient(transient),
+        }
+    }
+
     #[async_trait]
     impl TrustedSignerSource for SubgraphTrustedSigners {
         async fn verify_trusted(&self, signer: Address) -> Result<(), DipsError> {
@@ -391,32 +413,27 @@ mod subgraph {
                 )
             };
 
-            match refreshed {
-                // Authoritative answer from a fresh fetch: a newly-granted signer
-                // clears any stale negative entry.
-                Ok(()) if present => {
+            match decide(refreshed, present, fresh) {
+                // A newly-granted signer clears any stale negative entry.
+                Decision::Trusted => {
                     self.cache.write().unwrap().rejected.remove(&signer);
                     Ok(())
                 }
-                Ok(()) => {
+                Decision::Untrusted => {
                     self.note_rejected(signer);
                     Err(DipsError::SenderNotTrusted { signer })
                 }
-                // Couldn't refresh: fail open only for a known holder still inside
-                // the window; otherwise report transient -- and record no negative
-                // entry, since an inability to verify is not a definitive "no".
-                Err(transient) => {
-                    if present && fresh {
-                        tracing::warn!(
-                            %signer,
-                            "agreement-manager role refresh failed; admitting known \
-                             signer from cached set within fail-open window"
-                        );
-                        Ok(())
-                    } else {
-                        Err(transient)
-                    }
+                Decision::FailOpen => {
+                    tracing::warn!(
+                        %signer,
+                        "agreement-manager role refresh failed; admitting known \
+                         signer from cached set within fail-open window"
+                    );
+                    Ok(())
                 }
+                // Couldn't verify and can't fail open; report transient and record
+                // no negative entry, since this isn't a definitive "no".
+                Decision::Transient(e) => Err(e),
             }
         }
     }
@@ -704,6 +721,71 @@ mod subgraph {
                 posts, 1,
                 "concurrent unknown signers should share a single fetch"
             );
+        }
+
+        #[test]
+        fn decide_truth_table() {
+            let err = || DipsError::TrustVerificationUnavailable("down".to_string());
+
+            assert!(matches!(decide(Ok(()), true, true), Decision::Trusted));
+            // A successful fetch is authoritative, so presence alone admits.
+            assert!(matches!(decide(Ok(()), true, false), Decision::Trusted));
+            assert!(matches!(decide(Ok(()), false, true), Decision::Untrusted));
+            // The fail-open admit: refresh failed but a known holder is still fresh.
+            assert!(matches!(decide(Err(err()), true, true), Decision::FailOpen));
+            assert!(matches!(
+                decide(Err(err()), true, false),
+                Decision::Transient(_)
+            ));
+            assert!(matches!(
+                decide(Err(err()), false, true),
+                Decision::Transient(_)
+            ));
+            assert!(matches!(
+                decide(Err(err()), false, false),
+                Decision::Transient(_)
+            ));
+        }
+
+        #[tokio::test]
+        async fn known_holder_served_from_cache_during_outage() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(holders_body(&[HOLDER], now_secs())),
+                )
+                .mount(&server)
+                .await;
+            let client = leak_client(&server).await;
+            let src = SubgraphTrustedSigners::new(client, Duration::from_secs(60), Duration::ZERO);
+            src.refresh().await.unwrap();
+
+            // The subgraph goes down; within the window a known holder still passes.
+            server.reset().await;
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(500))
+                .mount(&server)
+                .await;
+            assert!(
+                src.verify_trusted(HOLDER).await.is_ok(),
+                "a known holder is admitted from cache while the subgraph is down"
+            );
+        }
+
+        #[tokio::test]
+        async fn fresh_head_within_lag_tolerance_passes() {
+            let (client, _server) = client_always(
+                ResponseTemplate::new(200).set_body_json(holders_body(&[HOLDER], now_secs())),
+            )
+            .await;
+            // Non-zero lag tolerance with a head at ~now: lag is inside tolerance,
+            // so the success side of the chain-lag guard trusts the fetch.
+            let src = SubgraphTrustedSigners::new(
+                client,
+                Duration::from_secs(60),
+                Duration::from_secs(1800),
+            );
+            assert!(src.verify_trusted(HOLDER).await.is_ok());
         }
     }
 }

--- a/crates/dips/src/trusted_signers.rs
+++ b/crates/dips/src/trusted_signers.rs
@@ -166,13 +166,48 @@ mod subgraph {
                 tick.tick().await; // the immediate first tick; already seeded above
                 loop {
                     tick.tick().await;
-                    if let Err(e) = bg.refresh().await {
-                        tracing::warn!(error = %e, "periodic agreement-manager role refresh failed");
-                    }
+                    bg.refresh_with_retry().await;
                 }
             });
 
             this
+        }
+
+        /// Refresh on the periodic schedule, retrying a failed fetch on a short
+        /// backoff rather than waiting a whole refresh interval. A brief subgraph
+        /// blip self-heals in seconds, so the fail-open window keeps its meaning.
+        async fn refresh_with_retry(&self) {
+            // Backoffs sit above REFRESH_DEBOUNCE so each retry actually re-fetches.
+            const BACKOFFS: [Duration; 4] = [
+                Duration::from_secs(10),
+                Duration::from_secs(30),
+                Duration::from_secs(60),
+                Duration::from_secs(120),
+            ];
+            let mut attempt = 0;
+            loop {
+                match self.refresh().await {
+                    Ok(()) => return,
+                    Err(e) if attempt < BACKOFFS.len() => {
+                        let backoff = BACKOFFS[attempt];
+                        tracing::warn!(
+                            error = %e,
+                            ?backoff,
+                            "periodic agreement-manager role refresh failed; retrying"
+                        );
+                        tokio::time::sleep(backoff).await;
+                        attempt += 1;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "agreement-manager role refresh still failing; \
+                             waiting for the next scheduled refresh"
+                        );
+                        return;
+                    }
+                }
+            }
         }
 
         fn is_fresh(&self, last_success: Option<Instant>) -> bool {

--- a/crates/dips/src/trusted_signers.rs
+++ b/crates/dips/src/trusted_signers.rs
@@ -48,20 +48,17 @@ mod subgraph {
 
     use async_trait::async_trait;
     use indexer_monitor::SubgraphClient;
-    use thegraph_core::alloy::primitives::Address;
+    use indexer_query::agreement_manager_roles::{self, AgreementManagerRolesQuery};
+    use thegraph_core::alloy::primitives::{keccak256, Address};
     use tokio::{sync::Mutex, time::Instant};
 
     use super::TrustedSignerSource;
     use crate::DipsError;
 
-    /// Fetches every active AGREEMENT_MANAGER_ROLE holder in one query, plus the
-    /// subgraph head time for the staleness guard. The role filter and `active:
-    /// true` are load-bearing: several roles are indexed, and revokes only flag.
-    const ROLE_HOLDERS_QUERY: &str = r#"{"query":"{ roleAssignments(where: {role: \"0xeb1b3455811b30c0dd237887f6349f22cc96ee5963709d7fe356d9b0cefa6d22\", active: true}, first: 1000) { account } _meta { block { timestamp } } }"}"#;
-
-    /// Page size for the holder query. The manager set is tiny in practice; if a
-    /// fetch ever returns a full page we log it rather than silently truncating.
-    const MAX_ROLE_HOLDERS: usize = 1000;
+    /// Page size for the holder query. The manager set is tiny in practice, so one
+    /// page almost always suffices; the fetch still pages so a larger set can't be
+    /// silently truncated.
+    const ROLE_PAGE_SIZE: i64 = 1000;
 
     /// After a failed on-demand fetch, don't re-hit the subgraph again for this
     /// long, so a burst of unknown signers can't turn into a fetch storm.
@@ -90,6 +87,9 @@ mod subgraph {
         /// Largest gap between the subgraph head and wall-clock that is still
         /// trusted; past it the data is treated as unreliable. 0 disables it.
         max_chain_lag: Duration,
+        /// Holder-query page size. Production uses [`ROLE_PAGE_SIZE`]; tests set a
+        /// small value to exercise pagination.
+        page_size: i64,
     }
 
     impl std::fmt::Debug for SubgraphTrustedSigners {
@@ -108,12 +108,22 @@ mod subgraph {
             max_stale: Duration,
             max_chain_lag: Duration,
         ) -> Arc<Self> {
+            Self::new_with_page_size(subgraph, max_stale, max_chain_lag, ROLE_PAGE_SIZE)
+        }
+
+        fn new_with_page_size(
+            subgraph: &'static SubgraphClient,
+            max_stale: Duration,
+            max_chain_lag: Duration,
+            page_size: i64,
+        ) -> Arc<Self> {
             Arc::new(Self {
                 subgraph,
                 cache: Arc::new(RwLock::new(RoleCache::default())),
                 refresh_lock: Arc::new(Mutex::new(())),
                 max_stale,
                 max_chain_lag,
+                page_size,
             })
         }
 
@@ -196,41 +206,72 @@ mod subgraph {
         }
 
         async fn fetch_holders(&self) -> anyhow::Result<HashSet<Address>> {
-            let body = bytes::Bytes::from_static(ROLE_HOLDERS_QUERY.as_bytes());
-            let response = self
-                .subgraph
-                .query_raw(body)
-                .await
-                .map_err(|e| anyhow::anyhow!("role-holder query failed: {e}"))?;
-            let parsed: GraphqlResponse = response
-                .json()
-                .await
-                .map_err(|e| anyhow::anyhow!("decoding role-holder response failed: {e}"))?;
+            // Derive the role id from its name so it can never drift from the
+            // on-chain AGREEMENT_MANAGER_ROLE constant.
+            let role = format!("0x{:x}", keccak256(b"AGREEMENT_MANAGER_ROLE"));
 
-            if let Some(errors) = parsed.errors.filter(|e| !e.is_empty()) {
-                let joined = errors
-                    .into_iter()
-                    .map(|e| e.message)
-                    .collect::<Vec<_>>()
-                    .join("; ");
-                return Err(anyhow::anyhow!(
-                    "role-holder query returned errors: {joined}"
-                ));
+            let mut holders = HashSet::new();
+            let mut last = String::new();
+            let mut block_hash: Option<String> = None;
+            let mut head_timestamp: Option<i64> = None;
+            let mut first_page = true;
+
+            loop {
+                let data = self
+                    .subgraph
+                    .query::<AgreementManagerRolesQuery, _>(agreement_manager_roles::Variables {
+                        role: role.clone(),
+                        first: self.page_size,
+                        last: last.clone(),
+                        block: block_hash.clone().map(|hash| {
+                            agreement_manager_roles::Block_height {
+                                hash: Some(hash),
+                                number: None,
+                                number_gte: None,
+                            }
+                        }),
+                    })
+                    .await
+                    .map_err(|e| anyhow::anyhow!("role-holder query failed: {e}"))?;
+
+                // The first page fixes the head timestamp (for the staleness guard)
+                // and the block that later pages pin to for a consistent read.
+                if first_page {
+                    first_page = false;
+                    if let Some(meta) = data.meta.as_ref() {
+                        head_timestamp = meta.block.timestamp;
+                        block_hash = meta.block.hash.clone();
+                    }
+                }
+
+                let page_len = data.role_assignments.len();
+                for row in data.role_assignments {
+                    last = row.id;
+                    let account = row.account.parse::<Address>().map_err(|e| {
+                        anyhow::anyhow!("invalid role-holder account {:?}: {e}", row.account)
+                    })?;
+                    holders.insert(account);
+                }
+                if (page_len as i64) < self.page_size {
+                    break;
+                }
             }
-
-            let data = parsed
-                .data
-                .ok_or_else(|| anyhow::anyhow!("role-holder response had no data"))?;
 
             // A badly-lagging subgraph may be missing recent grants or revokes,
             // so treat it as unreliable rather than trusting a stale role set.
             let max_lag = self.max_chain_lag.as_secs() as i64;
             if max_lag > 0 {
+                let timestamp = head_timestamp.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "indexing-payments subgraph returned no block timestamp; \
+                         cannot verify agreement-manager role freshness"
+                    )
+                })?;
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .map_err(|e| anyhow::anyhow!("system time before unix epoch: {e}"))?
                     .as_secs() as i64;
-                let lag = now - data.meta.block.timestamp;
+                let lag = now - timestamp;
                 if lag > max_lag {
                     return Err(anyhow::anyhow!(
                         "indexing-payments subgraph is {lag}s behind wall-clock (max {max_lag}s); \
@@ -239,18 +280,6 @@ mod subgraph {
                 }
             }
 
-            if data.role_assignments.len() >= MAX_ROLE_HOLDERS {
-                tracing::warn!(
-                    returned = data.role_assignments.len(),
-                    "agreement-manager role query hit the page cap; some holders may be missing"
-                );
-            }
-
-            let holders: HashSet<Address> = data
-                .role_assignments
-                .into_iter()
-                .map(|r| r.account)
-                .collect();
             if holders.is_empty() {
                 tracing::warn!(
                     "agreement-manager role set is empty; all DIPs proposals will be \
@@ -308,41 +337,6 @@ mod subgraph {
         }
     }
 
-    #[derive(serde::Deserialize)]
-    struct GraphqlResponse {
-        data: Option<RoleData>,
-        #[serde(default)]
-        errors: Option<Vec<GraphqlError>>,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct GraphqlError {
-        message: String,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct RoleData {
-        #[serde(rename = "roleAssignments")]
-        role_assignments: Vec<RoleRow>,
-        #[serde(rename = "_meta")]
-        meta: Meta,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct RoleRow {
-        account: Address,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct Meta {
-        block: MetaBlock,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct MetaBlock {
-        timestamp: i64,
-    }
-
     #[cfg(test)]
     mod test {
         use std::time::Duration;
@@ -350,7 +344,10 @@ mod subgraph {
         use indexer_monitor::{DeploymentDetails, SubgraphClient};
         use serde_json::json;
         use thegraph_core::alloy::primitives::{address, Address};
-        use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
+        use wiremock::{
+            matchers::{body_partial_json, method},
+            Mock, MockServer, ResponseTemplate,
+        };
 
         use super::*;
 
@@ -364,14 +361,26 @@ mod subgraph {
                 .as_secs() as i64
         }
 
+        /// A graphql_client response body for the role query: one `roleAssignments`
+        /// row per account (with a synthetic id cursor) plus the `_meta` head.
         fn holders_body(accounts: &[Address], timestamp: i64) -> serde_json::Value {
+            roles_page(accounts, 1, timestamp)
+        }
+
+        /// Like [`holders_body`] but with id cursors starting at `first_id`, so a
+        /// test can stitch several pages together (ids must strictly increase).
+        fn roles_page(accounts: &[Address], first_id: usize, timestamp: i64) -> serde_json::Value {
             json!({
                 "data": {
+                    "meta": { "block": { "number": 1, "hash": null, "timestamp": timestamp } },
                     "roleAssignments": accounts
                         .iter()
-                        .map(|a| json!({ "account": a }))
+                        .enumerate()
+                        .map(|(i, a)| json!({
+                            "id": format!("0x{:064x}", first_id + i),
+                            "account": a,
+                        }))
                         .collect::<Vec<_>>(),
-                    "_meta": { "block": { "timestamp": timestamp } }
                 }
             })
         }
@@ -506,14 +515,55 @@ mod subgraph {
             );
         }
 
-        #[test]
-        fn query_role_hash_matches_keccak() {
-            use thegraph_core::alloy::primitives::keccak256;
-            let expected = format!("0x{:x}", keccak256(b"AGREEMENT_MANAGER_ROLE"));
-            assert!(
-                ROLE_HOLDERS_QUERY.contains(&expected),
-                "query role hash drifted from keccak256(\"AGREEMENT_MANAGER_ROLE\")"
+        #[tokio::test]
+        async fn paginates_through_all_holders() {
+            // Page size 2 against three holders forces a second page: page 1 is
+            // full (ids 1-2), page 2 partial (id 3), selected by the id_gt cursor
+            // carried in the request body. All three must end up trusted.
+            const A: Address = address!("0000000000000000000000000000000000000001");
+            const B: Address = address!("0000000000000000000000000000000000000002");
+            const C: Address = address!("0000000000000000000000000000000000000003");
+
+            let server = MockServer::start().await;
+            // First page: empty cursor.
+            Mock::given(method("POST"))
+                .and(body_partial_json(json!({ "variables": { "last": "" } })))
+                .respond_with(ResponseTemplate::new(200).set_body_json(roles_page(
+                    &[A, B],
+                    1,
+                    now_secs(),
+                )))
+                .mount(&server)
+                .await;
+            // Second page: cursor is page 1's last id.
+            let page1_last = format!("0x{:064x}", 2);
+            Mock::given(method("POST"))
+                .and(body_partial_json(
+                    json!({ "variables": { "last": page1_last } }),
+                ))
+                .respond_with(ResponseTemplate::new(200).set_body_json(roles_page(
+                    &[C],
+                    3,
+                    now_secs(),
+                )))
+                .mount(&server)
+                .await;
+            let client = leak_client(&server).await;
+
+            let src = SubgraphTrustedSigners::new_with_page_size(
+                client,
+                Duration::from_secs(60),
+                Duration::ZERO,
+                2,
             );
+            src.refresh().await.unwrap();
+
+            for holder in [A, B, C] {
+                assert!(
+                    src.verify_trusted(holder).await.is_ok(),
+                    "holder {holder} from a later page should be trusted"
+                );
+            }
         }
     }
 }

--- a/crates/dips/src/trusted_signers.rs
+++ b/crates/dips/src/trusted_signers.rs
@@ -260,10 +260,16 @@ mod subgraph {
 
             match self.fetch_holders().await {
                 Ok(holders) => {
+                    let now_unix = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as i64)
+                        .unwrap_or(0);
                     let mut cache = self.cache.write().unwrap();
                     cache.holders = holders;
                     cache.last_success = Some(Instant::now());
                     cache.last_failed_attempt = None;
+                    crate::metrics::ROLE_SET_SIZE.set(cache.holders.len() as i64);
+                    crate::metrics::ROLE_LAST_REFRESH_TIMESTAMP.set(now_unix);
                     Ok(())
                 }
                 Err(e) => {

--- a/crates/dips/src/trusted_signers.rs
+++ b/crates/dips/src/trusted_signers.rs
@@ -41,7 +41,7 @@ pub use subgraph::SubgraphTrustedSigners;
 #[cfg(feature = "db")]
 mod subgraph {
     use std::{
-        collections::HashSet,
+        collections::{HashMap, HashSet},
         sync::{Arc, RwLock},
         time::Duration,
     };
@@ -64,6 +64,15 @@ mod subgraph {
     /// long, so a burst of unknown signers can't turn into a fetch storm.
     const REFRESH_DEBOUNCE: Duration = Duration::from_secs(5);
 
+    /// How long a "not a role holder" answer is reused from memory before that
+    /// signer is re-checked. Caps how often a repeated unknown signer drives a
+    /// fetch, and bounds how long a later-granted signer waits to be recognised.
+    const REJECTED_SIGNER_TTL: Duration = Duration::from_secs(3600);
+
+    /// Hard cap on the negative cache so a flood of distinct unknown signers
+    /// can't grow it without bound.
+    const MAX_REJECTED_SIGNERS: usize = 100_000;
+
     #[derive(Default)]
     struct RoleCache {
         holders: HashSet<Address>,
@@ -71,6 +80,10 @@ mod subgraph {
         last_success: Option<Instant>,
         /// When a fetch most recently failed (for debouncing retries).
         last_failed_attempt: Option<Instant>,
+        /// Signers recently confirmed *not* to hold the role, with the time of
+        /// that confirmation. A repeat of the same signer is rejected from here
+        /// until [`REJECTED_SIGNER_TTL`] passes; bounded by [`MAX_REJECTED_SIGNERS`].
+        rejected: HashMap<Address, Instant>,
     }
 
     /// Caches the AGREEMENT_MANAGER_ROLE holder set, refreshing on a timer and on
@@ -164,6 +177,26 @@ mod subgraph {
 
         fn is_fresh(&self, last_success: Option<Instant>) -> bool {
             last_success.is_some_and(|t| t.elapsed() < self.max_stale)
+        }
+
+        /// Record a definitive "not a role holder" so a repeat of the same signer
+        /// is answered from memory until it ages out. Prunes expired entries and
+        /// refuses to grow past a hard cap, bounding the map under a flood.
+        fn note_rejected(&self, signer: Address) {
+            let mut cache = self.cache.write().unwrap();
+            if cache.rejected.len() >= MAX_REJECTED_SIGNERS {
+                cache
+                    .rejected
+                    .retain(|_, t| t.elapsed() < REJECTED_SIGNER_TTL);
+                if cache.rejected.len() >= MAX_REJECTED_SIGNERS {
+                    tracing::warn!(
+                        cap = MAX_REJECTED_SIGNERS,
+                        "rejected-signer cache is full; not caching this rejection"
+                    );
+                    return;
+                }
+            }
+            cache.rejected.insert(signer, Instant::now());
         }
 
         /// Fetch the whole holder set and swap it into the cache. Single-flighted
@@ -293,17 +326,26 @@ mod subgraph {
     #[async_trait]
     impl TrustedSignerSource for SubgraphTrustedSigners {
         async fn verify_trusted(&self, signer: Address) -> Result<(), DipsError> {
-            // Fast path: a known holder whose cache is still inside the window is
-            // answered from memory, with no subgraph round-trip.
+            // Fast path, answered from memory: a known holder inside the window
+            // passes; a signer recently confirmed *not* a holder is rejected, so a
+            // repeated unknown signer can't drive a fetch until its entry ages out.
             {
                 let cache = self.cache.read().unwrap();
                 if cache.holders.contains(&signer) && self.is_fresh(cache.last_success) {
                     return Ok(());
                 }
+                if cache
+                    .rejected
+                    .get(&signer)
+                    .is_some_and(|t| t.elapsed() < REJECTED_SIGNER_TTL)
+                {
+                    return Err(DipsError::SenderNotTrusted { signer });
+                }
             }
 
-            // Unknown signer, or the cache has gone stale past the window: try a
-            // single-flighted refresh, then decide against the freshest data.
+            // A new (or newly-expired) signer, or a cache gone stale past the
+            // window: try a single-flighted refresh, then decide against the
+            // freshest data.
             let refreshed = self.refresh().await;
 
             let (present, fresh) = {
@@ -315,12 +357,19 @@ mod subgraph {
             };
 
             match refreshed {
-                // Authoritative answer from a fresh fetch.
-                Ok(()) if present => Ok(()),
-                Ok(()) => Err(DipsError::SenderNotTrusted { signer }),
+                // Authoritative answer from a fresh fetch: a newly-granted signer
+                // clears any stale negative entry.
+                Ok(()) if present => {
+                    self.cache.write().unwrap().rejected.remove(&signer);
+                    Ok(())
+                }
+                Ok(()) => {
+                    self.note_rejected(signer);
+                    Err(DipsError::SenderNotTrusted { signer })
+                }
                 // Couldn't refresh: fail open only for a known holder still inside
-                // the window (e.g. a concurrent refresh just succeeded); otherwise
-                // we can't vouch for the signer, so report transient.
+                // the window; otherwise report transient -- and record no negative
+                // entry, since an inability to verify is not a definitive "no".
                 Err(transient) => {
                     if present && fresh {
                         tracing::warn!(
@@ -564,6 +613,62 @@ mod subgraph {
                     "holder {holder} from a later page should be trusted"
                 );
             }
+        }
+
+        #[tokio::test]
+        async fn repeat_unknown_signer_is_not_refetched() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(holders_body(&[HOLDER], now_secs())),
+                )
+                .mount(&server)
+                .await;
+            let client = leak_client(&server).await;
+            let src = SubgraphTrustedSigners::new(client, Duration::from_secs(60), Duration::ZERO);
+
+            // First lookup: cold cache, one on-demand fetch, definitive reject.
+            assert!(matches!(
+                src.verify_trusted(STRANGER).await,
+                Err(DipsError::SenderNotTrusted { .. })
+            ));
+            // Second lookup of the same signer: served from the negative cache.
+            assert!(matches!(
+                src.verify_trusted(STRANGER).await,
+                Err(DipsError::SenderNotTrusted { .. })
+            ));
+
+            let posts = server.received_requests().await.unwrap().len();
+            assert_eq!(posts, 1, "a repeat of a known-bad signer must not re-query");
+        }
+
+        #[tokio::test]
+        async fn concurrent_unknown_signers_coalesce_one_fetch() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(holders_body(&[HOLDER], now_secs()))
+                        .set_delay(Duration::from_millis(200)),
+                )
+                .mount(&server)
+                .await;
+            let client = leak_client(&server).await;
+            let src = SubgraphTrustedSigners::new(client, Duration::from_secs(60), Duration::ZERO);
+
+            // Two distinct unknown signers arriving together coalesce onto one
+            // fetch via the single-flight refresh lock.
+            let a = address!("00000000000000000000000000000000000000aa");
+            let b = address!("00000000000000000000000000000000000000bb");
+            let (ra, rb) = tokio::join!(src.verify_trusted(a), src.verify_trusted(b));
+            assert!(matches!(ra, Err(DipsError::SenderNotTrusted { .. })));
+            assert!(matches!(rb, Err(DipsError::SenderNotTrusted { .. })));
+
+            let posts = server.received_requests().await.unwrap().len();
+            assert_eq!(
+                posts, 1,
+                "concurrent unknown signers should share a single fetch"
+            );
         }
     }
 }

--- a/crates/query/graphql/agreement_manager_roles.query.graphql
+++ b/crates/query/graphql/agreement_manager_roles.query.graphql
@@ -1,0 +1,30 @@
+# Active AGREEMENT_MANAGER_ROLE holders from the indexing-payments subgraph: the
+# signers the indexer trusts to send agreement proposals. Cursor-paginated by id;
+# $block pins later pages to the first page's block for a consistent read.
+
+query AgreementManagerRolesQuery(
+    $role: Bytes!
+    $first: Int!
+    $last: ID!
+    $block: Block_height
+) {
+    meta: _meta(block: $block) {
+        block {
+            number
+            hash
+            timestamp
+        }
+    }
+    roleAssignments(
+        block: $block
+        orderBy: id
+        orderDirection: asc
+        first: $first
+        # active: true is load-bearing -- a revoke flags the row rather than
+        # deleting it, and several roles are indexed, so both filters are needed.
+        where: { id_gt: $last, role: $role, active: true }
+    ) {
+        id
+        account
+    }
+}

--- a/crates/query/graphql/indexing_payments.schema.graphql
+++ b/crates/query/graphql/indexing_payments.schema.graphql
@@ -1,0 +1,64 @@
+# Subset of the indexing-payments subgraph's graph-node API schema, holding only
+# the RoleAssignment and _meta fields the agreement-manager-role query reads.
+# graphql_client uses it for compile-time type generation; grow it with the query.
+
+scalar Bytes
+
+type _Block_ {
+  hash: Bytes
+  number: Int!
+  timestamp: Int
+}
+
+type _Meta_ {
+  block: _Block_!
+  deployment: String!
+  hasIndexingErrors: Boolean!
+}
+
+input Block_height {
+  hash: Bytes
+  number: Int
+  number_gte: Int
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
+type RoleAssignment {
+  id: ID!
+  role: Bytes!
+  account: Bytes!
+  active: Boolean!
+}
+
+enum RoleAssignment_orderBy {
+  id
+  role
+  account
+  active
+}
+
+input RoleAssignment_filter {
+  id_gt: ID
+  role: Bytes
+  active: Boolean
+}
+
+type Query {
+  _meta(block: Block_height): _Meta_
+  roleAssignments(
+    skip: Int
+    first: Int
+    orderBy: RoleAssignment_orderBy
+    orderDirection: OrderDirection
+    where: RoleAssignment_filter
+    block: Block_height
+  ): [RoleAssignment!]!
+}
+
+schema {
+  query: Query
+}

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -190,3 +190,19 @@ pub mod payments_escrow_transactions_redeem {
 
     pub use payments_escrow_transactions_redeem_query::*;
 }
+
+pub mod agreement_manager_roles {
+    use graphql_client::GraphQLQuery;
+    type Bytes = String;
+
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "graphql/indexing_payments.schema.graphql",
+        query_path = "graphql/agreement_manager_roles.query.graphql",
+        response_derives = "Debug",
+        variables_derives = "Clone"
+    )]
+    pub struct AgreementManagerRolesQuery;
+
+    pub use agreement_manager_roles_query::*;
+}

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -20,6 +20,7 @@ use indexer_dips::{
         IndexerDipsService, IndexerDipsServiceServer,
     },
     server::{DipsServer, DipsServerContext},
+    trusted_signers::{SubgraphTrustedSigners, TrustedSignerSource},
 };
 use indexer_monitor::{DeploymentDetails, SubgraphClient};
 use release::IndexerServiceRelease;
@@ -108,6 +109,17 @@ pub async fn run() -> anyhow::Result<()> {
         &config.subgraphs.network.config,
     )
     .await;
+
+    // DIPs reads the agreement-manager role set from the indexing-payments
+    // subgraph; build its client before the router consumes graph_node.
+    let indexing_payments_subgraph = if config.dips.is_some() {
+        let subgraph_config = config.subgraphs.indexing_payments.as_ref().ok_or_else(|| {
+            anyhow!("subgraphs.indexing_payments must be set when DIPs is enabled")
+        })?;
+        Some(create_subgraph_client(http_client.clone(), &config.graph_node, subgraph_config).await)
+    } else {
+        None
+    };
 
     // V2 escrow accounts are in the network subgraph, not a separate escrow_v2 subgraph
 
@@ -213,6 +225,9 @@ pub async fn run() -> anyhow::Result<()> {
             min_grt_per_billion_entities_per_30_days,
             additional_networks,
             recurring_collector,
+            role_refresh_interval_secs,
+            role_failopen_grace_secs,
+            role_subgraph_max_lag_secs,
         } = dips;
 
         // The RecurringCollector address is the EIP-712 verifying contract used to
@@ -285,6 +300,17 @@ pub async fn run() -> anyhow::Result<()> {
                 .div_ceil(entity_divisor),
         );
 
+        // Authorise proposal senders against the on-chain agreement-manager role
+        // set, read from the indexing-payments subgraph built above.
+        let trusted_signers: Arc<dyn TrustedSignerSource> = SubgraphTrustedSigners::spawn(
+            indexing_payments_subgraph
+                .expect("indexing_payments client is built whenever DIPs is enabled"),
+            Duration::from_secs(*role_refresh_interval_secs),
+            Duration::from_secs(*role_failopen_grace_secs),
+            Duration::from_secs(*role_subgraph_max_lag_secs),
+        )
+        .await;
+
         // Build server context
         let ctx = Arc::new(DipsServerContext {
             rca_store: Arc::new(PsqlRcaStore {
@@ -299,6 +325,7 @@ pub async fn run() -> anyhow::Result<()> {
             registry,
             additional_networks: Arc::new(additional_networks.clone()),
             rca_domain,
+            trusted_signers,
         });
 
         // Create DIPS server

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -132,6 +132,9 @@ pub async fn run() -> anyhow::Result<()> {
     );
     let host_and_port = config.service.host_and_port;
     let indexer_address = config.indexer.indexer_address;
+    // Captured before `config.blockchain` is moved into the router state below;
+    // used to build the RCA EIP-712 domain for DIPs signer recovery.
+    let blockchain_chain_id = config.blockchain.chain_id as u64;
     let ipfs_url = config.service.ipfs_url.clone();
 
     // V2 escrow accounts (used by DIPs) live in the network subgraph; no
@@ -209,8 +212,15 @@ pub async fn run() -> anyhow::Result<()> {
             min_grt_per_30_days,
             min_grt_per_billion_entities_per_30_days,
             additional_networks,
-            ..
+            recurring_collector,
         } = dips;
+
+        // The RecurringCollector address is the EIP-712 verifying contract used to
+        // recover RCA signers; without it DIPs cannot authenticate proposals.
+        let recurring_collector = (*recurring_collector).ok_or_else(|| {
+            anyhow::anyhow!("dips.recurring_collector must be set when DIPs is enabled")
+        })?;
+        let rca_domain = indexer_dips::rca_eip712_domain(blockchain_chain_id, recurring_collector);
 
         if supported_networks.is_empty() {
             tracing::warn!(
@@ -288,6 +298,7 @@ pub async fn run() -> anyhow::Result<()> {
             )),
             registry,
             additional_networks: Arc::new(additional_networks.clone()),
+            rca_domain,
         });
 
         // Create DIPS server

--- a/crates/tap-agent/src/agent.rs
+++ b/crates/tap-agent/src/agent.rs
@@ -104,7 +104,8 @@ pub async fn start_agent(
                         ref escrow_min_balance_grt_wei,
                         max_signers_per_payer,
                     },
-                escrow: _, // Deprecated and ignored
+                indexing_payments: _, // DIPs only; not used by tap-agent
+                escrow: _,            // Deprecated and ignored
             },
         tap: TapConfig {
             sender_aggregator_endpoints,


### PR DESCRIPTION
## TL;DR

The indexer's payments service accepts any agreement proposal with a cryptographically valid signature, without checking who sent it. This change requires the recovered signer to be an approved agreement manager on-chain — read from the indexing-payments subgraph — and rejects every other sender. It also carries a set of unrelated configuration-documentation fixes, called out separately below.

## Motivation

The payments service recovers the signer of each incoming agreement proposal but then accepts any valid signature, with no check on whether that signer is allowed to offer agreements. An earlier allowlist was removed because it checked a payer field that the caller writes into the proposal themselves, which anyone could spoof; the only identity the indexer can trust is the cryptographically recovered signer. Until an authorization step lands, any party that can reach the payments port can have a proposal accepted and stored, which is the wrong default to carry into a real deployment. This change reads the set of approved agreement managers from an on-chain source — the indexing-payments subgraph, which indexes the agreement-manager role assignments — and accepts a proposal only when its recovered signer is in that set.

## Summary

Authorize agreement senders (the main change):
- Authorize the recovered signer before any other work: it must hold the agreement-manager role.
- Read the approved set from the indexing-payments subgraph, cached and refreshed on a timer.
- Refresh on demand for an unknown signer (rate-limited), so a new manager is recognised in seconds.
- A signer rejected in the last hour is cached, so a later approval can take an hour to apply.
- Serve known senders from cache through a subgraph outage, within a bounded window, then reject.
- Reject an unknown sender clearly; report an unverifiable set as transient so the sender retries.
- Add config for the subgraph endpoint and the refresh, fail-open-grace, and staleness timings.
- Validate the DIPs collector and subgraph config at load, so misconfiguration fails fast.
- Emit metrics for proposal outcomes and role-set health so operators can see the gate working.

Unrelated configuration and documentation changes also in this PR:
- Fix contradictory notes in the example config and document the DIPs tunables.
- Clarify when to set the subgraph auth token and how local indexing relates to the query URL.
- Spell out the credit risk of trusted senders, and that the free-query token bypasses payment.
