### PR TITLE
feat: introduce optional cap on # of DIPs agreements accepted per day

### DIFF
--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -204,7 +204,7 @@ recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
 
 # Optional safeguard: cap live DIPs agreements (awaiting acceptance or accepted) per
 # rolling 24h; rejected and expired proposals don't count. Unset = no cap; 0 rejects all.
-# max_agreements_per_day = 30
+# max_new_agreements_per_24h = 30
 
 [dips.min_grt_per_30_days]  # base rate component (per-network)
 # arbitrum-one = "450"

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -202,6 +202,10 @@ recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
 # domain at startup (EIP-5267). When unset, built-in domain constants are used.
 # rpc_url = "https://arb1.arbitrum.io/rpc"
 
+# Optional safeguard: cap DIPs proposals stored per rolling 24h, counting every
+# proposal received (not just on-chain accepts). Unset means no cap; 0 rejects all.
+# max_agreements_per_day = 30
+
 [dips.min_grt_per_30_days]  # base rate component (per-network)
 # arbitrum-one = "450"
 # matic = "300"

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -202,8 +202,8 @@ recurring_collector = "0xcccccccccccccccccccccccccccccccccccccccc"
 # domain at startup (EIP-5267). When unset, built-in domain constants are used.
 # rpc_url = "https://arb1.arbitrum.io/rpc"
 
-# Optional safeguard: cap DIPs proposals stored per rolling 24h, counting every
-# proposal received (not just on-chain accepts). Unset means no cap; 0 rejects all.
+# Optional safeguard: cap live DIPs agreements (awaiting acceptance or accepted) per
+# rolling 24h; rejected and expired proposals don't count. Unset = no cap; 0 rejects all.
 # max_agreements_per_day = 30
 
 [dips.min_grt_per_30_days]  # base rate component (per-network)

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -685,9 +685,9 @@ pub struct DipsConfig {
     /// Ethereum JSON-RPC endpoint used to fetch the EIP-712 domain from the
     /// RecurringCollector at startup (EIP-5267). Unset: built-in domain constants.
     pub rpc_url: Option<Url>,
-    /// Max DIPs proposals to store per rolling 24h window, counting every proposal
-    /// received (including ones later rejected on-chain or expired). None (unset)
-    /// disables the cap; a best-effort safeguard, not a security control.
+    /// Max live DIPs agreements (awaiting acceptance or accepted) per rolling 24h
+    /// window; rejected and expired proposals don't count. None (unset) disables the
+    /// cap; a best-effort safeguard, not a security control.
     pub max_agreements_per_day: Option<u64>,
 }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -685,6 +685,10 @@ pub struct DipsConfig {
     /// Ethereum JSON-RPC endpoint used to fetch the EIP-712 domain from the
     /// RecurringCollector at startup (EIP-5267). Unset: built-in domain constants.
     pub rpc_url: Option<Url>,
+    /// Max DIPs proposals to store per rolling 24h window, counting every proposal
+    /// received (including ones later rejected on-chain or expired). None (unset)
+    /// disables the cap; a best-effort safeguard, not a security control.
+    pub max_agreements_per_day: Option<u64>,
 }
 
 impl Default for DipsConfig {
@@ -698,6 +702,7 @@ impl Default for DipsConfig {
             additional_networks: BTreeMap::new(),
             recurring_collector: None,
             rpc_url: None,
+            max_agreements_per_day: None,
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -688,7 +688,7 @@ pub struct DipsConfig {
     /// Max live DIPs agreements (awaiting acceptance or accepted) per rolling 24h
     /// window; rejected and expired proposals don't count. None (unset) disables the
     /// cap; a best-effort safeguard, not a security control.
-    pub max_agreements_per_day: Option<u64>,
+    pub max_new_agreements_per_24h: Option<u64>,
 }
 
 impl Default for DipsConfig {
@@ -702,7 +702,7 @@ impl Default for DipsConfig {
             additional_networks: BTreeMap::new(),
             recurring_collector: None,
             rpc_url: None,
-            max_agreements_per_day: None,
+            max_new_agreements_per_24h: None,
         }
     }
 }

--- a/crates/dips/src/database.rs
+++ b/crates/dips/src/database.rs
@@ -32,7 +32,7 @@
 //! Without idempotency, the retry would fail with a duplicate key error, causing
 //! Dipper to mark the agreement as failed even though it was successfully stored.
 
-use std::any::Any;
+use std::{any::Any, time::Duration};
 
 use async_trait::async_trait;
 use sqlx::PgPool;
@@ -71,7 +71,61 @@ impl RcaStore for PsqlRcaStore {
         Ok(())
     }
 
+    async fn count_since(&self, window: Duration) -> Result<u64, DipsError> {
+        // NOW() is the database clock, so the window is unaffected by host clock skew.
+        let count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM pending_rca_proposals
+             WHERE created_at >= NOW() - ($1 * interval '1 second')",
+        )
+        .bind(window.as_secs() as i64)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| DipsError::UnknownError(e.into()))?;
+
+        Ok(count.max(0) as u64)
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    /// Insert a proposal row whose created_at is `hours_ago` before the DB clock.
+    async fn insert_at(pool: &PgPool, id: Uuid, hours_ago: i64) {
+        sqlx::query(
+            "INSERT INTO pending_rca_proposals (id, signed_payload, version, status, created_at, updated_at)
+             VALUES ($1, $2, 2, 'pending', NOW() - ($3 * interval '1 hour'), NOW())",
+        )
+        .bind(id)
+        .bind(vec![1u8, 2, 3])
+        .bind(hours_ago)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    // Exercises the rolling-window SQL against a real Postgres (testcontainers);
+    // the in-memory store can't, since it ignores the window.
+    #[tokio::test]
+    async fn count_since_excludes_rows_outside_the_window() {
+        let test_db = test_assets::setup_shared_test_db().await;
+        let store = PsqlRcaStore {
+            pool: test_db.pool.clone(),
+        };
+        insert_at(&test_db.pool, Uuid::from_u128(1), 1).await; // inside 24h
+        insert_at(&test_db.pool, Uuid::from_u128(2), 25).await; // outside 24h
+
+        let count = store
+            .count_since(Duration::from_secs(24 * 60 * 60))
+            .await
+            .unwrap();
+
+        assert_eq!(count, 1, "only the row inside the window should count");
     }
 }

