### PR TITLE
fix: store agreement proposals without the signer signature

### DIFF
--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -276,6 +276,17 @@ impl SignedRecurringCollectionAgreement {
     pub fn encode_vec(&self) -> Vec<u8> {
         self.abi_encode()
     }
+
+    /// ABI-encode the same agreement but with an empty signature. The signature
+    /// only authenticates the sender at proposal time; the indexer-agent rejects
+    /// any stored proposal that still carries one (acceptance is offer-based).
+    pub fn encode_without_signature(&self) -> Vec<u8> {
+        SignedRecurringCollectionAgreement {
+            agreement: self.agreement.clone(),
+            signature: Default::default(),
+        }
+        .abi_encode()
+    }
 }
 
 /// Convert bytes32 subgraph deployment ID to IPFS CIDv0 string.
@@ -366,6 +377,11 @@ pub async fn validate_and_create_rca(
     // Derive agreement ID deterministically from the RCA fields
     let agreement_id = derive_agreement_id(&signed_rca.agreement);
 
+    // Persist and compare proposals with the signature stripped: the agent
+    // rejects any stored row that still carries one, so a re-send (which always
+    // arrives signed) must compare against this form, not the raw incoming bytes.
+    let stored_bytes = signed_rca.encode_without_signature();
+
     // Early replay/idempotency check, ahead of the capacity cap and the IPFS
     // fetch: a recorded proposal's retry is resolved from the store, never
     // capacity-rejected or charged for the download. Failing open is best-effort.
@@ -373,7 +389,7 @@ pub async fn validate_and_create_rca(
         Ok(None) => {}
         Ok(Some(prior)) => {
             // A different payload reusing the same id is the only true conflict.
-            if prior.signed_payload != rca_bytes {
+            if prior.signed_payload != stored_bytes {
                 tracing::warn!(
                     %agreement_id,
                     "replay conflict: agreement id re-sent with a different payload"
@@ -515,9 +531,9 @@ pub async fn validate_and_create_rca(
         "creating RCA agreement"
     );
 
-    // Store the raw signed RCA bytes
+    // Store the RCA with an empty signature (see encode_without_signature).
     rca_store
-        .store_rca(agreement_id, rca_bytes, PROTOCOL_VERSION)
+        .store_rca(agreement_id, stored_bytes, PROTOCOL_VERSION)
         .await
         .map_err(|error| {
             tracing::error!(%agreement_id, %error, "failed to store RCA");
@@ -624,6 +640,16 @@ mod test {
         rca.sign(&test_rca_domain(), test_signer())
             .expect("signing test RCA")
             .abi_encode()
+    }
+
+    /// The sig-stripped form `validate_and_create_rca` actually persists. Replay
+    /// tests seed the store with this so a re-send compares as identical.
+    fn rca_to_stored_bytes(rca: RecurringCollectionAgreement) -> Vec<u8> {
+        SignedRecurringCollectionAgreement {
+            agreement: rca,
+            signature: Default::default(),
+        }
+        .abi_encode()
     }
 
     fn create_test_rca(
@@ -796,6 +822,18 @@ mod test {
         let data = in_memory.data.read().await;
         assert_eq!(data.len(), 1);
         assert_eq!(data[0].0, agreement_id);
+
+        // The persisted payload must carry an empty signature: the agent rejects
+        // any stored proposal that still has one. Decode the stored bytes back
+        // and confirm the signature field is empty while the agreement survives.
+        let stored = SignedRecurringCollectionAgreement::abi_decode(data[0].1.as_ref())
+            .expect("stored payload decodes");
+        assert!(
+            stored.signature.is_empty(),
+            "stored payload must have an empty signature, got {} bytes",
+            stored.signature.len()
+        );
+        assert_eq!(derive_agreement_id(&stored.agreement), agreement_id);
     }
 
     #[test]
@@ -1402,16 +1440,17 @@ mod test {
 
     #[tokio::test]
     async fn test_replay_identical_pending_accepts_without_fetch() {
-        // Arrange: seed the identical bytes as a pending row.
+        // Arrange: seed the sig-stripped form (what gets stored) as a pending row,
+        // then re-send the same proposal signed.
         let payer = Address::repeat_byte(0x42);
         let service_provider = Address::repeat_byte(0x11);
         let rca = create_test_rca(payer, service_provider, U256::from(200), U256::from(100));
         let agreement_id = derive_agreement_id(&rca);
-        let rca_bytes = rca_to_wire_bytes(rca);
+        let rca_bytes = rca_to_wire_bytes(rca.clone());
 
         let store = Arc::new(InMemoryRcaStore::default());
         store
-            .store_rca(agreement_id, rca_bytes.clone(), PROTOCOL_VERSION)
+            .store_rca(agreement_id, rca_to_stored_bytes(rca), PROTOCOL_VERSION)
             .await
             .unwrap();
         let ctx = context_with_store_and_panic_fetcher(store);
@@ -1425,16 +1464,16 @@ mod test {
 
     #[tokio::test]
     async fn test_replay_identical_accepted_accepts_without_fetch() {
-        // Arrange: seed identical bytes, then promote the row to accepted.
+        // Arrange: seed the sig-stripped form, then promote the row to accepted.
         let payer = Address::repeat_byte(0x42);
         let service_provider = Address::repeat_byte(0x11);
         let rca = create_test_rca(payer, service_provider, U256::from(200), U256::from(100));
         let agreement_id = derive_agreement_id(&rca);
-        let rca_bytes = rca_to_wire_bytes(rca);
+        let rca_bytes = rca_to_wire_bytes(rca.clone());
 
         let store = Arc::new(InMemoryRcaStore::default());
         store
-            .store_rca(agreement_id, rca_bytes.clone(), PROTOCOL_VERSION)
+            .store_rca(agreement_id, rca_to_stored_bytes(rca), PROTOCOL_VERSION)
             .await
             .unwrap();
         set_status(&store, "accepted").await;
@@ -1455,11 +1494,11 @@ mod test {
         let service_provider = Address::repeat_byte(0x11);
         let rca = create_test_rca(payer, service_provider, U256::from(200), U256::from(100));
         let agreement_id = derive_agreement_id(&rca);
-        let rca_bytes = rca_to_wire_bytes(rca);
+        let rca_bytes = rca_to_wire_bytes(rca.clone());
 
         let store = Arc::new(InMemoryRcaStore::default());
         store
-            .store_rca(agreement_id, rca_bytes.clone(), PROTOCOL_VERSION)
+            .store_rca(agreement_id, rca_to_stored_bytes(rca), PROTOCOL_VERSION)
             .await
             .unwrap();
         set_status(&store, "completed").await;
@@ -1474,16 +1513,16 @@ mod test {
 
     #[tokio::test]
     async fn test_replay_identical_rejected_rerejects_without_fetch() {
-        // Arrange: seed identical bytes, then mark the row rejected.
+        // Arrange: seed the sig-stripped form, then mark the row rejected.
         let payer = Address::repeat_byte(0x42);
         let service_provider = Address::repeat_byte(0x11);
         let rca = create_test_rca(payer, service_provider, U256::from(200), U256::from(100));
         let agreement_id = derive_agreement_id(&rca);
-        let rca_bytes = rca_to_wire_bytes(rca);
+        let rca_bytes = rca_to_wire_bytes(rca.clone());
 
         let store = Arc::new(InMemoryRcaStore::default());
         store
-            .store_rca(agreement_id, rca_bytes.clone(), PROTOCOL_VERSION)
+            .store_rca(agreement_id, rca_to_stored_bytes(rca), PROTOCOL_VERSION)
             .await
             .unwrap();
         set_status(&store, "rejected").await;
@@ -1510,13 +1549,15 @@ mod test {
         let agreement_id = derive_agreement_id(&seeded);
         assert_eq!(agreement_id, derive_agreement_id(&conflicting));
 
-        let seeded_bytes = rca_to_wire_bytes(seeded);
+        // Seed the sig-stripped form, matching what production stores, so the
+        // conflict comes from the differing terms rather than the signature.
+        let seeded_stored = rca_to_stored_bytes(seeded);
         let conflicting_bytes = rca_to_wire_bytes(conflicting);
-        assert_ne!(seeded_bytes, conflicting_bytes);
+        assert_ne!(seeded_stored, conflicting_bytes);
 
         let store = Arc::new(InMemoryRcaStore::default());
         store
-            .store_rca(agreement_id, seeded_bytes.clone(), PROTOCOL_VERSION)
+            .store_rca(agreement_id, seeded_stored.clone(), PROTOCOL_VERSION)
             .await
             .unwrap();
         let ctx = context_with_store_and_panic_fetcher(store.clone());
@@ -1528,7 +1569,7 @@ mod test {
         // Assert: conflict reported and the stored row is left unchanged.
         assert!(matches!(result, Err(DipsError::ReplayConflict { .. })));
         let stored = store.lookup(agreement_id).await.unwrap().unwrap();
-        assert_eq!(stored.signed_payload, seeded_bytes);
+        assert_eq!(stored.signed_payload, seeded_stored);
     }
 
     #[tokio::test]
@@ -1573,11 +1614,11 @@ mod test {
         let service_provider = Address::repeat_byte(0x11);
         let rca = create_test_rca(payer, service_provider, U256::from(200), U256::from(100));
         let agreement_id = derive_agreement_id(&rca);
-        let rca_bytes = rca_to_wire_bytes(rca);
+        let rca_bytes = rca_to_wire_bytes(rca.clone());
 
         let store = Arc::new(InMemoryRcaStore::default());
         store
-            .store_rca(agreement_id, rca_bytes.clone(), PROTOCOL_VERSION)
+            .store_rca(agreement_id, rca_to_stored_bytes(rca), PROTOCOL_VERSION)
             .await
             .unwrap();
         let ctx = Arc::new(DipsServerContext {

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -28,18 +28,21 @@
 //! # Validation Flow
 //!
 //! When an RCA arrives, this crate validates:
-//! 1. **Service provider** - RCA is addressed to this indexer
-//! 2. **Timestamps** - Deadline and end time haven't passed
-//! 3. **Replay/idempotency** - Once the deterministic agreement id is derived,
+//! 1. **Signer** - The EIP-712 signature recovers a trusted signer (one holding
+//!    the on-chain agreement-manager role); a missing or untrusted one is rejected
+//! 2. **Service provider** - RCA is addressed to this indexer
+//! 3. **Timestamps** - Deadline and end time haven't passed
+//! 4. **Replay/idempotency** - Once the deterministic agreement id is derived,
 //!    a re-sent proposal is resolved against the store before any IPFS fetch
-//! 4. **IPFS manifest** - Subgraph deployment exists and is parseable
-//! 5. **Network** - Subgraph's network is supported by this indexer
-//! 6. **Pricing** - Offered price meets indexer's minimum
+//! 5. **IPFS manifest** - Subgraph deployment exists and is parseable
+//! 6. **Network** - Subgraph's network is supported by this indexer
+//! 7. **Pricing** - Offered price meets indexer's minimum
 //!
-//! Signature and signer-authorization checks are NOT performed here. With the
-//! switch to offer-based authorization, the on-chain `acceptIndexingAgreement`
-//! call verifies the signer (via either an ECDSA signature or a pre-stored
-//! payer offer) when the indexer-agent submits the acceptance transaction.
+//! The signature only authenticates the sender at proposal time. Once the signer
+//! is recovered and authorized it is stripped from the stored proposal, because
+//! acceptance is offer-based: the indexer-agent later calls `acceptIndexingAgreement`
+//! against the payer's on-chain offer (with an empty signature), and the contract
+//! verifies the signer at that point.
 //!
 //! # Modules
 //!

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -577,6 +577,14 @@ mod test {
             .unwrap()
     }
 
+    /// A second fixed key, distinct from `test_signer`, so a re-send can carry a
+    /// genuinely different signature over identical terms.
+    fn second_test_signer() -> PrivateKeySigner {
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+            .parse()
+            .unwrap()
+    }
+
     fn test_rca_domain() -> Eip712Domain {
         rca_eip712_domain(1337, Address::repeat_byte(0xCC))
     }
@@ -1397,14 +1405,16 @@ mod test {
         }
     }
 
-    /// Build a context whose store is the supplied seeded one and whose IPFS
-    /// fetcher panics if called, so a reached download surfaces as a test panic.
-    fn context_with_store_and_panic_fetcher(
+    /// Build a context over the given store, IPFS fetcher, and trusted-signer set,
+    /// holding the price calculator, registry, and domain fixed across tests.
+    fn context_with(
         store: Arc<InMemoryRcaStore>,
+        ipfs_fetcher: Arc<dyn IpfsFetcher>,
+        trusted_signers: Arc<dyn TrustedSignerSource>,
     ) -> Arc<DipsServerContext> {
         Arc::new(DipsServerContext {
             rca_store: store,
-            ipfs_fetcher: Arc::new(PanicIpfsFetcher),
+            ipfs_fetcher,
             price_calculator: Arc::new(PriceCalculator::new(
                 HashSet::from(["mainnet".to_string()]),
                 BTreeMap::from([("mainnet".to_string(), U256::from(100))]),
@@ -1413,9 +1423,21 @@ mod test {
             registry: Arc::new(crate::registry::test_registry()),
             additional_networks: Arc::new(BTreeMap::new()),
             rca_domain: test_rca_domain(),
-            trusted_signers: trusted_signers_for_test(),
+            trusted_signers,
             max_new_agreements_per_24h: None,
         })
+    }
+
+    /// Build a context whose store is the supplied seeded one and whose IPFS
+    /// fetcher panics if called, so a reached download surfaces as a test panic.
+    fn context_with_store_and_panic_fetcher(
+        store: Arc<InMemoryRcaStore>,
+    ) -> Arc<DipsServerContext> {
+        context_with(
+            store,
+            Arc::new(PanicIpfsFetcher),
+            trusted_signers_for_test(),
+        )
     }
 
     /// Overwrite the status of the single seeded row, for the accepted/rejected cases.
@@ -1573,6 +1595,51 @@ mod test {
         assert!(matches!(result, Err(DipsError::ReplayConflict { .. })));
         let stored = store.lookup(agreement_id).await.unwrap().unwrap();
         assert_eq!(stored.signed_payload, seeded_stored);
+    }
+
+    #[tokio::test]
+    async fn test_replay_same_terms_different_signature_is_idempotent() {
+        // The behaviour this PR exists for: a re-send signed by a different key
+        // over identical terms must replay as idempotent, not ReplayConflict,
+        // because the stored form has the signature stripped.
+        let payer = Address::repeat_byte(0x42);
+        let service_provider = Address::repeat_byte(0x11);
+        let rca = create_test_rca(payer, service_provider, U256::from(200), U256::from(100));
+        let agreement_id = derive_agreement_id(&rca);
+
+        // Two distinct trusted signers yield two distinct signatures over one RCA.
+        let trusted: Arc<dyn TrustedSignerSource> =
+            Arc::new(StaticTrustedSigners(HashSet::from([
+                test_signer().address(),
+                second_test_signer().address(),
+            ])));
+        let signed_a = rca.sign(&test_rca_domain(), test_signer()).unwrap();
+        let signed_b = rca.sign(&test_rca_domain(), second_test_signer()).unwrap();
+        assert_ne!(signed_a.signature, signed_b.signature);
+
+        // Store the first proposal through the full pipeline (real fetcher).
+        let store = Arc::new(InMemoryRcaStore::default());
+        let ctx_first = context_with(
+            store.clone(),
+            Arc::new(MockIpfsFetcher::default()),
+            trusted.clone(),
+        );
+        let first =
+            super::validate_and_create_rca(ctx_first, &service_provider, signed_a.abi_encode())
+                .await;
+        assert_eq!(first.unwrap(), agreement_id);
+
+        // Re-send the same terms signed by the other key; the panicking fetcher
+        // proves the replay short-circuits before any IPFS download.
+        let ctx_replay = context_with(store, Arc::new(PanicIpfsFetcher), trusted);
+        let replay =
+            super::validate_and_create_rca(ctx_replay, &service_provider, signed_b.abi_encode())
+                .await;
+        assert_eq!(
+            replay.unwrap(),
+            agreement_id,
+            "differently-signed re-send must replay idempotently"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## TL;DR

This makes the indexer service remove the signature before saving an indexing proposal.

## Motivation

When the service receives an indexing-agreement proposal it first verifies the sender's signature, then saves the proposal for the agent to act on. The agent no longer uses that signature to accept on-chain — it accepts against the payer's posted on-chain offer — so it now treats any saved proposal that still carries a signature as a mistake and refuses it. The result is that every proposal the service saves is discarded by the agent and no agreement can be accepted. Clearing the signature before saving, while still verifying it first, lets the two services line up again.

## Summary

- Keeps verifying the sender's signature on every incoming proposal, unchanged.
- Saves the proposal with the signature cleared, which is the form the agent expects.
- Compares a re-sent proposal against that same cleared form so genuine retries still match.
- Updates the affected tests to seed and check the stored form.

Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01USBDULGGvrHzVTKWgxfYz4
