### PR TITLE
feat: validate the escrow dust floor at config load

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -20,7 +20,10 @@ use regex::Regex;
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
 use serde_with::{serde_as, DurationSecondsWithFrac};
-use thegraph_core::{alloy::primitives::Address, DeploymentId};
+use thegraph_core::{
+    alloy::primitives::{Address, U256},
+    DeploymentId,
+};
 use url::Url;
 
 use crate::{NonZeroGRT, GRT};
@@ -270,6 +273,21 @@ impl Config {
         if self.tap.allocation_reconciliation_interval_secs == Duration::ZERO {
             return Err(
                 "tap.allocation_reconciliation_interval_secs must be greater than 0".to_string(),
+            );
+        }
+
+        // The escrow dust floor is sent to the subgraph as an integer; reject a
+        // non-numeric value at load rather than failing later at query time.
+        if self
+            .subgraphs
+            .network
+            .escrow_min_balance_grt_wei
+            .parse::<U256>()
+            .is_err()
+        {
+            return Err(
+                "subgraphs.network.escrow_min_balance_grt_wei must be a non-negative integer (wei)"
+                    .to_string(),
             );
         }
 
@@ -1338,6 +1356,44 @@ mod tests {
         assert!(result
             .unwrap_err()
             .contains("No operator mnemonic configured"));
+    }
+
+    /// Test that config validation rejects a non-numeric escrow dust floor.
+    #[sealed_test(files = ["minimal-config-example.toml"])]
+    fn test_validation_rejects_non_numeric_escrow_min_balance() {
+        let mut minimal_config: toml::Value = toml::from_str(
+            fs::read_to_string("minimal-config-example.toml")
+                .unwrap()
+                .as_str(),
+        )
+        .unwrap();
+
+        minimal_config
+            .get_mut("subgraphs")
+            .unwrap()
+            .get_mut("network")
+            .unwrap()
+            .as_table_mut()
+            .unwrap()
+            .insert(
+                "escrow_min_balance_grt_wei".to_string(),
+                toml::Value::String("not-a-number".to_string()),
+            );
+
+        let temp_config_path = tempfile::NamedTempFile::new().unwrap();
+        fs::write(
+            temp_config_path.path(),
+            toml::to_string(&minimal_config).unwrap(),
+        )
+        .unwrap();
+
+        let result = Config::parse(
+            ConfigPrefix::Service,
+            Some(PathBuf::from(temp_config_path.path())).as_ref(),
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("escrow_min_balance_grt_wei"));
     }
 
     // === DIPS Startup Validation Tests ===


### PR DESCRIPTION
> Stacked on #1057 — review/merge that first; this PR targets its branch so the diff shows only the escrow-floor validation.

## TL;DR

The minimum escrow balance that filters out dust deposits is an unvalidated text value sent straight to the subgraph, so a typo isn't caught until a query later fails. This adds a check at config load that the value is a valid number. Zero still means "no floor" and the default is unchanged.

## Motivation

The indexer filters escrow accounts below `escrow_min_balance_grt_wei` out of its queries to blunt dust-deposit crowding attacks. That value is stored as raw text and handed to the subgraph unchecked, so a malformed entry passes startup silently and only shows up later as a failing escrow query — at which point the indexer can't see any payer balances. Validating it at load turns that into an immediate, clear startup error. Zero remains a legitimate setting meaning "no dust floor", so it is accepted.

## Summary

- Parse `escrow_min_balance_grt_wei` as a non-negative integer during config validation.
- Reject a non-numeric value at startup with a clear message instead of failing later at query time.
- Leave the type and meaning unchanged: 0 still means "no floor"; default stays 0.1 GRT.
- Add a test covering rejection of a non-numeric value.