--- a/crates/dips/src/database.rs
+++ b/crates/dips/src/database.rs
@@ -72,10 +72,13 @@ impl RcaStore for PsqlRcaStore {
     }
 
     async fn count_since(&self, window: Duration) -> Result<u64, DipsError> {
-        // NOW() is the database clock, so the window is unaffected by host clock skew.
+        // Count live agreements only: 'pending' (awaiting the agent) and 'accepted'.
+        // The agent records rejected and expired proposals as 'rejected', so they
+        // drop out. NOW() is the DB clock, so the window ignores host clock skew.
         let count: i64 = sqlx::query_scalar(
             "SELECT count(*) FROM pending_rca_proposals
-             WHERE created_at >= NOW() - ($1 * interval '1 second')",
+             WHERE status IN ('pending', 'accepted')
+               AND created_at >= NOW() - ($1 * interval '1 second')",
         )
         .bind(window.as_secs() as i64)
         .fetch_one(&self.pool)
@@ -96,15 +99,16 @@ mod tests {
 
     use super::*;
 
-    /// Insert a proposal row whose created_at is `hours_ago` before the DB clock.
-    async fn insert_at(pool: &PgPool, id: Uuid, hours_ago: i64) {
+    /// Insert a proposal row with `status`, created `hours_ago` before the DB clock.
+    async fn insert_at(pool: &PgPool, id: Uuid, hours_ago: i64, status: &str) {
         sqlx::query(
             "INSERT INTO pending_rca_proposals (id, signed_payload, version, status, created_at, updated_at)
-             VALUES ($1, $2, 2, 'pending', NOW() - ($3 * interval '1 hour'), NOW())",
+             VALUES ($1, $2, 2, $4, NOW() - ($3 * interval '1 hour'), NOW())",
         )
         .bind(id)
         .bind(vec![1u8, 2, 3])
         .bind(hours_ago)
+        .bind(status)
         .execute(pool)
         .await
         .unwrap();
@@ -118,8 +122,8 @@ mod tests {
         let store = PsqlRcaStore {
             pool: test_db.pool.clone(),
         };
-        insert_at(&test_db.pool, Uuid::from_u128(1), 1).await; // inside 24h
-        insert_at(&test_db.pool, Uuid::from_u128(2), 25).await; // outside 24h
+        insert_at(&test_db.pool, Uuid::from_u128(1), 1, "pending").await; // inside 24h
+        insert_at(&test_db.pool, Uuid::from_u128(2), 25, "pending").await; // outside 24h
 
         let count = store
             .count_since(Duration::from_secs(24 * 60 * 60))
@@ -127,5 +131,25 @@ mod tests {
             .unwrap();
 
         assert_eq!(count, 1, "only the row inside the window should count");
+    }
+
+    // The cap counts live agreements only; the agent records both rejected and
+    // expired proposals as 'rejected', so neither should count toward the cap.
+    #[tokio::test]
+    async fn count_since_counts_only_pending_and_accepted() {
+        let test_db = test_assets::setup_shared_test_db().await;
+        let store = PsqlRcaStore {
+            pool: test_db.pool.clone(),
+        };
+        insert_at(&test_db.pool, Uuid::from_u128(1), 1, "pending").await;
+        insert_at(&test_db.pool, Uuid::from_u128(2), 1, "accepted").await;
+        insert_at(&test_db.pool, Uuid::from_u128(3), 1, "rejected").await;
+
+        let count = store
+            .count_since(Duration::from_secs(24 * 60 * 60))
+            .await
+            .unwrap();
+
+        assert_eq!(count, 2, "only pending and accepted rows should count");
     }
 }

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -287,7 +287,7 @@ pub(crate) fn try_extract_deployment_id(rca_bytes: &[u8]) -> Option<String> {
     Some(bytes32_to_ipfs_hash(&metadata.subgraphDeploymentId.0))
 }
 
-/// Window over which the per-day cap counts live agreements (pending or accepted).
+/// Window over which the cap counts live agreements (pending or accepted).
 const CAPACITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
 
 /// Validate and create a RecurringCollectionAgreement.
@@ -314,7 +314,7 @@ pub async fn validate_and_create_rca(
         registry,
         additional_networks,
         rca_domain,
-        max_agreements_per_day,
+        max_new_agreements_per_24h,
     } = ctx.as_ref();
 
     // Decode SignedRCA
@@ -350,7 +350,7 @@ pub async fn validate_and_create_rca(
     // Capacity safeguard: cap live agreements (pending or accepted) per rolling
     // 24h, checked before the IPFS fetch so an over-cap proposal costs no download.
     // Count-then-store isn't atomic, so concurrent proposals may overshoot slightly.
-    if let Some(limit) = max_agreements_per_day {
+    if let Some(limit) = max_new_agreements_per_24h {
         match rca_store.count_since(CAPACITY_WINDOW).await {
             Ok(count) if count >= *limit => {
                 return Err(DipsError::CapacityExceeded { limit: *limit });
@@ -530,7 +530,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
-            max_agreements_per_day: None,
+            max_new_agreements_per_24h: None,
         })
     }
 
@@ -877,7 +877,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
-            max_agreements_per_day: None,
+            max_new_agreements_per_24h: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1052,7 +1052,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
-            max_agreements_per_day: None,
+            max_new_agreements_per_24h: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1088,7 +1088,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
-            max_agreements_per_day: None,
+            max_new_agreements_per_24h: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1124,7 +1124,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
-            max_agreements_per_day: None,
+            max_new_agreements_per_24h: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1160,7 +1160,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
-            max_agreements_per_day: None,
+            max_new_agreements_per_24h: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1250,7 +1250,7 @@ mod test {
         );
     }
 
-    /// Build a context backed by `store` with the per-day cap set to `max`.
+    /// Build a context backed by `store` with the per-24h cap set to `max`.
     fn capacity_ctx(store: Arc<dyn RcaStore>, max: Option<u64>) -> Arc<DipsServerContext> {
         Arc::new(DipsServerContext {
             rca_store: store,
@@ -1263,7 +1263,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
-            max_agreements_per_day: max,
+            max_new_agreements_per_24h: max,
         })
     }
 

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -200,6 +200,8 @@ pub enum DipsError {
     DeadlineExpired { deadline: u64, now: u64 },
     #[error("agreement end time {ends_at} has already passed (current time: {now})")]
     AgreementExpired { ends_at: u64, now: u64 },
+    #[error("indexer is at its DIPs proposal capacity ({limit} per 24h)")]
+    CapacityExceeded { limit: u64 },
 }
 
 #[cfg(feature = "rpc")]
@@ -285,6 +287,9 @@ pub(crate) fn try_extract_deployment_id(rca_bytes: &[u8]) -> Option<String> {
     Some(bytes32_to_ipfs_hash(&metadata.subgraphDeploymentId.0))
 }
 
+/// Window over which the per-day agreement cap counts stored proposals.
+const CAPACITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
+
 /// Validate and create a RecurringCollectionAgreement.
 ///
 /// Performs validation:
@@ -309,6 +314,7 @@ pub async fn validate_and_create_rca(
         registry,
         additional_networks,
         rca_domain,
+        max_agreements_per_day,
     } = ctx.as_ref();
 
     // Decode SignedRCA
@@ -339,6 +345,21 @@ pub async fn validate_and_create_rca(
     let ends_at: u64 = signed_rca.agreement.endsAt;
     if ends_at < now {
         return Err(DipsError::AgreementExpired { ends_at, now });
+    }
+
+    // Capacity safeguard: cap proposals stored per rolling 24h, checked before
+    // the IPFS fetch so an over-cap proposal costs no download. Count-then-store
+    // isn't atomic, so concurrent proposals may overshoot the cap slightly.
+    if let Some(limit) = max_agreements_per_day {
+        match rca_store.count_since(CAPACITY_WINDOW).await {
+            Ok(count) if count >= *limit => {
+                return Err(DipsError::CapacityExceeded { limit: *limit });
+            }
+            Ok(_) => {}
+            // Fail open: the cap is a best-effort safeguard, not a security control,
+            // so a transient count failure shouldn't reject a valid proposal.
+            Err(e) => tracing::warn!(error = %e, "DIPs capacity check failed; allowing proposal"),
+        }
     }
 
     // Derive agreement ID deterministically from the RCA fields
@@ -474,7 +495,7 @@ mod test {
         price::PriceCalculator,
         rca_eip712_domain,
         server::DipsServerContext,
-        store::{FailingRcaStore, InMemoryRcaStore},
+        store::{FailingRcaStore, InMemoryRcaStore, RcaStore},
         AcceptIndexingAgreementMetadata, DipsError, IndexingAgreementTermsV1,
         RecurringCollectionAgreement, SignedRecurringCollectionAgreement,
     };
@@ -509,6 +530,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            max_agreements_per_day: None,
         })
     }
 
@@ -855,6 +877,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            max_agreements_per_day: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1029,6 +1052,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            max_agreements_per_day: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1064,6 +1088,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            max_agreements_per_day: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1099,6 +1124,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            max_agreements_per_day: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1134,6 +1160,7 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
+            max_agreements_per_day: None,
         });
 
         let rca_bytes = rca_to_wire_bytes(rca);
@@ -1221,5 +1248,184 @@ mod test {
             hash, "QmNLei78zWmzUdbeRB3CiUfAizWUrbeeZh5K1rhAQKCh51",
             "Known test vector mismatch"
         );
+    }
+
+    /// Build a context backed by `store` with the per-day cap set to `max`.
+    fn capacity_ctx(store: Arc<dyn RcaStore>, max: Option<u64>) -> Arc<DipsServerContext> {
+        Arc::new(DipsServerContext {
+            rca_store: store,
+            ipfs_fetcher: Arc::new(MockIpfsFetcher::default()),
+            price_calculator: Arc::new(PriceCalculator::new(
+                HashSet::from(["mainnet".to_string()]),
+                BTreeMap::from([("mainnet".to_string(), U256::from(100))]),
+                U256::from(50),
+            )),
+            registry: Arc::new(crate::registry::test_registry()),
+            additional_networks: Arc::new(BTreeMap::new()),
+            rca_domain: test_rca_domain(),
+            max_agreements_per_day: max,
+        })
+    }
+
+    /// Fill an in-memory store with `n` distinct stored proposals.
+    async fn prefill(store: &InMemoryRcaStore, n: u64) {
+        for i in 0..n {
+            store
+                .store_rca(uuid::Uuid::from_u128(i as u128 + 1), vec![i as u8], 2)
+                .await
+                .unwrap();
+        }
+    }
+
+    /// A store whose count query fails but whose writes succeed, to exercise the
+    /// capacity check's fail-open path.
+    #[derive(Debug, Default)]
+    struct CountFailingStore(InMemoryRcaStore);
+
+    #[async_trait::async_trait]
+    impl RcaStore for CountFailingStore {
+        async fn store_rca(
+            &self,
+            agreement_id: uuid::Uuid,
+            signed_rca: Vec<u8>,
+            version: u64,
+        ) -> Result<(), DipsError> {
+            self.0.store_rca(agreement_id, signed_rca, version).await
+        }
+
+        async fn count_since(&self, _window: std::time::Duration) -> Result<u64, DipsError> {
+            Err(DipsError::UnknownError(anyhow::anyhow!(
+                "count failed (test)"
+            )))
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[tokio::test]
+    async fn capacity_at_limit_rejects() {
+        let service_provider = Address::repeat_byte(0x11);
+        let store = Arc::new(InMemoryRcaStore::default());
+        prefill(&store, 2).await;
+        let ctx = capacity_ctx(store, Some(2));
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            service_provider,
+            U256::from(200),
+            U256::from(100),
+        );
+
+        let result =
+            super::validate_and_create_rca(ctx.clone(), &service_provider, rca_to_wire_bytes(rca))
+                .await;
+
+        assert!(matches!(
+            result,
+            Err(DipsError::CapacityExceeded { limit: 2 })
+        ));
+        // The over-cap proposal must not have been stored.
+        let stored = ctx
+            .rca_store
+            .as_any()
+            .downcast_ref::<InMemoryRcaStore>()
+            .unwrap();
+        assert_eq!(stored.data.read().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn capacity_under_limit_passes() {
+        let service_provider = Address::repeat_byte(0x11);
+        let store = Arc::new(InMemoryRcaStore::default());
+        prefill(&store, 1).await;
+        let ctx = capacity_ctx(store, Some(2));
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            service_provider,
+            U256::from(200),
+            U256::from(100),
+        );
+
+        let result =
+            super::validate_and_create_rca(ctx.clone(), &service_provider, rca_to_wire_bytes(rca))
+                .await;
+
+        assert!(result.is_ok(), "got: {:?}", result);
+        // The accepted proposal is stored, taking the count from 1 to 2.
+        let stored = ctx
+            .rca_store
+            .as_any()
+            .downcast_ref::<InMemoryRcaStore>()
+            .unwrap();
+        assert_eq!(stored.data.read().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn capacity_unset_skips_check() {
+        let service_provider = Address::repeat_byte(0x11);
+        let store = Arc::new(InMemoryRcaStore::default());
+        // Five already stored, but no cap configured, so a new one still passes.
+        prefill(&store, 5).await;
+        let ctx = capacity_ctx(store, None);
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            service_provider,
+            U256::from(200),
+            U256::from(100),
+        );
+
+        let result =
+            super::validate_and_create_rca(ctx, &service_provider, rca_to_wire_bytes(rca)).await;
+
+        assert!(result.is_ok(), "got: {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn capacity_count_failure_fails_open() {
+        let service_provider = Address::repeat_byte(0x11);
+        // The count query errors; the cap is best-effort, so the proposal is
+        // allowed through rather than rejected.
+        let ctx = capacity_ctx(Arc::new(CountFailingStore::default()), Some(1));
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            service_provider,
+            U256::from(200),
+            U256::from(100),
+        );
+
+        let result =
+            super::validate_and_create_rca(ctx.clone(), &service_provider, rca_to_wire_bytes(rca))
+                .await;
+
+        assert!(result.is_ok(), "got: {:?}", result);
+        // Fail-open still completes the path and stores the proposal.
+        let stored = ctx
+            .rca_store
+            .as_any()
+            .downcast_ref::<CountFailingStore>()
+            .unwrap();
+        assert_eq!(stored.0.data.read().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn capacity_zero_limit_rejects_all() {
+        let service_provider = Address::repeat_byte(0x11);
+        // An empty store with a cap of 0 still rejects every proposal (0 >= 0).
+        let ctx = capacity_ctx(Arc::new(InMemoryRcaStore::default()), Some(0));
+        let rca = create_test_rca(
+            Address::repeat_byte(0x42),
+            service_provider,
+            U256::from(200),
+            U256::from(100),
+        );
+
+        let result =
+            super::validate_and_create_rca(ctx, &service_provider, rca_to_wire_bytes(rca)).await;
+
+        assert!(matches!(
+            result,
+            Err(DipsError::CapacityExceeded { limit: 0 })
+        ));
     }
 }

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -200,7 +200,7 @@ pub enum DipsError {
     DeadlineExpired { deadline: u64, now: u64 },
     #[error("agreement end time {ends_at} has already passed (current time: {now})")]
     AgreementExpired { ends_at: u64, now: u64 },
-    #[error("indexer is at its DIPs proposal capacity ({limit} per 24h)")]
+    #[error("indexer is at its DIPs agreement capacity ({limit} per 24h)")]
     CapacityExceeded { limit: u64 },
 }
 
@@ -287,7 +287,7 @@ pub(crate) fn try_extract_deployment_id(rca_bytes: &[u8]) -> Option<String> {
     Some(bytes32_to_ipfs_hash(&metadata.subgraphDeploymentId.0))
 }
 
-/// Window over which the per-day agreement cap counts stored proposals.
+/// Window over which the per-day cap counts live agreements (pending or accepted).
 const CAPACITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
 
 /// Validate and create a RecurringCollectionAgreement.
@@ -347,9 +347,9 @@ pub async fn validate_and_create_rca(
         return Err(DipsError::AgreementExpired { ends_at, now });
     }
 
-    // Capacity safeguard: cap proposals stored per rolling 24h, checked before
-    // the IPFS fetch so an over-cap proposal costs no download. Count-then-store
-    // isn't atomic, so concurrent proposals may overshoot the cap slightly.
+    // Capacity safeguard: cap live agreements (pending or accepted) per rolling
+    // 24h, checked before the IPFS fetch so an over-cap proposal costs no download.
+    // Count-then-store isn't atomic, so concurrent proposals may overshoot slightly.
     if let Some(limit) = max_agreements_per_day {
         match rca_store.count_since(CAPACITY_WINDOW).await {
             Ok(count) if count >= *limit => {

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -81,7 +81,7 @@ pub struct DipsServerContext {
     pub additional_networks: Arc<BTreeMap<String, String>>,
     /// EIP-712 domain for recovering the RCA signer (RecurringCollector).
     pub rca_domain: Eip712Domain,
-    /// Max DIPs agreements to store per rolling 24h window. None disables the cap.
+    /// Max live DIPs agreements (pending or accepted) per rolling 24h window. None disables the cap.
     pub max_agreements_per_day: Option<u64>,
 }
 

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -82,7 +82,7 @@ pub struct DipsServerContext {
     /// EIP-712 domain for recovering the RCA signer (RecurringCollector).
     pub rca_domain: Eip712Domain,
     /// Max live DIPs agreements (pending or accepted) per rolling 24h window. None disables the cap.
-    pub max_agreements_per_day: Option<u64>,
+    pub max_new_agreements_per_24h: Option<u64>,
 }
 
 /// DIPS server implementing RCA protocol.
@@ -239,7 +239,7 @@ mod tests {
                 registry: Arc::new(crate::registry::test_registry()),
                 additional_networks: Arc::new(BTreeMap::new()),
                 rca_domain: crate::rca_eip712_domain(1337, Address::repeat_byte(0xCC)),
-                max_agreements_per_day: None,
+                max_new_agreements_per_24h: None,
             })
         }
     }

--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -81,6 +81,8 @@ pub struct DipsServerContext {
     pub additional_networks: Arc<BTreeMap<String, String>>,
     /// EIP-712 domain for recovering the RCA signer (RecurringCollector).
     pub rca_domain: Eip712Domain,
+    /// Max DIPs agreements to store per rolling 24h window. None disables the cap.
+    pub max_agreements_per_day: Option<u64>,
 }
 
 /// DIPS server implementing RCA protocol.
@@ -115,6 +117,7 @@ fn reject_reason_from_error(err: &DipsError) -> RejectReason {
         DipsError::UnexpectedServiceProvider { .. } => RejectReason::UnexpectedServiceProvider,
         DipsError::UnsupportedMetadataVersion(_) => RejectReason::UnsupportedMetadataVersion,
         DipsError::ManifestTooLarge { .. } => RejectReason::ManifestTooLarge,
+        DipsError::CapacityExceeded { .. } => RejectReason::CapacityExceeded,
         // Malformed proposals with no dedicated reason map to the catch-all; the
         // detail carries the specifics.
         DipsError::AbiDecoding(_)
@@ -236,6 +239,7 @@ mod tests {
                 registry: Arc::new(crate::registry::test_registry()),
                 additional_networks: Arc::new(BTreeMap::new()),
                 rca_domain: crate::rca_eip712_domain(1337, Address::repeat_byte(0xCC)),
+                max_agreements_per_day: None,
             })
         }
     }
@@ -473,6 +477,18 @@ mod tests {
 
         // Assert
         assert_eq!(reason, RejectReason::ManifestTooLarge);
+    }
+
+    #[test]
+    fn test_reject_reason_capacity_exceeded() {
+        // Arrange
+        let err = DipsError::CapacityExceeded { limit: 30 };
+
+        // Act
+        let reason = super::reject_reason_from_error(&err);
+
+        // Assert
+        assert_eq!(reason, RejectReason::CapacityExceeded);
     }
 
     #[test]

--- a/crates/dips/src/store.rs
+++ b/crates/dips/src/store.rs
@@ -25,7 +25,7 @@
 //! - [`InMemoryRcaStore`] - In-memory store for unit tests
 //! - [`PsqlRcaStore`](crate::database::PsqlRcaStore) - PostgreSQL implementation
 
-use std::any::Any;
+use std::{any::Any, time::Duration};
 
 use async_trait::async_trait;
 use uuid::Uuid;
@@ -54,6 +54,11 @@ pub trait RcaStore: Sync + Send + std::fmt::Debug {
         version: u64,
     ) -> Result<(), DipsError>;
 
+    /// Count proposals stored within the trailing `window`. Backs the per-day
+    /// capacity cap. The in-memory test store ignores the window and counts all
+    /// its entries.
+    async fn count_since(&self, window: Duration) -> Result<u64, DipsError>;
+
     /// Downcast to concrete type for testing.
     fn as_any(&self) -> &dyn Any;
 }
@@ -80,6 +85,10 @@ impl RcaStore for InMemoryRcaStore {
         Ok(())
     }
 
+    async fn count_since(&self, _window: Duration) -> Result<u64, DipsError> {
+        Ok(self.data.read().await.len() as u64)
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -97,6 +106,12 @@ impl RcaStore for FailingRcaStore {
         _signed_rca: Vec<u8>,
         _version: u64,
     ) -> Result<(), DipsError> {
+        Err(DipsError::UnknownError(anyhow::anyhow!(
+            "database connection failed (test store)"
+        )))
+    }
+
+    async fn count_since(&self, _window: Duration) -> Result<u64, DipsError> {
         Err(DipsError::UnknownError(anyhow::anyhow!(
             "database connection failed (test store)"
         )))

--- a/crates/dips/src/store.rs
+++ b/crates/dips/src/store.rs
@@ -54,9 +54,9 @@ pub trait RcaStore: Sync + Send + std::fmt::Debug {
         version: u64,
     ) -> Result<(), DipsError>;
 
-    /// Count proposals stored within the trailing `window`. Backs the per-day
-    /// capacity cap. The in-memory test store ignores the window and counts all
-    /// its entries.
+    /// Count live agreements (status `pending` or `accepted`) within the trailing
+    /// `window`; rejected and expired proposals are excluded. The in-memory test
+    /// store has no status, so it ignores the window and counts every entry.
     async fn count_since(&self, window: Duration) -> Result<u64, DipsError>;
 
     /// Downcast to concrete type for testing.

--- a/crates/service/src/constants.rs
+++ b/crates/service/src/constants.rs
@@ -39,17 +39,6 @@ use std::time::Duration;
 /// - Graph-node processing time
 pub const HTTP_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Timeout for DIPS HTTP client requests.
-///
-/// DIPS (Decentralized Indexer Payment System) operations involve:
-/// - IPFS content fetching
-/// - Agreement validation and storage
-/// - Network registry lookups
-///
-/// 60 seconds provides additional headroom for these heavier operations
-/// compared to standard graph-node queries.
-pub const DIPS_HTTP_CLIENT_TIMEOUT: Duration = Duration::from_secs(60);
-
 // =============================================================================
 // DATABASE CONFIGURATION
 // =============================================================================

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -268,6 +268,7 @@ async fn start_dips(
         additional_networks,
         recurring_collector,
         rpc_url,
+        max_agreements_per_day,
     } = dips;
 
     // The RecurringCollector address is the EIP-712 verifying contract used to
@@ -303,6 +304,7 @@ async fn start_dips(
     tracing::info!(
         supported_networks = ?supported_networks,
         ipfs_url = %ipfs_url,
+        max_agreements_per_day = ?max_agreements_per_day,
         "DIPs configuration loaded"
     );
     for (network, grt) in min_grt_per_30_days.iter() {
@@ -367,6 +369,7 @@ async fn start_dips(
         registry,
         additional_networks: Arc::new(additional_networks.clone()),
         rca_domain,
+        max_agreements_per_day: *max_agreements_per_day,
     });
 
     // Create DIPS server

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -268,7 +268,7 @@ async fn start_dips(
         additional_networks,
         recurring_collector,
         rpc_url,
-        max_agreements_per_day,
+        max_new_agreements_per_24h,
     } = dips;
 
     // The RecurringCollector address is the EIP-712 verifying contract used to
@@ -304,7 +304,7 @@ async fn start_dips(
     tracing::info!(
         supported_networks = ?supported_networks,
         ipfs_url = %ipfs_url,
-        max_agreements_per_day = ?max_agreements_per_day,
+        max_new_agreements_per_24h = ?max_new_agreements_per_24h,
         "DIPs configuration loaded"
     );
     for (network, grt) in min_grt_per_30_days.iter() {
@@ -369,7 +369,7 @@ async fn start_dips(
         registry,
         additional_networks: Arc::new(additional_networks.clone()),
         rca_domain,
-        max_agreements_per_day: *max_agreements_per_day,
+        max_new_agreements_per_24h: *max_new_agreements_per_24h,
     });
 
     // Create DIPS server


### PR DESCRIPTION
## TL;DR

Indexers can now set a limit on how many DIPs agreements they take on in a day. Once an indexer holds that many live agreements (awaiting acceptance or accepted) in the last 24 hours, further proposals are turned away with a capacity reason. The limit is off by default, so nothing changes unless an operator sets it. Intoduced by indexer demand.

## Motivation

When the dipper sends an indexer a DIPs proposal, the indexer validates it and stores it for its agent to act on, with no ceiling on how many it will take in a day. A burst of proposals can therefore commit an indexer to indexing far more subgraphs than it has capacity for, and today the only limits are transport-level rate limits that bound request volume, not the indexing work each stored proposal implies. This gives operators a domain-level safeguard: a per-indexer daily cap on agreements taken on, so an indexer can protect its own resources. The cap is best-effort and opt-in, not a hard guarantee.

## Summary

- Add an optional per-day cap on live DIPs agreements an indexer holds, over a rolling 24h window.
- Over the cap, reject the proposal with the existing capacity reason before any manifest download.
- Count live agreements (pending or accepted) from the database; exclude rejected and expired.
- Default to no cap; an unreadable count fails open, so a database blip doesn't reject proposals.
- Cover the behaviour with unit tests and database-backed tests for the window and status filter.
