### PR TITLE
feat: reject zero for the metrics port and size limits

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -291,6 +291,21 @@ impl Config {
             );
         }
 
+        // Reject zero for limits where it is nonsensical: a metrics port of 0 binds a
+        // random OS port the scraper can't find, and a zero batch/body size rejects all work.
+        if self.metrics.port == 0 {
+            return Err("metrics.port must be greater than 0".to_string());
+        }
+        if self.service.max_cost_model_batch_size == 0 {
+            return Err("service.max_cost_model_batch_size must be greater than 0".to_string());
+        }
+        if self.service.max_request_body_size == 0 {
+            return Err("service.max_request_body_size must be greater than 0".to_string());
+        }
+        if self.service.max_status_request_body_size == 0 {
+            return Err("service.max_status_request_body_size must be greater than 0".to_string());
+        }
+
         if self.tap.allocation_reconciliation_interval_secs < Duration::from_secs(60) {
             tracing::warn!(
                 "Your `tap.allocation_reconciliation_interval_secs` value is too low. \
@@ -1394,6 +1409,39 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("escrow_min_balance_grt_wei"));
+    }
+
+    /// Test that config validation rejects a metrics port of 0.
+    #[sealed_test(files = ["minimal-config-example.toml"])]
+    fn test_validation_rejects_zero_metrics_port() {
+        let mut minimal_config: toml::Value = toml::from_str(
+            fs::read_to_string("minimal-config-example.toml")
+                .unwrap()
+                .as_str(),
+        )
+        .unwrap();
+
+        let mut metrics = toml::value::Table::new();
+        metrics.insert("port".to_string(), toml::Value::Integer(0));
+        minimal_config
+            .as_table_mut()
+            .unwrap()
+            .insert("metrics".to_string(), toml::Value::Table(metrics));
+
+        let temp_config_path = tempfile::NamedTempFile::new().unwrap();
+        fs::write(
+            temp_config_path.path(),
+            toml::to_string(&minimal_config).unwrap(),
+        )
+        .unwrap();
+
+        let result = Config::parse(
+            ConfigPrefix::Service,
+            Some(PathBuf::from(temp_config_path.path())).as_ref(),
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("metrics.port"));
     }
 
     // === DIPS Startup Validation Tests ===

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -20,7 +20,10 @@ use regex::Regex;
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
 use serde_with::{serde_as, DurationSecondsWithFrac};
-use thegraph_core::{alloy::primitives::Address, DeploymentId};
+use thegraph_core::{
+    alloy::primitives::{Address, U256},
+    DeploymentId,
+};
 use url::Url;
 
 use crate::{NonZeroGRT, GRT};
@@ -270,6 +273,21 @@ impl Config {
         if self.tap.allocation_reconciliation_interval_secs == Duration::ZERO {
             return Err(
                 "tap.allocation_reconciliation_interval_secs must be greater than 0".to_string(),
+            );
+        }
+
+        // The escrow dust floor is sent to the subgraph as an integer; reject a
+        // non-numeric value at load rather than failing later at query time.
+        if self
+            .subgraphs
+            .network
+            .escrow_min_balance_grt_wei
+            .parse::<U256>()
+            .is_err()
+        {
+            return Err(
+                "subgraphs.network.escrow_min_balance_grt_wei must be a non-negative integer (wei)"
+                    .to_string(),
             );
         }
 
@@ -1338,6 +1356,44 @@ mod tests {
         assert!(result
             .unwrap_err()
             .contains("No operator mnemonic configured"));
+    }
+
+    /// Test that config validation rejects a non-numeric escrow dust floor.
+    #[sealed_test(files = ["minimal-config-example.toml"])]
+    fn test_validation_rejects_non_numeric_escrow_min_balance() {
+        let mut minimal_config: toml::Value = toml::from_str(
+            fs::read_to_string("minimal-config-example.toml")
+                .unwrap()
+                .as_str(),
+        )
+        .unwrap();
+
+        minimal_config
+            .get_mut("subgraphs")
+            .unwrap()
+            .get_mut("network")
+            .unwrap()
+            .as_table_mut()
+            .unwrap()
+            .insert(
+                "escrow_min_balance_grt_wei".to_string(),
+                toml::Value::String("not-a-number".to_string()),
+            );
+
+        let temp_config_path = tempfile::NamedTempFile::new().unwrap();
+        fs::write(
+            temp_config_path.path(),
+            toml::to_string(&minimal_config).unwrap(),
+        )
+        .unwrap();
+
+        let result = Config::parse(
+            ConfigPrefix::Service,
+            Some(PathBuf::from(temp_config_path.path())).as_ref(),
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("escrow_min_balance_grt_wei"));
     }
 
     // === DIPS Startup Validation Tests ===


### PR DESCRIPTION
> Stacked on #1058 — review/merge that first; this PR targets its branch so the diff shows only the mandatory-positive checks.

## TL;DR

A few config limits read as plain numbers where 0 has no sensible meaning — a metrics port of 0, or a request-body or cost-model batch size of 0. This rejects 0 for those at config load instead of letting it cause confusing behaviour later. Defaults are unchanged.

## Motivation

Some config values must be positive to make any sense, but nothing stops an operator setting them to 0 today. A metrics port of 0 makes the operating system pick a random port on each start, so the metrics endpoint is effectively unreachable to whatever scrapes it. A request-body or status-body size of 0 rejects every request, and a cost-model batch size of 0 rejects every batch — each a self-inflicted outage that only shows up once traffic arrives. Catching these at startup, the way the timing settings already are, turns a late and puzzling failure into a clear configuration error.

## Summary

- Reject a `metrics.port` of 0 at config load.
- Reject a `max_request_body_size`, `max_status_request_body_size`, or `max_cost_model_batch_size` of 0.
- Leave all defaults and behaviour for positive values unchanged.
- Add a test covering rejection of a zero metrics port.
