### PR TITLE
refactor: represent "no signer limit" as an absent value

### DIFF
--- a/crates/config/default_values.toml
+++ b/crates/config/default_values.toml
@@ -6,7 +6,6 @@ syncing_interval_secs = 60
 recently_closed_allocation_buffer_secs = 3600
 max_data_staleness_mins = 30
 escrow_min_balance_grt_wei = "100000000000000000"
-max_signers_per_payer = 0
 
 [service]
 ipfs_url = "https://api.thegraph.com/ipfs/"

--- a/crates/config/maximal-config-example.toml
+++ b/crates/config/maximal-config-example.toml
@@ -87,10 +87,9 @@ max_data_staleness_mins = 30
 # Minimum escrow balance (GRT wei) for V2 escrow queries. Filters dust deposits
 # to raise the cost of crowding attacks. Default: 0.1 GRT.
 escrow_min_balance_grt_wei = "100000000000000000"
-# Maximum signers to fetch per payer. 0 = no limit (recommended).
-# A positive value caps pagination but allows attackers to crowd out legitimate
-# signers, orphaning receipts and enabling free queries.
-max_signers_per_payer = 0
+# Maximum signers to fetch per payer. Unset = no limit (recommended); a positive
+# value caps pagination but lets attackers crowd out legitimate signers.
+# max_signers_per_payer = 1000
 
 # Indexing-payments subgraph, read for the set of accounts allowed to send DIPs
 # agreement proposals (the agreement-manager role). Required when [dips] is set.

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -5,6 +5,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     env,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    num::NonZeroUsize,
     path::PathBuf,
     time::Duration,
 };
