### PR TITLE
feat: log subgraph deployment id on RCA acceptance

### DIFF
--- a/crates/dips/src/server.rs
+++ b/crates/dips/src/server.rs
@@ -213,7 +213,11 @@ impl IndexerDipsService for DipsServer {
                 crate::metrics::PROPOSAL_OUTCOMES
                     .with_label_values(&["accepted"])
                     .inc();
-                tracing::info!(%agreement_id, "RCA accepted");
+                tracing::info!(
+                    %agreement_id,
+                    deployment_id = deployment_id.as_deref().unwrap_or("unknown"),
+                    "RCA accepted"
+                );
                 Ok(Response::new(SubmitAgreementProposalResponse {
                     outcome: Some(Outcome::Accepted(Accepted {})),
                 }))


### PR DESCRIPTION
## TL;DR

The indexer's "RCA accepted" log line records only the agreement id, not the subgraph it is for. This adds the subgraph deployment id to that line so an operator filtering their logs by a deployment hash can find the acceptance.

## Motivation

When dipper proposes a Direct Indexer Payments agreement, the indexer-service validates it and logs the outcome. Today the rejection log includes the subgraph deployment id but the acceptance log does not — it carries only the agreement id. An operator searching their logs for a specific subgraph's deployment hash therefore sees rejections but never the matching acceptance, which makes it look as though a proposal was never accepted even when it was. The deployment id is already decoded in the handler and already used on the rejection path, so this adds it to the acceptance log as well, matching the rejection log's fields.
