### PR TITLE
fix: update rand sample_iter usage for rand 0.10 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,7 +1895,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2159,6 +2159,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,7 +2400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2482,6 +2493,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2714,7 +2734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3475,9 +3495,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4341,7 +4373,7 @@ dependencies = [
  "indexer-watcher",
  "ipfs-api-backend-hyper",
  "prost 0.14.3",
- "rand 0.9.5",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4499,7 +4531,7 @@ dependencies = [
  "profiler",
  "prometheus 0.13.4",
  "ractor",
- "rand 0.9.5",
+ "rand 0.10.2",
  "reqwest 0.12.24",
  "rstest",
  "ruint",
@@ -4604,7 +4636,7 @@ dependencies = [
  "indexer-receipt",
  "num_cpus",
  "prost 0.14.3",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rdkafka 0.38.0",
  "regex",
  "reqwest 0.12.24",
@@ -5047,7 +5079,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -6735,6 +6767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "ractor"
 version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6785,6 +6823,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6822,6 +6871,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -7936,7 +7991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -7947,7 +8002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ ractor = { version = "0.15.7", features = [
     "async-trait",
     "tokio_runtime",
 ], default-features = false }
-rand = "0.9.0"
+rand = "0.10.0"
 reqwest = { version = "0.12", features = [
     "charset",
     "h2",

--- a/crates/dips/src/lib.rs
+++ b/crates/dips/src/lib.rs
@@ -464,7 +464,7 @@ mod test {
     };
 
     use indexer_monitor::EscrowAccounts;
-    use rand::{distr::Alphanumeric, Rng};
+    use rand::distr::{Alphanumeric, Distribution};
     use thegraph_core::alloy::{
         primitives::{Address, ChainId, FixedBytes, U256},
         signers::local::PrivateKeySigner,
@@ -695,8 +695,8 @@ mod test {
             Self {
                 payee: PrivateKeySigner::random(),
                 payer: PrivateKeySigner::random(),
-                deployment_id: rand::rng()
-                    .sample_iter(&Alphanumeric)
+                deployment_id: Alphanumeric
+                    .sample_iter(rand::rng())
                     .take(32)
                     .map(char::from)
                     .collect(),

--- a/crates/tap-agent/src/test.rs
+++ b/crates/tap-agent/src/test.rs
@@ -13,7 +13,10 @@ use actors::TestableActor;
 use bigdecimal::num_bigint::BigInt;
 use indexer_monitor::{DeploymentDetails, EscrowAccounts, SubgraphClient};
 use ractor::{concurrency::JoinHandle, Actor, ActorRef};
-use rand::{distr::Alphanumeric, rng, Rng};
+use rand::{
+    distr::{Alphanumeric, Distribution},
+    rng,
+};
 use reqwest::Url;
 use sqlx::{types::BigDecimal, PgPool, Row};
 use tap_aggregator::server::run_server;
@@ -72,8 +75,8 @@ const ESCROW_POLLING_INTERVAL: Duration = Duration::from_secs(30);
 /// Generates a random prefix to be used for actor registry
 pub fn generate_random_prefix() -> String {
     const SIZE: usize = 16;
-    rng()
-        .sample_iter(&Alphanumeric)
+    Alphanumeric
+        .sample_iter(rng())
         .take(SIZE)
         .map(char::from)
         .collect()


### PR DESCRIPTION
## Summary

The `rand` crate v0.10 moved `sample_iter` off the `Rng` trait and onto `Distribution` — it's now called as `distribution.sample_iter(rng)` instead of `rng.sample_iter(&distribution)`. This currently breaks `cargo clippy` and `cargo test` on the pending `rand` 0.10.0 security-update PR (#1070), in `indexer-tap-agent`'s `test.rs` (confirmed via CI logs on #1070) and `indexer-dips`'s `lib.rs` test module (same broken pattern, not exercised by that CI job but would break on `main` once #1070 merges).

This PR applies the same fix pattern used in `rand`'s own docs (calling `sample_iter` on the `Distribution` instance) in both places, and drops the now-unused `Rng` import.

## Changes
- `crates/tap-agent/src/test.rs`: `generate_random_prefix()` fixed
- `crates/dips/src/lib.rs`: `VoucherContext::random()` (test-only) fixed

## Test plan
- [x] `cargo check -p indexer-tap-agent --tests` — compiles clean
- [x] `cargo check -p indexer-dips --tests` — compiles clean
- [x] `cargo fmt --check -p indexer-tap-agent -p indexer-dips` — no diff
- [x] `cargo clippy -p indexer-tap-agent -p indexer-dips --all-features --all-targets -- -A dead-code -D warnings` — clean, matching CI's exact invocation

This should unblock #1070 (`rand` 0.10.0 [security]) once rebased on top of, or merged alongside, this fix.