@@ -522,12 +523,11 @@ pub struct NetworkSubgraphConfig {
     #[serde(default = "default_escrow_min_balance_grt_wei")]
     pub escrow_min_balance_grt_wei: String,
 
-    /// Maximum signers to fetch per payer. 0 = no limit (recommended).
-    /// Setting a positive value caps pagination but allows attackers to crowd out
-    /// legitimate signers, orphaning receipts and enabling free queries.
-    /// Default: 0.
-    #[serde(default = "default_max_signers_per_payer")]
-    pub max_signers_per_payer: usize,
+    /// Maximum signers to fetch per payer. Leave unset for no limit (recommended);
+    /// a positive cap lets attackers crowd out legitimate signers, orphaning
+    /// receipts and enabling free queries.
+    #[serde(default)]
+    pub max_signers_per_payer: Option<NonZeroUsize>,
 }
 
 fn default_max_data_staleness_mins() -> u64 {
@@ -536,10 +536,6 @@ fn default_max_data_staleness_mins() -> u64 {
 
 fn default_escrow_min_balance_grt_wei() -> String {
     "100000000000000000".to_string() // 0.1 GRT
-}
-
-fn default_max_signers_per_payer() -> usize {
-    0
 }
 
 #[deprecated(note = "V2 escrow accounts are in the network subgraph; escrow config is ignored.")]

--- a/crates/monitor/src/escrow_accounts.rs
+++ b/crates/monitor/src/escrow_accounts.rs
@@ -426,7 +426,7 @@ mod tests {
             true,
             Address::ZERO, // collector address; mock ignores query variables
             "100000000000000000".to_string(),
-            0,
+            None, // no signer-per-payer cap
         )
         .await
         .unwrap();

--- a/crates/monitor/src/escrow_accounts.rs
+++ b/crates/monitor/src/escrow_accounts.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    num::NonZeroUsize,
     str::FromStr,
     time::Duration,
 };
@@ -116,7 +117,7 @@ pub async fn escrow_accounts_v2(
     reject_thawing_signers: bool,
     collector_address: Address,
     min_balance_grt_wei: String,
-    max_signers_per_payer: usize,
+    max_signers_per_payer: Option<NonZeroUsize>,
 ) -> Result<EscrowAccountsWatcher, anyhow::Error> {
     indexer_watcher::new_watcher(interval, move || {
         get_escrow_accounts_v2(
@@ -137,7 +138,7 @@ async fn get_escrow_accounts_v2(
     reject_thawing_signers: bool,
     collector_address: Address,
     min_balance_grt_wei: String,
-    max_signers_per_payer: usize,
+    max_signers_per_payer: Option<NonZeroUsize>,
 ) -> anyhow::Result<EscrowAccounts> {
     tracing::trace!(
         indexer_address = ?indexer_address,
@@ -149,6 +150,9 @@ async fn get_escrow_accounts_v2(
         self as network_escrow_account_v2, Block_height, NetworkEscrowAccountQueryV2,
     };
     use indexer_query::signers_by_payer::{self as signers_by_payer, SignersByPayerQuery};
+
+    // Cap on signers fetched per payer; None means no limit.
+    let max_signers = max_signers_per_payer.map(NonZeroUsize::get);
 
     let page_size: i64 = 200;
     let mut last: Option<String> = None;
@@ -191,15 +195,17 @@ async fn get_escrow_accounts_v2(
         // Paginate additional signers for any payer that hit the 1000-per-payer nested cap
         let mut response = response;
         for account in &mut response.payments_escrow_accounts {
-            if max_signers_per_payer > 0 && account.payer.signers.len() >= max_signers_per_payer {
-                tracing::warn!(
-                    payer = %account.payer.id,
-                    signers = account.payer.signers.len(),
-                    max = max_signers_per_payer,
-                    "Payer signers already at or above max_signers_per_payer cap; skipping follow-up pagination"
-                );
-                account.payer.signers.truncate(max_signers_per_payer);
-                continue;
+            if let Some(max) = max_signers {
+                if account.payer.signers.len() >= max {
+                    tracing::warn!(
+                        payer = %account.payer.id,
+                        signers = account.payer.signers.len(),
+                        max,
+                        "Payer signers already at or above max_signers_per_payer cap; skipping follow-up pagination"
+                    );
+                    account.payer.signers.truncate(max);
+                    continue;
+                }
             }
 
             if account.payer.signers.len() < 1000 {
@@ -245,8 +251,7 @@ async fn get_escrow_accounts_v2(
                 }
 
                 if page_len < 1000
-                    || (max_signers_per_payer > 0
-                        && account.payer.signers.len() >= max_signers_per_payer)
+                    || max_signers.is_some_and(|max| account.payer.signers.len() >= max)
                 {
                     break;
                 }
@@ -258,14 +263,16 @@ async fn get_escrow_accounts_v2(
                     .unwrap_or_default();
             }
 
-            if max_signers_per_payer > 0 && account.payer.signers.len() >= max_signers_per_payer {
-                tracing::warn!(
-                    payer = %account.payer.id,
-                    signers = account.payer.signers.len(),
-                    max = max_signers_per_payer,
-                    "Payer signers capped at max_signers_per_payer"
-                );
-                account.payer.signers.truncate(max_signers_per_payer);
+            if let Some(max) = max_signers {
+                if account.payer.signers.len() >= max {
+                    tracing::warn!(
+                        payer = %account.payer.id,
+                        signers = account.payer.signers.len(),
+                        max,
+                        "Payer signers capped at max_signers_per_payer"
+                    );
+                    account.payer.signers.truncate(max);
+                }
             }
 
             if account.payer.signers.len() > 1000 {

--- a/crates/service/tests/router_test.rs
+++ b/crates/service/tests/router_test.rs
@@ -88,7 +88,7 @@ fn build_service_router(inputs: RouterInputs) -> ServiceRouter {
                 recently_closed_allocation_buffer_secs: Duration::from_secs(0),
                 max_data_staleness_mins: 0,
                 escrow_min_balance_grt_wei: "100000000000000000".to_string(),
-                max_signers_per_payer: 0,
+                max_signers_per_payer: None,
             },
         )
         .escrow_accounts_v2(inputs.escrow_accounts_v2)


### PR DESCRIPTION
## TL;DR

The indexer limits how many signers it loads per payer, and today setting that limit to 0 means "no limit" — the opposite of what 0 looks like it should do. This change makes "no limit" an absent value instead, leaving 0 free to be rejected as the nonsensical setting it is. The default behaviour (no limit) does not change.

## Motivation

The indexer loads the set of signers each payer has authorised, and a configurable cap bounds how many it will page through. Today that cap uses 0 to mean "unlimited", which overloads a number that naturally reads as "load zero signers" and diverges from how the rest of the config expresses an optional limit (by leaving it unset). The cost is a config that is easy to misread: an operator glancing at `max_signers_per_payer = 0` could reasonably believe it disables signer loading, when it does the exact opposite. Expressing "no limit" as an absent value removes that ambiguity, and a value of 0 — which would orphan every receipt by loading no signers — is now rejected at startup rather than silently treated as unlimited.

## Summary

- Change the per-payer signer limit from a plain number to an optional positive number.
- Unset now means "no limit" (the recommended default; behaviour unchanged).
- Reject 0 at config load, since loading zero signers per payer is nonsensical.
- Update the escrow-account signer pagination to the optional type.
- Migration: any config setting `max_signers_per_payer = 0` must remove the line; 0 now errors.
